### PR TITLE
8.0 compatibility for base and fiscalcode modules

### DIFF
--- a/l10n_it_base/partner/partner.py
+++ b/l10n_it_base/partner/partner.py
@@ -20,12 +20,11 @@
 #
 ##############################################################################
 
-from openerp.osv import osv
-from openerp.osv import fields
+from openerp.osv import osv, fields
 from openerp.tools.translate import _
 
 
-class res_region(osv.osv):
+class res_region(osv.Model):
     _name = 'res.region'
     _description = 'Region'
     _columns = {
@@ -37,7 +36,7 @@ class res_region(osv.osv):
 res_region()
 
 
-class res_province(osv.osv):
+class res_province(osv.Model):
     _name = 'res.province'
     _description = 'Province'
     _columns = {
@@ -53,7 +52,7 @@ class res_province(osv.osv):
 res_province()
 
 
-class res_city(osv.osv):
+class res_city(osv.Model):
     _name = 'res.city'
     _description = 'City'
     _columns = {
@@ -70,7 +69,7 @@ class res_city(osv.osv):
     }
 
 
-class res_partner(osv.osv):
+class res_partner(osv.Model):
     _inherit = 'res.partner'
 
     _columns = {

--- a/l10n_it_fiscalcode/fiscalcode.py
+++ b/l10n_it_fiscalcode/fiscalcode.py
@@ -19,13 +19,13 @@
 #
 ##############################################################################
 
-from osv import fields, osv
-import tools
-import pooler
-from tools.translate import _
+from openerp.osv import osv, fields
+import openerp.tools
+import openerp.pooler
+from openerp.tools.translate import _
 import datetime
 
-class res_partner(osv.osv):
+class res_partner(osv.Model):
     _inherit = 'res.partner'
 
     def check_fiscalcode(self, cr, uid, ids, context={}):

--- a/l10n_it_fiscalcode/wizard/compute_fc.py
+++ b/l10n_it_fiscalcode/wizard/compute_fc.py
@@ -19,14 +19,14 @@
 #
 ##############################################################################
 
-from osv import fields, osv
-import tools
-import pooler
-from tools.translate import _
+from openerp.osv import osv, fields
+import openerp.tools
+import openerp.pooler
+from openerp.tools.translate import _
 
 import datetime
 
-class wizard_compute_fc(osv.osv_memory):
+class wizard_compute_fc(osv.TransientModel):
 
     _name = "wizard.compute.fc"
     _description = "Compute Fiscal Code"


### PR DESCRIPTION
I added openerp namespace and changed base classes from osv.osv to osv.Model, etc.
This allows to install these two modules on 8.0
