### PR TITLE
[FIX] Do not raise ImportError if user doesn't use module.

### DIFF
--- a/l10n_it_fiscalcode/wizard/compute_fc.py
+++ b/l10n_it_fiscalcode/wizard/compute_fc.py
@@ -21,8 +21,18 @@
 
 from openerp import models, fields, api, _
 from openerp.exceptions import except_orm
+import logging
 import datetime
-from codicefiscale import build
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from codicefiscale import build
+except ImportError:
+    _logger.warning(
+        'codicefiscale library not found. '
+        'If you plan to use it, please install the codicefiscale library '
+        'from https://pypi.python.org/pypi/codicefiscale')
 
 
 class wizard_compute_fc(models.TransientModel):


### PR DESCRIPTION
As suggested in https://yelizariev.github.io/odoo/development/2015/07/06/external-dependencies.html

p.s: I still haven't time to test it, any volunteers?