### PR TITLE
[8.0] vat stament report fixes

### DIFF
--- a/account_vat_period_end_statement/report/vat_period_end_statement.py
+++ b/account_vat_period_end_statement/report/vat_period_end_statement.py
@@ -98,8 +98,8 @@ class VatPeriodEndStatementReport(report_sxw.rml_parse):
                 else:
                     vat_undeductible = child.tax_code_id.sum_period
         else:
-            vat_code = tax_code.code
-            vat_name = tax_code.name
+            vat_code = tax.description
+            vat_name = tax.name
             vat_deductible = tax_code.sum_period
 
         res[vat_name] = {

--- a/account_vat_period_end_statement/views/report_vatperiodendstatement.xml
+++ b/account_vat_period_end_statement/views/report_vatperiodendstatement.xml
@@ -169,17 +169,10 @@ Tax Code
     	<t t-foreach="tax_code_amounts" t-as="tax_code">
     		<!-- Prepare values -->
     		<t t-set="code" t-value="(tax_code_amounts[tax_code]['code'])"/>
-    		<t t-set="tax_code_base" t-value="(tax_code_amounts[tax_code]['base'])"/>
-    		<t t-set="tax_code_vat" t-value="(tax_code_amounts[tax_code]['vat'])"/>
-    		<t t-set="tax_code_vat_deductible" t-value="(tax_code_amounts[tax_code]['vat_deductible'])"/>
-    		<t t-set="tax_code_vat_undeductible" t-value="(tax_code_amounts[tax_code]['vat_undeductible'])"/>
-    		<!-- Credit have negative values : in the report will be positive -->
-    	    <span t-if="(tax_code_type == 'credit')">
-    			<t t-set="tax_code_base" t-value="(-1 * tax_code_base)"/>
-    			<t t-set="tax_code_vat" t-value="(-1 * tax_code_vat)"/>
-    			<t t-set="tax_code_vat_deductible" t-value="(-1 * tax_code_vat_deductible)"/>
-    			<t t-set="tax_code_vat_undeductible" t-value="(-1 * tax_code_vat_undeductible)"/>
-    		</span>
+    		<t t-set="tax_code_base" t-value="abs(tax_code_amounts[tax_code]['base'])"/>
+    		<t t-set="tax_code_vat" t-value="abs(tax_code_amounts[tax_code]['vat'])"/>
+    		<t t-set="tax_code_vat_deductible" t-value="abs(tax_code_amounts[tax_code]['vat_deductible'])"/>
+    		<t t-set="tax_code_vat_undeductible" t-value="abs(tax_code_amounts[tax_code]['vat_undeductible'])"/>
     		<!-- print values  -->
     		<tr>
     			<td><span t-esc="code"/></td>


### PR DESCRIPTION
I propose 2 fixes:

1) always use code/name of the tax instead of the code's ones.
2) always use absolute values
