### PR TITLE
fix an error when the 'Accounting' tab is not visible for some users

### DIFF
--- a/l10n_it_ricevute_bancarie/views/partner_view.xml
+++ b/l10n_it_ricevute_bancarie/views/partner_view.xml
@@ -9,6 +9,7 @@
             <field name="name">res.parner.form.riba</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_user'))]"/>
             <field name="arch" type="xml">
                 <field name="property_payment_term" position="after">
                     <separator string="Ri.Ba. properties" colspan="2"/>


### PR DESCRIPTION
When a user that doesn't have any accounting role/group, tries to acces a partner form he/she gets:
```
return old_api(self, *args, **kwargs)
File "/srv/webapp/instances/odoo/prod/buildout/parts/odoo/openerp/addons/base/ir/ir_ui_view.py", line 360, in raise_view_error
raise AttributeError(message)
AttributeError: Element '<field name="property_payment_term">' cannot be located in parent view

Error context:
View `res.parner.form.riba`
[view_id: 1558, xml_id: l10n_it_ricevute_bancarie.view_partner_form_riba, model: res.partner, parent_id: 126]
```

..because the accounting tab is not visible for them. This fixes this issue.