### PR TITLE
FIX DDT: partner to invoice

### DIFF
--- a/l10n_it_ddt/wizard/add_picking_to_ddt.py
+++ b/l10n_it_ddt/wizard/add_picking_to_ddt.py
@@ -29,7 +29,7 @@ class AddPickingToDdt(models.TransientModel):
                     self.ddt_id.id in [d.id for d in picking.ddt_ids]:
                 raise UserError(
                     _("Picking %s already in ddt") % picking.name)
-            elif picking.partner_id != self.ddt_id.partner_id:
+            elif picking.partner_id != self.ddt_id.partner_shipping_id:
                 raise UserError(
                     _("Selected Picking %s have"
                       " different Partner") % picking.name)

--- a/l10n_it_ddt/wizard/ddt_from_picking.py
+++ b/l10n_it_ddt/wizard/ddt_from_picking.py
@@ -39,8 +39,10 @@ class DdTFromPickings(models.TransientModel):
                 raise UserError(
                     _("Selected Pickings have different Partner"))
             partner = picking.partner_id
-            values['partner_id'] = partner.id
-            values['partner_invoice_id'] = partner.id
+            values['partner_id'] = partner.commercial_partner_id.id
+            values['partner_invoice_id'] = picking.with_context(
+                {'inv_type': 'out_invoice'}
+                )._get_partner_to_invoice(picking)
             values['partner_shipping_id'] = partner.id
         parcels = 0
         for picking in self.picking_ids:


### PR DESCRIPTION
abbiamo preso un ordine di vendita che indirizzo di consegna diverso da quello di fattura/cliente con fatturazione su consegnato.
Il picking presentava l'indirizzo di consegna ereditato dall'ordine e fatturandolo usciva correttamente il partner di fatturazione.
Lo stesso picking lo abbiamo portato in un DDT, (e qui i 3 indirizzi cliente + fatturazione + consegna erano tutti e tre uguali corrispondevano all'indirizzo di consenga del Picking) e poi fatturando lo stesso DDT abbiamo ottenuto una fattura all'indirizzo di consegna e non al partner principale