### PR TITLE
FIX  l10n_it_ricevute_bancarie group invoices

### DIFF
--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_issue.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_issue.py
@@ -100,7 +100,7 @@ class RibaIssue(models.TransientModel):
                         rdl_id = create_rdl(
                             countme, bank_id.id, rd_id,
                             move_line.date_maturity, move_line.partner_id.id,
-                            self.configuration_id.acceptance_account_id.id)
+                            self.configuration_id.acceptance_account_id.id).id
                         # total = 0.0
                         # invoice_date_group = ''
                         for grouped_line in grouped_lines[key]:


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/170

-> Install the module l10n_it_ricevute_bancarie
-> On tab Accounting of parter activate "Group Ri.Ba." and set payment as "RiBA 30 Days End of Month"
-> Create new customer invoice, insert a line and validate
-> From Ri.Ba -> Issue RiBa -> Select the line of relative invoice -> Wizard "Salvo buon fine" -> Error