### PR TITLE
l10n_it_split_payment: Always give amount_sp a value

### DIFF
--- a/l10n_it_split_payment/models/account.py
+++ b/l10n_it_split_payment/models/account.py
@@ -48,6 +48,7 @@ class AccountInvoice(models.Model):
     @api.depends('invoice_line.price_subtotal', 'tax_line.amount')
     def _compute_amount(self):
         super(AccountInvoice, self)._compute_amount()
+        self.amount_sp = 0
         if self.fiscal_position.split_payment:
             self.amount_sp = self.amount_tax
             self.amount_tax = 0


### PR DESCRIPTION
otherwise you could get into errors like

  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/addons/account/account_invoice.py", line 647, in button_reset_taxes
    account_invoice_tax.create(taxe)
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/models.py", line 4093, in create
    record = self.browse(self._create(old_vals))
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/api.py", line 508, in new_api
    result = method(self._model, cr, uid, *args, **old_kwargs)
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/models.py", line 4303, in _create
    recs.recompute()
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/api.py", line 266, in wrapper
    return new_api(self, *args, **kwargs)
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/models.py", line 5756, in recompute
    name: rec[name] for name in names
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/models.py", line 5756, in <dictcomp>
    name: rec[name] for name in names
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/models.py", line 5640, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/fields.py", line 840, in __get__
    return record._cache[self]
  File "/srv/odoo-8-agilebg-test/agilebg/parts/odoo/openerp/models.py", line 6022, in __getitem__
    value = self._recs.env.cache[field][self._recs.id]
KeyError: 663