### PR TITLE
[FIX] Add fix purchase tax multicompany

### DIFF
--- a/l10n_it_account/__openerp__.py
+++ b/l10n_it_account/__openerp__.py
@@ -31,6 +31,7 @@
         'views/account_view.xml',
         'reports/account_reports_view.xml',
         'views/config_view.xml',
+        'views/company_view.xml',
     ],
     'installable': True,
     # this post_init script only works when you install account and

--- a/l10n_it_account/models/__init__.py
+++ b/l10n_it_account/models/__init__.py
@@ -3,3 +3,4 @@
 from . import account
 from . import account_tax
 from . import res_config
+from . import company

--- a/l10n_it_account/models/account_tax.py
+++ b/l10n_it_account/models/account_tax.py
@@ -78,6 +78,8 @@ class AccountTax(models.Model):
         """
         if tax.company_id.skip_it_account_check:
             return
+        if tax.company_id.check_purchase_tax_multicompany:
+            return
         if tax.type_tax_use == 'purchase' and not tax.parent_id:
             if tax.base_code_id:
                 if self.exist(

--- a/l10n_it_account/models/company.py
+++ b/l10n_it_account/models/company.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# © <2016> <Nicola Malcontenti - nicola.malcontenti@agilebg.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields
+
+
+class Company(models.Model):
+    _inherit = 'res.company'
+
+    check_purchase_tax_multicompany = fields.Boolean(
+        string='Check Purchase Tax Multicompany',
+        help='Check this field to allow this company\n'
+             ' to use purchase tax in multicompany')

--- a/l10n_it_account/views/company_view.xml
+++ b/l10n_it_account/views/company_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+    	<record id="view_company_form_inherit" model="ir.ui.view">
+            <field name="name">res.company.form.inherit</field>
+            <field name="model">res.company</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="arch" type="xml">
+				<xpath expr="//field[@name='website']" position="after">
+                    <field name="check_purchase_tax_multicompany"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
I try to explain the problem.
If i use multicompany and each company are from different country, when i try too install new tax_account i get "Tax code already use" error.
With this fix, if you check check_purchase_tax_multicompany field on your company you can avoid all controls.