### PR TITLE
- Correzione reperimento partner dal sale order

### DIFF
--- a/l10n_it_ddt/wizard/ddt_from_picking.py
+++ b/l10n_it_ddt/wizard/ddt_from_picking.py
@@ -47,7 +47,7 @@ class DdTFromPickings(models.TransientModel):
             # ----- Get partners from order if it exists
             sale = picking.sale_id or False
             if sale:
-                values['partner_id'] = sale.partner.id
+                values['partner_id'] = sale.partner_id.id
                 values['partner_invoice_id'] = sale.partner_invoice_id.id
                 values['partner_shipping_id'] = sale.partner_shipping_id.id
         parcels = 0


### PR DESCRIPTION
The error is in line when you retrieve partner from sale. Is not sale.partner.id but the field name is sale.parner_id.id

Thanks