### PR TITLE
FIX  account_invoice_entry_date: period not found

### DIFF
--- a/account_invoice_entry_date/models/account.py
+++ b/account_invoice_entry_date/models/account.py
@@ -79,6 +79,11 @@ class AccountInvoice(models.Model):
                         ])
                 if period_ids:
                     period_id = period_ids[0]
+                else:
+                    raise Warning(
+                        _("Can't find a non special period for %s - %s (%s)")
+                        % (date_start, date_stop, inv.company_id.name)
+                    )
 
                 self.write(
                     cr, uid, [inv.id], {


### PR DESCRIPTION
  l10n-italy/account_invoice_entry_date/models/account.py", line 85, in action_move_create
    'registration_date': reg_date, 'period_id': period_id})
ValueError: "local variable 'period_id' referenced before assignment" while evaluating
u'action_move_create()