### PR TITLE
[8.0][FIX] l10n_it_corrispettivi: fix ValueError raised when trying to add a new invoice line.

### DIFF
--- a/l10n_it_corrispettivi/account_view.xml
+++ b/l10n_it_corrispettivi/account_view.xml
@@ -171,18 +171,6 @@
             </field>
         </record>
 
-        <record id="invoice_form" model="ir.ui.view">
-            <field name="name">account.invoice.form</field>
-            <field name="model">account.invoice</field>
-            <field name="type">form</field>
-            <field name="inherit_id" ref="account.invoice_form"></field>
-            <field name="arch" type="xml">
-                <field name="company_id" position="replace">
-                    <field name="company_id" on_change="onchange_company_id(company_id,partner_id,type,invoice_line,currency_id)" widget="selection" groups="base.group_multi_company"/>
-                </field>
-            </field>
-        </record>
-
         <record id="view_account_corrispettivi_filter" model="ir.ui.view">
             <field name="name">account.corrispettivi.select</field>
             <field name="model">account.invoice</field>


### PR DESCRIPTION
This PR fixes the following error:

```
ValueError: "name 'partner_id' is not defined" while evaluating '[company_id,partner_id,type,invoice_line,currency_id]'
````

This error is raised when trying to add a new invoice line.
