### PR TITLE
In caso di multiazienda, nel wizard di creazione della fattura

### DIFF
--- a/l10n_it_ddt/wizard/ddt_create_invoice.py
+++ b/l10n_it_ddt/wizard/ddt_create_invoice.py
@@ -23,6 +23,8 @@ class DdTCreateInvoice(models.TransientModel):
 
     journal_id = fields.Many2one('account.journal', 'Journal', required=True)
     date = fields.Date('Date')
+    company_id = fields.Many2one('res.company', string='Company',
+        default=lambda self: self.env.user.company_id, )
 
     def check_ddt_data(self, ddts):
         carriage_condition_id = False

--- a/l10n_it_ddt/wizard/ddt_create_invoice.xml
+++ b/l10n_it_ddt/wizard/ddt_create_invoice.xml
@@ -8,8 +8,9 @@
             <field name="arch" type="xml">
               <form string="DdT Create Invoice">
                   <group>
-                    <field name="journal_id" domain="[('type', 'in', ['sale', 'sale_refund'])]"/>
+                    <field name="journal_id" domain="[('type', 'in', ['sale', 'sale_refund']),('company_id','=',company_id)]"/>
                     <field name="date"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
                   </group>
                     <footer>
                         <button name="create_invoice" string="Create" type="object" class="oe_highlight"/>


### PR DESCRIPTION
dal DDT si trova il campo company_id per selezionare il giornale
di vendita tra quelli dell'azienda selezionata.