### PR TITLE
[10.0] FIX travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     packages:
       - expect-dev  # provides unbuffer utility
       - python-lxml  # because pip installation is slow
+      - unixodbc-dev
 
 env:
   global:


### PR DESCRIPTION
that would fail with
src/pyodbc.h:56:17: fatal error: sql.h: No such file or directory

See
https://odoo-community.org/groups/contributors-15/contributors-49577
and
https://github.com/OCA/maintainer-quality-tools/issues/427