### PR TITLE
[ADD] flag on product to exclude of withholding tax

### DIFF
--- a/l10n_it_withholding_tax/__openerp__.py
+++ b/l10n_it_withholding_tax/__openerp__.py
@@ -10,11 +10,12 @@
               'Odoo Community Association (OCA)',
     'website': 'http://www.openforce.it',
     'license': 'AGPL-3',
-    "depends": ['account', 'account_voucher'],
+    "depends": ['account', 'account_voucher', 'product'],
     "data": [
         'views/account.xml',
         'views/voucher.xml',
         'views/withholding_tax.xml',
+        'views/product.xml',
         'wizard/create_wt_statement_view.xml',
         'security/ir.model.access.csv',
         'workflow.xml',

--- a/l10n_it_withholding_tax/i18n/it.po
+++ b/l10n_it_withholding_tax/i18n/it.po
@@ -1,23 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_it_withholding_tax
-# 
-# Translators:
-# Paolo Valier, 2016
-# Paolo Valier, 2016
+#	* l10n_it_withholding_tax
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-italy (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-01-31 15:00+0000\n"
-"PO-Revision-Date: 2016-06-05 07:07+0000\n"
-"Last-Translator: Paolo Valier\n"
-"Language-Team: Italian (http://www.transifex.com/oca/OCA-l10n-italy-8-0/language/it/)\n"
+"POT-Creation-Date: 2017-04-24 09:46+0000\n"
+"PO-Revision-Date: 2017-04-24 09:46+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_it_withholding_tax
 #: model:ir.model,name:l10n_it_withholding_tax.model_account_move
@@ -73,7 +69,8 @@ msgid "Amount"
 msgstr "Importo"
 
 #. module: l10n_it_withholding_tax
-#: field:account.invoice.withholding.tax,base:0 field:withholding.tax,base:0
+#: field:account.invoice.withholding.tax,base:0
+#: field:withholding.tax,base:0
 #: field:withholding.tax.statement,base:0
 #: field:withholding.tax.wizard.create.statement,base:0
 msgid "Base"
@@ -107,7 +104,8 @@ msgstr "Crea Movimento di Ritenuta"
 
 #. module: l10n_it_withholding_tax
 #: field:account.invoice.withholding.tax,create_uid:0
-#: field:withholding.tax,create_uid:0 field:withholding.tax.move,create_uid:0
+#: field:withholding.tax,create_uid:0
+#: field:withholding.tax.move,create_uid:0
 #: field:withholding.tax.rate,create_uid:0
 #: field:withholding.tax.statement,create_uid:0
 #: field:withholding.tax.voucher.line,create_uid:0
@@ -178,9 +176,7 @@ msgstr "Da pagare"
 #. module: l10n_it_withholding_tax
 #: code:addons/l10n_it_withholding_tax/models/withholding_tax.py:111
 #, python-format
-msgid ""
-"Error! You cannot have 2 pricelist versions that                     "
-"overlap!"
+msgid "Error! You cannot have 2 pricelist versions that                     overlap!"
 msgstr "Errore! I periodi si sovrappongono"
 
 #. module: l10n_it_withholding_tax
@@ -195,8 +191,10 @@ msgid "Group By..."
 msgstr "Group By..."
 
 #. module: l10n_it_withholding_tax
-#: field:account.invoice.withholding.tax,id:0 field:withholding.tax,id:0
-#: field:withholding.tax.move,id:0 field:withholding.tax.rate,id:0
+#: field:account.invoice.withholding.tax,id:0
+#: field:withholding.tax,id:0
+#: field:withholding.tax.move,id:0
+#: field:withholding.tax.rate,id:0
 #: field:withholding.tax.statement,id:0
 #: field:withholding.tax.voucher.line,id:0
 #: field:withholding.tax.wizard.create.statement,id:0
@@ -209,6 +207,11 @@ msgstr "ID"
 #: field:withholding.tax.statement,invoice_id:0
 msgid "Invoice"
 msgstr "Fattura"
+
+#. module: l10n_it_withholding_tax
+#: model:ir.model,name:l10n_it_withholding_tax.model_account_invoice_line
+msgid "Invoice Line"
+msgstr "Riga fattura"
 
 #. module: l10n_it_withholding_tax
 #: model:ir.model,name:l10n_it_withholding_tax.model_account_invoice_withholding_tax
@@ -233,7 +236,8 @@ msgstr "Ultima modifica il"
 
 #. module: l10n_it_withholding_tax
 #: field:account.invoice.withholding.tax,write_uid:0
-#: field:withholding.tax,write_uid:0 field:withholding.tax.move,write_uid:0
+#: field:withholding.tax,write_uid:0
+#: field:withholding.tax.move,write_uid:0
 #: field:withholding.tax.rate,write_uid:0
 #: field:withholding.tax.statement,write_uid:0
 #: field:withholding.tax.voucher.line,write_uid:0
@@ -243,7 +247,8 @@ msgstr "Last Updated by"
 
 #. module: l10n_it_withholding_tax
 #: field:account.invoice.withholding.tax,write_date:0
-#: field:withholding.tax,write_date:0 field:withholding.tax.move,write_date:0
+#: field:withholding.tax,write_date:0
+#: field:withholding.tax.move,write_date:0
 #: field:withholding.tax.rate,write_date:0
 #: field:withholding.tax.statement,write_date:0
 #: field:withholding.tax.voucher.line,write_date:0
@@ -257,7 +262,8 @@ msgid "Moves"
 msgstr "Movimenti"
 
 #. module: l10n_it_withholding_tax
-#: field:withholding.tax,name:0 field:withholding.tax.move,display_name:0
+#: field:withholding.tax,name:0
+#: field:withholding.tax.move,display_name:0
 #: field:withholding.tax.statement,display_name:0
 msgid "Name"
 msgstr "Nome"
@@ -321,12 +327,14 @@ msgid "Tax"
 msgstr "Importo"
 
 #. module: l10n_it_withholding_tax
-#: field:withholding.tax,tax:0 field:withholding.tax.rate,tax:0
+#: field:withholding.tax,tax:0
+#: field:withholding.tax.rate,tax:0
 msgid "Tax %"
 msgstr "Tax %"
 
 #. module: l10n_it_withholding_tax
-#: field:withholding.tax,comment:0 field:withholding.tax.rate,comment:0
+#: field:withholding.tax,comment:0
+#: field:withholding.tax.rate,comment:0
 msgid "Text"
 msgstr "Text"
 
@@ -409,9 +417,7 @@ msgstr "Warning!"
 #. module: l10n_it_withholding_tax
 #: code:addons/l10n_it_withholding_tax/models/withholding_tax.py:254
 #, python-format
-msgid ""
-"Warning! You cannot delet move linked to voucher.You                     "
-"must before delete the voucher."
+msgid "Warning! You cannot delet move linked to voucher.You                     must before delete the voucher."
 msgstr "Warning! You cannot delet move linked to voucher.You                     must before delete the voucher."
 
 #. module: l10n_it_withholding_tax
@@ -495,6 +501,16 @@ msgid "Withholding tax"
 msgstr "Ritenuta"
 
 #. module: l10n_it_withholding_tax
+#: field:account.invoice.line,withholding_tax_exclude:0
+msgid "Withholding tax exclude"
+msgstr "No Rit"
+
+#. module: l10n_it_withholding_tax
+#: field:product.template,withholding_tax_exclude:0
+msgid "Withholding tax exclude"
+msgstr "No Rit"
+
+#. module: l10n_it_withholding_tax
 #: model:ir.actions.act_window,name:l10n_it_withholding_tax.action_withholding_tax
 msgid "Withhoulding Tax"
 msgstr "Ritenuta"
@@ -519,16 +535,13 @@ msgstr "You can choose Only ONE move."
 #: view:account.voucher:l10n_it_withholding_tax.view_withholding_voucher_payment_receipt_form
 #: view:account.voucher:l10n_it_withholding_tax.view_withholding_voucher_payment_supplier_form
 #: view:account.voucher:l10n_it_withholding_tax.view_withholding_voucher_vendor_receipt_form
-msgid ""
-"onchange_amount(amount, amount_unreconciled, "
-"amount_residual_withholding_tax, context)"
+msgid "onchange_amount(amount, amount_unreconciled, amount_residual_withholding_tax, context)"
 msgstr "onchange_amount(amount, amount_unreconciled, amount_residual_withholding_tax, context)"
 
 #. module: l10n_it_withholding_tax
 #: view:account.voucher:l10n_it_withholding_tax.view_withholding_voucher_payment_receipt_form
 #: view:account.voucher:l10n_it_withholding_tax.view_withholding_voucher_payment_supplier_form
 #: view:account.voucher:l10n_it_withholding_tax.view_withholding_voucher_vendor_receipt_form
-msgid ""
-"onchange_reconcile(reconcile, amount, amount_unreconciled, "
-"amount_residual_withholding_tax, context)"
+msgid "onchange_reconcile(reconcile, amount, amount_unreconciled, amount_residual_withholding_tax, context)"
 msgstr "onchange_reconcile(reconcile, amount, amount_unreconciled, amount_residual_withholding_tax, context)"
+

--- a/l10n_it_withholding_tax/models/__init__.py
+++ b/l10n_it_withholding_tax/models/__init__.py
@@ -6,3 +6,4 @@
 from . import account
 from . import voucher
 from . import withholding_tax
+from . import product

--- a/l10n_it_withholding_tax/models/product.py
+++ b/l10n_it_withholding_tax/models/product.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Simone Versienti <s.versienti@apuliasoftware.it>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields
+
+
+class ProductTemplate(models.Model):
+
+    _inherit = 'product.template'
+
+    withholding_tax_exclude = fields.Boolean()

--- a/l10n_it_withholding_tax/models/withholding_tax.py
+++ b/l10n_it_withholding_tax/models/withholding_tax.py
@@ -56,7 +56,10 @@ class withholding_tax(models.Model):
         }
         if not amount_invoice and invoice_id:
             invoice = invoice_obj.browse(invoice_id)
-            amount_invoice = invoice.amount_untaxed
+            total_withholding_tax_excluded = \
+                invoice.compute_amount_withholding_excluded()
+            amount_invoice = (
+                invoice.amount_untaxed - total_withholding_tax_excluded)
         # v7->v8 removed tax = self.browse(cr, uid, withholding_tax_id)
         base = amount_invoice * self.base
         tax = base * ((self.tax or 0.0) / 100.0)

--- a/l10n_it_withholding_tax/views/account.xml
+++ b/l10n_it_withholding_tax/views/account.xml
@@ -106,5 +106,26 @@
             </field>
         </record>
 
+        <record model="ir.ui.view" id="view_withholding_tax_exclude_tree">
+            <field name="name">view.withholding.tax.exclude.tree</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='discount']" position="after">
+                    <field name="withholding_tax_exclude"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="view_withholding_tax_exclude_supplier_tree">
+            <field name="name">view.withholding.tax.exclude.supplier.tree</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_supplier_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='discount']" position="after">
+                    <field name="withholding_tax_exclude"/>
+                </xpath>
+            </field>
+        </record>
     </data>
 </openerp>

--- a/l10n_it_withholding_tax/views/product.xml
+++ b/l10n_it_withholding_tax/views/product.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data>
+
+    <record model="ir.ui.view" id="view_product_template_withholding_exclude_form">
+            <field name="name">view.product.template.withholding.exclude.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="account.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='taxes_id']" position="after">
+                    <field name="withholding_tax_exclude"/>
+                </xpath>
+            </field>
+    </record>
+
+</data>
+</openerp>


### PR DESCRIPTION
Il campo `withholding_tax_exclude` permette di identificare, in fase di creazione di una fattura (sia cliente che fornitore), gli eventuali prodotti che non sono soggetti a ritenuta d'acconto. 
Per questo è stata leggermente modificata la funzione che calcola l'importo della ritenuta, in modo da escludere i prodotti che abbiano la spunta sul nuovo campo.
Il campo `withholding_tax_exclude` è stato aggiunto sia nella scheda Contabilità di ciascun prodotto che nella visualizzazione delle righe della fattura.

Per testare la funzionalità:

- creare un nuovo prodotto e spuntare la casella relativa al nuovo campo aggiunto

- creare una fattura (cliente o fornitore), selezionando una posizione fiscale che preveda una ritenuta

- inserire alcuni prodotti, tra cui il prodotto creato in precedenza ed aggiornare

- sotto le righe fattura, nella parte relativa alle ritenute d'acconto, saranno mostrati il totale imponibile e l'importo, che non terranno conto del prodotto identificato come "non soggetto a ritenuta". 