### PR TITLE
FIX l10n_it_ricevute_bancarie tests

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account/account.py
+++ b/l10n_it_ricevute_bancarie/models/account/account.py
@@ -207,11 +207,12 @@ class AccountInvoice(models.Model):
     def action_invoice_draft(self):
         # ---- Delete Due Cost Line of invoice when set Back to Draft
         # ---- line was added on new validate
+        super(AccountInvoice, self).action_invoice_draft()
         for invoice in self:
+            invoice.refresh()
             for line in invoice.invoice_line_ids:
                 if line.due_cost_line:
                     line.unlink()
-        super(AccountInvoice, self).action_invoice_draft()
 
     @api.multi
     def action_cancel(self):


### PR DESCRIPTION
after https://github.com/odoo/odoo/commit/efa4f85480cbea1b68454091168bc988bc9c8341
otherwise:

```
2017-05-20 03:21:02,605 6389 ERROR openerp_test odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba: ERROR: test_delete_due_cost_line (odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba.TestInvoiceDueCost)
2017-05-20 03:21:02,605 6389 ERROR openerp_test odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba: Traceback (most recent call last):
2017-05-20 03:21:02,605 6389 ERROR openerp_test odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba: `   File "/home/travis/build/OCA/l10n-italy/l10n_it_ricevute_bancarie/tests/test_riba.py", line 205, in test_delete_due_cost_line
2017-05-20 03:21:02,605 6389 ERROR openerp_test odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba: `     self.invoice.action_invoice_draft()
2017-05-20 03:21:02,606 6389 ERROR openerp_test odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba: `   File "/home/travis/build/OCA/l10n-italy/l10n_it_ricevute_bancarie/models/account/account.py", line 213, in action_invoice_draft
2017-05-20 03:21:02,606 6389 ERROR openerp_test odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba: `     line.unlink()
2017-05-20 03:21:02,606 6389 ERROR openerp_test odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba: `   File "/home/travis/odoo-10.0/addons/account/models/account_invoice.py", line 1360, in unlink
2017-05-20 03:21:02,606 6389 ERROR openerp_test odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba: `     raise UserError(_('You can only delete an invoice line if the invoice is in draft state.'))
2017-05-20 03:21:02,606 6389 ERROR openerp_test odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba: ` UserError: (u'You can only delete an invoice line if the invoice is in draft state.', None)
```