### PR TITLE
8.0 -Tax lines with price included

### DIFF
--- a/l10n_it_vat_registries/vat_registry.py
+++ b/l10n_it_vat_registries/vat_registry.py
@@ -204,7 +204,6 @@ class Parser(report_sxw.rml_parse):
         obj_tax = self.pool.get('account.tax')
         tax_ids = obj_tax.search(self.cr, self.uid, [
             '&',
-            '&',
             '|',
             ('base_code_id', '=', tax_code_id),
             '|',
@@ -213,12 +212,10 @@ class Parser(report_sxw.rml_parse):
             ('ref_base_code_id', '=', tax_code_id),
             ('ref_tax_code_id', '=', tax_code_id),
             ('parent_id', '=', False),
-            ('price_include', '=', False),
         ])
         if not tax_ids:
             # I'm in the case of partially deductible VAT
             child_tax_ids = obj_tax.search(self.cr, self.uid, [
-                '&',
                 '|',
                 ('base_code_id', '=', tax_code_id),
                 '|',
@@ -226,7 +223,6 @@ class Parser(report_sxw.rml_parse):
                 '|',
                 ('ref_base_code_id', '=', tax_code_id),
                 ('ref_tax_code_id', '=', tax_code_id),
-                ('price_include', '=', False),
             ])
             for tax in obj_tax.browse(self.cr, self.uid, child_tax_ids):
                 if tax.parent_id:

--- a/l10n_it_vat_registries/wizard/print_registro_iva.py
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.py
@@ -50,7 +50,7 @@ class WizardRegistroIva(models.TransientModel):
         ('customer', 'Customer Invoices'),
         ('supplier', 'Supplier Invoices'),
         ('corrispettivi', 'Corrispettivi'),
-        ], 'Layout', required=True,
+    ], 'Layout', required=True,
         default='customer')
     tax_registry_id = fields.Many2one('account.tax.registry', 'VAT registry')
     journal_ids = fields.Many2many(
@@ -88,7 +88,7 @@ class WizardRegistroIva(models.TransientModel):
             ('journal_id', 'in', [j.id for j in wizard.journal_ids]),
             ('period_id', 'in', [p.id for p in wizard.period_ids]),
             ('state', '=', 'posted'),
-            ], order='date, name')
+        ], order='date, name')
         if not move_ids:
             raise UserError(_('No documents found in the current selection'))
         datas = {}


### PR DESCRIPTION
Dare la possibilità di stampare sui registri anche movimenti che usano un codice iva con tassa inclusa nel prezzo.
E' il caso di chi registra i corrispettivi.
NB: Gli imponibili in questo caso vengono mostrati se sul conto imposta è vistato il relativo campo "E' imponibile"