### PR TITLE
FIX l10n_it_ricevute_bancarie while duplicating

### DIFF
--- a/l10n_it_ricevute_bancarie/__manifest__.py
+++ b/l10n_it_ricevute_bancarie/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': "Ricevute Bancarie",
-    'version': "10.0.0.1.3",
+    'version': "10.0.0.1.4",
     'author': "Odoo Community Association (OCA)",
     'category': "Accounting & Finance",
     'website': "https://odoo-community.org/",

--- a/l10n_it_ricevute_bancarie/models/account/account.py
+++ b/l10n_it_ricevute_bancarie/models/account/account.py
@@ -244,6 +244,7 @@ class AccountInvoice(models.Model):
             for line in invoice.invoice_line_ids:
                 if line.due_cost_line:
                     line.unlink()
+        return invoice
 
 
 class AccountInvoiceLine(models.Model):

--- a/l10n_it_ricevute_bancarie/tests/test_riba.py
+++ b/l10n_it_ricevute_bancarie/tests/test_riba.py
@@ -178,6 +178,8 @@ class TestInvoiceDueCost(common.TransactionCase):
         self.assertEqual(
             (self.invoice.invoice_line_ids[1].price_unit +
              self.invoice.invoice_line_ids[2].price_unit), 10.00)
+        new_inv = self.invoice.copy()
+        self.assertEqual(len(new_inv.invoice_line_ids), 1)
 
     def test_not_add_due_cost(self):
         # create 2 invoice for partner in same month on the second one no


### PR DESCRIPTION
File "odoo/lib/python2.7/site-packages/odoo/models.py", line 4369, in <lambda>
    @api.returns('self', lambda value: value.id)
AttributeError: 'NoneType' object has no attribute 'id'

while duplicating