### PR TITLE
[BUG] voucher payment could not be validated if payment journal (e.g.…

### DIFF
--- a/l10n_it_withholding_tax/models/voucher.py
+++ b/l10n_it_withholding_tax/models/voucher.py
@@ -232,7 +232,8 @@ class account_voucher(orm.Model):
                         'credit': line_payment.credit + debit,
                         'debit': line_payment.debit + credit
                     }
-                    move_line_obj.write(cr, uid, [line_payment.id], val)
+                    move_line_obj.write(cr, uid, [line_payment.id], val,
+                        update_check=False)
 
         # Merge with existing lines to reconcile
         if rec_list_new_moves:


### PR DESCRIPTION
… bank) had 'Autopost Created Moves' flagged. Now added update_check=True variable in account.move.line.write() method.