### PR TITLE
[FIX][8.0] missing date invoice in ctx from shipping

### DIFF
--- a/l10n_it_ddt/wizard/ddt_create_invoice.py
+++ b/l10n_it_ddt/wizard/ddt_create_invoice.py
@@ -92,6 +92,7 @@ class DdTCreateInvoice(models.TransientModel):
             ctx = self.env.context.copy()
             ctx['ddt_partner_id'] = partner_id  # ddts[0].partner_invoice_id.id
             ctx['inv_type'] = 'out_invoice'
+            ctx['date_inv'] = self.date
             picking_list = [p.picking_ids for p in ddt_partner[partner_id]]
             for pll in picking_list:
                 for p in pll:


### PR DESCRIPTION
When creating invoice from ddt, date is not put in invoice because missing in ctx.
With this mp the bug is solved