### PR TITLE
Fiscalyear code in the footer instead of year of the print

### DIFF
--- a/l10n_it_central_journal/central_journal.py
+++ b/l10n_it_central_journal/central_journal.py
@@ -31,8 +31,6 @@ class Parser(report_sxw.rml_parse):
         res = False
         if self.localcontext.get('print_state') == 'def':
             fiscalyear_obj = self.pool.get('account.fiscalyear')
-            fiscalyear_ids = fiscalyear_obj.search(
-                self.cr, self.uid, [('id', '=', fiscalyear_id)])
             print_info = {
                 'date_last_print': end_date_print,
                 'progressive_line_number': end_row,
@@ -41,7 +39,7 @@ class Parser(report_sxw.rml_parse):
                 'progressive_credit': end_credit,
             }
             res = fiscalyear_obj.write(
-                self.cr, self.uid, fiscalyear_ids, print_info)
+                self.cr, self.uid, [fiscalyear.id], print_info)
         return res
 
     def __init__(self, cr, uid, name, context):
@@ -59,8 +57,8 @@ class Parser(report_sxw.rml_parse):
                 'start_row'),
             'date_move_line_to': data['form'].get(
                 'date_move_line_to'),
-            'fiscalyear': data['form'].get(
-                'fiscalyear'),
+            'fiscalyear': self.pool['account.fiscalyear'].browse(
+                self.cr, self.uid, data['form'].get('fiscalyear')),
             'print_state': data['form'].get(
                 'print_state'),
             'progressive_credit': data['form'].get(

--- a/l10n_it_central_journal/reports.xml
+++ b/l10n_it_central_journal/reports.xml
@@ -16,5 +16,57 @@
             ref="l10n_it_account.l10n_it_account_a4_portrait"/>
        </record>
     </data>
+    
+    <data>
+        <template id="l10n_it_central_journal.central_journal_internal_layout">
+          <!-- Multicompany -->
+          <t t-if="o and 'company_id' in o">
+              <t t-set="company" t-value="o.company_id"></t>
+          </t>
+          <t t-if="not o or not 'company_id' in o">
+              <t t-set="company" t-value="res_company"></t>
+          </t>
+
+          <div class="header">
+              <div class="row">
+                  <div class="col-xs-4 company-info">
+                      <h3 class="name"><span t-esc="company.name" /></h3>
+                      <span class="address">
+                        <span class="street" t-esc="company.street" /><br/>
+                        <span class="zip" t-esc="company.zip" /> -
+                        <span class="city" t-esc="company.city" /> -
+                        <span class="state" t-esc="company.state_id.code" /><br/>
+                      </span>
+                      <span class="vat text-right" t-if="company.partner_id.vat">
+                        <span>Vat:</span> <span t-esc="company.partner_id.vat" />
+                      </span><br/>
+                      <span class="fiscalcode text-right" t-if="company.partner_id.fiscalcode">
+                        <span>Fiscalcode:</span> <span t-esc="company.partner_id.fiscalcode" />
+                      </span>
+                  </div>
+                  <div class="col-xs-4 col-xs-offset-4 text-right doc-info">
+                      <h3 class="doc-title" t-esc="title"/>
+                  </div>
+              </div>
+          </div>
+          <t t-raw="0" />
+          <div class="footer">
+              <div class="row">
+                  <div class="col-xs-4">
+
+                  </div>
+                  <div class="col-xs-4 col-xs-offset-4 text-right">
+                    <span style="display: none;" id="l10n_it_count_fiscal_page_base" t-esc="l10n_it_count_fiscal_page_base" />
+                    <ul class="list-inline">Pag:
+                        <li><span t-esc="fiscalyear.code"/></li>
+                        <li>/</li>
+                        <li><span class="page"/></li>
+                    </ul>
+                  </div>
+              </div>
+          </div>
+      </template>
+
+    </data>
 </openerp>
 

--- a/l10n_it_central_journal/views/report_account_central_journal.xml
+++ b/l10n_it_central_journal/views/report_account_central_journal.xml
@@ -7,7 +7,7 @@
 <template id="report_giornale">
     <t t-call="report.html_container">
         <t t-set="title" t-value="'Stampa libro giornale'"/>
-        <t t-call="l10n_it_account.internal_layout">
+        <t t-call="l10n_it_central_journal.central_journal_internal_layout">
 
             <div class="page">
                 <t t-set="print_details" t-value="1"/>
@@ -39,7 +39,7 @@
                         </tr>
                     </thead>
                     
-                    <t t-set="counter" t-value="start_row"/>
+                    <t t-set="counter" t-value="start_row - 1"/>
                     <t t-set="save_move_id" t-value="0"/>
                     <t t-set="tot_credit" t-value="progressive_credit"/>
                     <t t-set="tot_debit" t-value="progressive_debit"/>


### PR DESCRIPTION
Nella numerazione delle pagine, viene indicato il codice dell'anno fiscale che si va a stampare anzichè l'anno di stampa.
Così se nel 2017 si va a stampare il libro giornale con le registrazioni del 2016, le pagine verrano numerate con 2016/1, 2016/2....

Viene corretta anche la numerazione delle righe in stampa.