### PR TITLE
[8.0] add configuration filter in riba detail

### DIFF
--- a/l10n_it_ricevute_bancarie/models/riba.py
+++ b/l10n_it_ricevute_bancarie/models/riba.py
@@ -319,6 +319,9 @@ class RibaListLine(models.Model):
         'account.move.line', compute='_compute_lines', string='Payments')
     type = fields.Selection(
         string="Type", related='distinta_id.config_id.type', readonly=True)
+    config_id = fields.Many2one(
+        string="Configuration", related='distinta_id.config_id',
+        readonly=True, store=True)
 
     @api.multi
     def confirm(self):

--- a/l10n_it_ricevute_bancarie/views/riba_detail_view.xml
+++ b/l10n_it_ricevute_bancarie/views/riba_detail_view.xml
@@ -23,6 +23,7 @@
                     <separator orientation="vertical"/>
                     <field name="partner_id" />
                     <field name="due_date" />
+                    <field name="config_id" />
                </search>
             </field>
         </record>
@@ -35,6 +36,7 @@
             <field name="model">riba.distinta.line</field>
             <field name="arch" type="xml">
                 <tree string="Dettaglio distinte Ri.Ba.">
+                    <field name="config_id" />
                     <field name="sequence"/>
                     <field name="invoice_number"/>
                     <field name="invoice_date"/>


### PR DESCRIPTION
Spesso i clienti hanno diverse banche sulle quali gestire le riba e per ognuna ci può essere una configurazione.
Con questa PR aggiungo la possibilità di cercare, dal dettaglio distinte, le scadenze anche per nome configurazione.