### PR TITLE
FIX l10n_it_withholding_tax menu

### DIFF
--- a/l10n_it_withholding_tax/__manifest__.py
+++ b/l10n_it_withholding_tax/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Italian Withholding Tax',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Account',
     'author': 'Openforce, Odoo Italia Network, '
               'Odoo Community Association (OCA)',

--- a/l10n_it_withholding_tax/views/withholding_tax.xml
+++ b/l10n_it_withholding_tax/views/withholding_tax.xml
@@ -78,7 +78,7 @@
         </record>
 
         <menuitem id="menu_withholding_tax" name="Withholding Tax" 
-            action="action_withholding_tax" parent="account.menu_action_tax_form" sequence="45"/>
+            action="action_withholding_tax" parent="account.account_account_menu" sequence="45"/>
 
 
         <!--


### PR DESCRIPTION
unusable taxes menu with odoo enterprise or web_responsive