### PR TITLE
fix display_name depends on itself

### DIFF
--- a/l10n_it_ddt/models/stock_picking_package_preparation.py
+++ b/l10n_it_ddt/models/stock_picking_package_preparation.py
@@ -96,7 +96,7 @@ class StockPickingPackagePreparation(models.Model):
     carrier_id = fields.Many2one(
         'res.partner', string='Carrier')
     parcels = fields.Integer('Parcels')
-    display_name = fields.Char(string='Name', compute='_compute_display_name')
+    display_name = fields.Char(string='Name', compute='_compute_clean_display_name')
     volume = fields.Float('Volume')
     invoice_id = fields.Many2one(
         'account.invoice', string='Invoice', readonly=True, copy=False)
@@ -186,7 +186,11 @@ class StockPickingPackagePreparation(models.Model):
         return True
 
     @api.multi
-    def _compute_display_name(self):
+    @api.depends('name',
+                'ddt_number',
+                'partner_id.name',
+                'date')
+    def _compute_clean_display_name(self):
         for prep in self:
             name = u''
             if prep.name:

--- a/l10n_it_ddt/models/stock_picking_package_preparation.py
+++ b/l10n_it_ddt/models/stock_picking_package_preparation.py
@@ -96,7 +96,8 @@ class StockPickingPackagePreparation(models.Model):
     carrier_id = fields.Many2one(
         'res.partner', string='Carrier')
     parcels = fields.Integer('Parcels')
-    display_name = fields.Char(string='Name', compute='_compute_clean_display_name')
+    display_name = fields.Char(
+        string='Name', compute='_compute_clean_display_name')
     volume = fields.Float('Volume')
     invoice_id = fields.Many2one(
         'account.invoice', string='Invoice', readonly=True, copy=False)


### PR DESCRIPTION
fix odoo warning 
"odoo.fields:Field stock.picking.package.preparation.display_name depends on itself; please fix its decorator @api.depends()"

patch to issue #409 renaming compute method and filling @api.depends decorator