### PR TITLE
FIX l10n_it_withholding_tax

### DIFF
--- a/l10n_it_withholding_tax/views/withholding_tax.xml
+++ b/l10n_it_withholding_tax/views/withholding_tax.xml
@@ -107,7 +107,7 @@
             <field name="model">withholding.tax.statement</field>
             <field name="arch" type="xml">
 
-                <form string="Withholding Tax statement">
+                <form string="Withholding Tax statement" delete="false">
                     <sheet> 
                         <group>
                             <group>
@@ -127,7 +127,7 @@
                             <page string="WT moves" name="wt_moves">
                                 <group>
                                     <field name="move_ids" nolabel="1">
-                                        <tree>
+                                        <tree delete="false">
                                             <field name="date"/>
                                             <field name="withholding_tax_id"/>
                                             <field name="date_maturity"/>
@@ -192,7 +192,7 @@
             <field name="name">view.withholding.tax.move.form</field>
             <field name="model">withholding.tax.move</field>
             <field name="arch" type="xml">
-                <form string="Withholding Tax Move">
+                <form string="Withholding Tax Move" delete="false">
                     <header>
                         <button name="action_set_to_draft" states="paid" string="Set to Draft" type="object" />
                         <button name="action_paid" states="due" string="Paid" type="object" />

--- a/l10n_it_withholding_tax_payment/models/withholding_tax.py
+++ b/l10n_it_withholding_tax_payment/models/withholding_tax.py
@@ -157,3 +157,10 @@ class WithholdingTaxMovePayment(models.Model):
                 # Wt move set to due
                 for wt_move in move.line_ids:
                     wt_move.action_paid()
+
+    @api.multi
+    def unlink(self):
+        for payment in self:
+            if payment.state != 'draft':
+                raise ValidationError(_("You can only delete draft payments"))
+        return super(WithholdingTaxMovePayment, self).unlink()

--- a/l10n_it_withholding_tax_payment/views/withholding_tax.xml
+++ b/l10n_it_withholding_tax_payment/views/withholding_tax.xml
@@ -75,7 +75,7 @@
                         <newline/>
                         <group>
                             <field name="line_ids" nolabel="1">
-                                <tree>
+                                <tree delete="false">
                                     <field name="date"/>
                                     <field name="partner_id"/>
                                     <field name="withholding_tax_id"/>


### PR DESCRIPTION
Gli oggetti withholding.tax.move, withholding.tax.statement e withholding.tax.move.payment si possono eliminare dalla vista elendo dei relativi menu