### PR TITLE
[FIX] l10n_it_reverse_charge: replace action_cancel_draft by action_invoice_draft

### DIFF
--- a/l10n_it_reverse_charge/__manifest__.py
+++ b/l10n_it_reverse_charge/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Reverse Charge IVA',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Localization/Italy',
     'summary': 'Reverse Charge for Italy',
     'author': 'Odoo Italia Network,Odoo Community Association (OCA)',

--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -415,16 +415,16 @@ class AccountInvoice(models.Model):
         return super(AccountInvoice, self).action_cancel()
 
     @api.multi
-    def action_cancel_draft(self):
-        super(AccountInvoice, self).action_cancel_draft()
+    def action_invoice_draft(self):
+        super(AccountInvoice, self).action_invoice_draft()
         invoice_model = self.env['account.invoice']
         for inv in self:
             if inv.rc_self_invoice_id:
                 self_invoice = invoice_model.browse(
                     inv.rc_self_invoice_id.id)
-                self_invoice.action_cancel_draft()
+                self_invoice.action_invoice_draft()
             if inv.rc_self_purchase_invoice_id:
                 self_purchase_invoice = invoice_model.browse(
                     inv.rc_self_purchase_invoice_id.id)
-                self_purchase_invoice.action_cancel_draft()
+                self_purchase_invoice.action_invoice_draft()
         return True


### PR DESCRIPTION
Due to https://github.com/odoo/odoo/commit/bc8d5dbf2c2ee19b337195bdb4bee8e6ba8508cf

In this way both invoices are again set as draft.