### PR TITLE
[FIX] account_vat_period_end_statement: check move_id exists to get statement_draft properly working

### DIFF
--- a/account_vat_period_end_statement/__manifest__.py
+++ b/account_vat_period_end_statement/__manifest__.py
@@ -26,7 +26,7 @@
 
 {
     "name": "Period End VAT Statement",
-    "version": "10.0.1.3.0",
+    "version": "10.0.1.3.1",
     'category': 'Generic Modules/Accounting',
     'license': 'AGPL-3',
     "depends": [

--- a/account_vat_period_end_statement/models/account.py
+++ b/account_vat_period_end_statement/models/account.py
@@ -70,13 +70,16 @@ class AccountVatPeriodEndStatement(models.Model):
         precision = self.env.user.company_id.currency_id.decimal_places
         for statement in self:
             residual = 0.0
-            if not statement.move_id:
-                statement.residual = 0.0
-                statement.reconciled = False
-                return
-            for line in statement.move_id.line_ids:
-                if line.account_id.id == statement.authority_vat_account_id.id:
-                    residual += line.amount_residual
+            if statement.move_id.exists():
+                if not statement.move_id:
+                    statement.residual = 0.0
+                    statement.reconciled = False
+                    return
+                for line in statement.move_id.line_ids:
+                    authority_vat_account_id = (
+                        statement.authority_vat_account_id.id)
+                    if line.account_id.id == authority_vat_account_id:
+                        residual += line.amount_residual
             statement.residual = abs(residual)
             if float_is_zero(statement.residual, precision_digits=precision):
                 statement.reconciled = True
@@ -88,13 +91,14 @@ class AccountVatPeriodEndStatement(models.Model):
     def _compute_lines(self):
         for statement in self:
             payment_lines = []
-            for line in statement.move_id.line_ids:
-                payment_lines.extend(filter(None, [
-                    rp.credit_move_id.id for rp in line.matched_credit_ids
-                ]))
-                payment_lines.extend(filter(None, [
-                    rp.debit_move_id.id for rp in line.matched_debit_ids
-                ]))
+            if statement.move_id.exists():
+                for line in statement.move_id.line_ids:
+                    payment_lines.extend(filter(None, [
+                        rp.credit_move_id.id for rp in line.matched_credit_ids
+                    ]))
+                    payment_lines.extend(filter(None, [
+                        rp.debit_move_id.id for rp in line.matched_debit_ids
+                    ]))
             statement.payment_ids = self.env['account.move.line'].browse(
                 list(set(payment_lines)))
 


### PR DESCRIPTION
The field `move_id` needs to be checked if exists in the computed fields, otherwise the method unlink, during the fields recomputation, raises a MissingError for them