### PR TITLE
[10][FIX]l10n_it_central_journal-menu

### DIFF
--- a/l10n_it_central_journal/wizard/print_giornale.xml
+++ b/l10n_it_central_journal/wizard/print_giornale.xml
@@ -51,7 +51,7 @@
 
     <menuitem
             name="Central Journal"
-            parent="account.menu_finance_legal_statement"
+            parent="account.menu_finance_reports"
             action="action_giornale"
             id="menu_giornale"
             icon="STOCK_PRINT"/>


### PR DESCRIPTION
modificato riferimento padre del menu "Central Journal", quello utilizzato viene eliminato nella versione enterprise.
