### PR TITLE
[8.0][FIX] date format in riba line created

### DIFF
--- a/l10n_it_ricevute_bancarie/__openerp__.py
+++ b/l10n_it_ricevute_bancarie/__openerp__.py
@@ -26,7 +26,7 @@
 
 {
     'name': "Ricevute Bancarie",
-    'version': "8.0.1.3.0",
+    'version': "8.0.1.3.1",
     'author': "Odoo Community Association (OCA)",
     'category': "Accounting & Finance",
     'website': "http://www.odoo-italia.org",

--- a/l10n_it_ricevute_bancarie/models/riba.py
+++ b/l10n_it_ricevute_bancarie/models/riba.py
@@ -226,11 +226,14 @@ class RibaListLine(models.Model):
         for move_line in self.move_line_ids:
             self.amount += move_line.amount
             if not self.invoice_date:
-                self.invoice_date = str(
-                    move_line.move_line_id.invoice.date_invoice)
+                self.invoice_date = str(fields.Date.from_string(
+                    move_line.move_line_id.invoice.date_invoice
+                ).strftime('%d/%m/%Y'))
             else:
-                self.invoice_date = "%s, %s" % (self.invoice_date, str(
-                    move_line.move_line_id.invoice.date_invoice))
+                self.invoice_date = "%s, %s" % (
+                    self.invoice_date, str(fields.Date.from_string(
+                        move_line.move_line_id.invoice.date_invoice
+                    ).strftime('%d/%m/%Y')))
             if not self.invoice_number:
                 self.invoice_number = str(
                     move_line.move_line_id.invoice.internal_number)


### PR DESCRIPTION
Riba lines created from move lines have date non formatted for Italy (date is a char field). With this mp date are put correctly.