### PR TITLE
[10.0] FIX VAT registries and VAT statement when invoices with negative lines

### DIFF
--- a/l10n_it_account/__manifest__.py
+++ b/l10n_it_account/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Account',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'category': 'Hidden',
     'author': "Agile Business Group,Abstract,Odoo Community Association (OCA)",
     'website': 'http://www.odoo-italia.net',


### PR DESCRIPTION
Bug solved:
 - Create an invoice with a positive line and a negative line
 - Print VAT register

Get wrong totals