### PR TITLE
[FIX] l10n_it_vat_registries: workaround to fix the following issue:

### DIFF
--- a/l10n_it_vat_registries/README.rst
+++ b/l10n_it_vat_registries/README.rst
@@ -41,6 +41,7 @@ Contributors
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Sergio Corato <sergiocorato@gmail.com>
 * Elena Carlesso <ecarlesso@linkgroup.it>
+* Alex Comba <alex.comba@agilebg.com>
 
 Funders
 -------

--- a/l10n_it_vat_registries/__manifest__.py
+++ b/l10n_it_vat_registries/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Italian Localization - VAT Registries',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'category': 'Localization/Italy',
     "author": "Agile Business Group, Odoo Community Association (OCA)"
               ", LinkIt Srl",

--- a/l10n_it_vat_registries/i18n/it.po
+++ b/l10n_it_vat_registries/i18n/it.po
@@ -1,29 +1,26 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * l10n_it_vat_registries
-# 
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2017
-# Paolo Valier, 2017
+# 	* l10n_it_vat_registries
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-06 01:45+0000\n"
-"PO-Revision-Date: 2018-02-06 01:45+0000\n"
-"Last-Translator: Paolo Valier, 2017\n"
-"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"POT-Creation-Date: 2018-02-19 13:26+0000\n"
+"PO-Revision-Date: 2018-02-19 14:29+0100\n"
+"Last-Translator: Alex Comba <alex.comba@agilebg.com>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
 "Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.4\n"
 
 #. module: l10n_it_vat_registries
 #: model:ir.actions.act_window,help:l10n_it_vat_registries.action_account_tax_registry_form
 msgid "A VAT registry is used to group several journals in one registry."
-msgstr ""
-"Un registro è usato per raggruppare diversi sezionali in un unico registro."
+msgstr "Un registro è usato per raggruppare diversi sezionali in un unico registro."
 
 #. module: l10n_it_vat_registries
 #: model:ir.ui.view,arch_db:l10n_it_vat_registries.report_registro_iva
@@ -188,6 +185,11 @@ msgid "Layout"
 msgstr "Layout"
 
 #. module: l10n_it_vat_registries
+#: model:ir.ui.view,arch_db:l10n_it_vat_registries.wizard_registro_iva
+msgid "Load Journals"
+msgstr "Carica Sezionali"
+
+#. module: l10n_it_vat_registries
 #: model:ir.model.fields,field_description:l10n_it_vat_registries.field_wizard_registro_iva_message
 msgid "Message"
 msgstr "Messaggio"
@@ -196,7 +198,7 @@ msgstr "Messaggio"
 #: code:addons/l10n_it_vat_registries/models/vat_registry.py:75
 #, python-format
 msgid "Move line %s has too many base taxes"
-msgstr ""
+msgstr "La registrazione %s ha troppi codici imponibili"
 
 #. module: l10n_it_vat_registries
 #: model:ir.ui.view,arch_db:l10n_it_vat_registries.report_registro_iva
@@ -214,11 +216,21 @@ msgid "Name"
 msgstr "Nome"
 
 #. module: l10n_it_vat_registries
-#: code:addons/l10n_it_vat_registries/wizard/print_registro_iva.py:58
-#: code:addons/l10n_it_vat_registries/wizard/print_registro_iva.py:67
+#: code:addons/l10n_it_vat_registries/wizard/print_registro_iva.py:56
+#: code:addons/l10n_it_vat_registries/wizard/print_registro_iva.py:69
 #, python-format
 msgid "No documents found in the current selection"
 msgstr "Nessun documento trovato nella presente selezione"
+
+#. module: l10n_it_vat_registries
+#: code:addons/l10n_it_vat_registries/wizard/print_registro_iva.py:65
+#, python-format
+msgid ""
+"No journals found in the current selection.\n"
+"Please load them before to retry!"
+msgstr ""
+"Nessun sezionale trovato nella presente selezione.\n"
+"Caricarli prima di riprovare!"
 
 #. module: l10n_it_vat_registries
 #: model:ir.ui.view,arch_db:l10n_it_vat_registries.report_registro_iva
@@ -310,13 +322,8 @@ msgstr "Registro IVA"
 
 #. module: l10n_it_vat_registries
 #: model:ir.model.fields,help:l10n_it_vat_registries.field_account_journal_tax_registry_id
-msgid ""
-"You can group several journals within 1 registry. In printing wizard, you "
-"will be able to select the registry in order to load that group of journals"
-msgstr ""
-"È possibile raggruppare più giornali in un unico registro. Nella procedura "
-"guidata di stampa è possibile selezionare un registro per caricare quel dato"
-" gruppo di giornali."
+msgid "You can group several journals within 1 registry. In printing wizard, you will be able to select the registry in order to load that group of journals"
+msgstr "È possibile raggruppare più giornali in un unico registro. Nella procedura guidata di stampa è possibile selezionare un registro per caricare quel dato gruppo di giornali."
 
 #. module: l10n_it_vat_registries
 #: model:ir.model,name:l10n_it_vat_registries.model_account_tax_registry

--- a/l10n_it_vat_registries/tests/test_registry.py
+++ b/l10n_it_vat_registries/tests/test_registry.py
@@ -22,6 +22,11 @@ class TestRegistry(AccountingTestCase):
             'amount_type': 'fixed',
             'account_id': self.ova.id,
         })
+        tax_registry = self.env['account.tax.registry'].create({
+            'name': 'Sales',
+            'layout_type': 'customer',
+            'journal_ids': [(6, 0, [self.journal.id])],
+        })
         invoice_account = self.env['account.account'].search([
             (
                 'user_type_id', '=',
@@ -56,10 +61,11 @@ class TestRegistry(AccountingTestCase):
         wizard = self.env['wizard.registro.iva'].create({
             'from_date': fields.Date.today(),
             'to_date': fields.Date.today(),
+            'tax_registry_id': tax_registry.id,
             'layout_type': 'supplier',
-            'journal_ids': [(6, 0, [self.journal.id])],
             'fiscal_page_base': 0,
         })
+        wizard.load_journal_ids()
         res = wizard.print_registro()
         html = self.env['report'].get_html(
             res['data']['ids'], 'l10n_it_vat_registries.report_registro_iva',

--- a/l10n_it_vat_registries/wizard/print_registro_iva.py
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.py
@@ -18,9 +18,8 @@ class WizardRegistroIva(models.TransientModel):
     layout_type = fields.Selection([
         ('customer', 'Customer Invoices'),
         ('supplier', 'Supplier Invoices'),
-        ('corrispettivi', 'Corrispettivi'),
-        ], 'Layout', required=True,
-        default='customer')
+        ('corrispettivi', 'Corrispettivi'), ],
+        'Layout', required=True, default='customer')
     tax_registry_id = fields.Many2one('account.tax.registry', 'VAT registry')
     journal_ids = fields.Many2many(
         'account.journal',
@@ -28,17 +27,17 @@ class WizardRegistroIva(models.TransientModel):
         'journal_id',
         'registro_id',
         string='Journals',
-        help='Select journals you want retrieve documents from',
-        required=True)
+        help='Select journals you want retrieve documents from')
     message = fields.Char(string='Message', size=64, readonly=True)
     only_totals = fields.Boolean(
         string='Prints only totals')
     fiscal_page_base = fields.Integer('Last printed page', required=True)
 
-    @api.onchange('tax_registry_id')
-    def on_change_vat_registry(self):
+    @api.multi
+    def load_journal_ids(self):
+        self.ensure_one()
         self.journal_ids = self.tax_registry_id.journal_ids
-        self.layout_type = self.tax_registry_id.layout_type
+        return {"type": "ir.actions.do_nothing"}
 
     @api.onchange('date_range_id')
     def on_change_date_range_id(self):
@@ -47,22 +46,25 @@ class WizardRegistroIva(models.TransientModel):
             self.to_date = self.date_range_id.date_end
 
     def _get_move_ids(self, wizard):
-        move_ids = self.env['account.move'].search([
+        moves = self.env['account.move'].search([
             ('date', '>=', self.from_date),
             ('date', '<=', self.to_date),
             ('journal_id', 'in', [j.id for j in self.journal_ids]),
-            ('state', '=', 'posted'),
-            ], order='date, name')
+            ('state', '=', 'posted'), ], order='date, name')
 
-        if not move_ids:
+        if not moves:
             raise UserError(_('No documents found in the current selection'))
 
-        return [move.id for move in move_ids]
+        return moves.ids
 
+    @api.multi
     def print_registro(self):
+        self.ensure_one()
         wizard = self
+        if not wizard.journal_ids:
+            raise UserError(_('No journals found in the current selection.\n'
+                              'Please load them before to retry!'))
         move_ids = self._get_move_ids(wizard)
-
         if not move_ids:
             raise UserError(_('No documents found in the current selection'))
 

--- a/l10n_it_vat_registries/wizard/print_registro_iva.xml
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.xml
@@ -17,7 +17,12 @@
                             <field name="to_date"/>
                         </group>
                         <separator string="Journals" colspan="2"/>
-                        <field name="tax_registry_id"></field>
+                        <group>
+                            <field name="tax_registry_id"></field>
+                        </group>
+                        <group>
+                            <button name="load_journal_ids" type="object" string="Load Journals" icon="fa-upload"/>
+                        </group>
                         <field name="journal_ids" colspan="2" nolabel="1" height="250" domain="[('type', 'in', ('sale','purchase'))]"/>
                         <separator string="Layout" colspan="2"/>
                         <field name="layout_type"/>


### PR DESCRIPTION
Steps to reproduce:

* select vat registry on the wizard
* journal_ids are properly filled
* click on the print_registro button
* the error 'No documents found in the current selection' is raised

This error is due to onchange on m2m field `journal_ids` whose values are not saved on the wizard when print_registro button is clicked.
Please also note I had avoid required attribute from journal_ids otherwise load_journal_ids button would have raised an error.