### PR TITLE
[UPD] l10n_it_fiscal_document_type: added group_ids to view_partner_f…

### DIFF
--- a/l10n_it_fiscal_document_type/views/res_partner_view.xml
+++ b/l10n_it_fiscal_document_type/views/res_partner_view.xml
@@ -3,6 +3,7 @@
         <record id="view_partner_fiscal_document_type" model="ir.ui.view">
             <field name="name">res.partner.fiscal.document.type.form</field>
             <field name="model">res.partner</field>
+            <field name="groups_id" eval="[(6, 0, [ref('account.group_account_invoice')])]"/>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='property_payment_term_id']" position="before">


### PR DESCRIPTION
If you create an odoo user without accounting privileges, odoo will give an error accessing contacts because xpath can't find fields property_payment_term_id that is inside the notebook visible only for users with accounting privileges.