### PR TITLE
[FIX] configuration in DDT type to restrict pickings to be in only one DDT

### DIFF
--- a/l10n_it_ddt/__openerp__.py
+++ b/l10n_it_ddt/__openerp__.py
@@ -13,7 +13,7 @@
 
 {
     'name': 'DDT',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.0.1',
     'category': 'Localization/Italy',
     'summary': 'Documento di Trasporto',
     'author': 'Davide Corio, Odoo Community Association (OCA),'

--- a/l10n_it_ddt/i18n/it.po
+++ b/l10n_it_ddt/i18n/it.po
@@ -11,17 +11,16 @@
 # Paolo Valier, 2016-2017
 msgid ""
 msgstr ""
-"Project-Id-Version: l10n-italy (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-22 11:45+0000\n"
-"PO-Revision-Date: 2018-01-30 11:08+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
-"Language-Team: Italian (http://www.transifex.com/oca/OCA-l10n-italy-8-0/language/it/)\n"
+"POT-Creation-Date: 2018-03-06 10:50+0000\n"
+"PO-Revision-Date: 2018-03-06 10:50+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Language: it\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: \n"
 
 #. module: l10n_it_ddt
 #: view:add.pickings.to.ddt:l10n_it_ddt.view_add_pickings_to_ddt
@@ -130,7 +129,8 @@ msgstr "Crea fattura"
 
 #. module: l10n_it_ddt
 #: field:add.pickings.to.ddt,create_uid:0
-#: field:ddt.create.invoice,create_uid:0 field:ddt.from.pickings,create_uid:0
+#: field:ddt.create.invoice,create_uid:0
+#: field:ddt.from.pickings,create_uid:0
 #: field:stock.ddt.type,create_uid:0
 #: field:stock.picking.carriage_condition,create_uid:0
 #: field:stock.picking.goods_description,create_uid:0
@@ -142,7 +142,8 @@ msgstr "Creato da"
 #. module: l10n_it_ddt
 #: field:add.pickings.to.ddt,create_date:0
 #: field:ddt.create.invoice,create_date:0
-#: field:ddt.from.pickings,create_date:0 field:stock.ddt.type,create_date:0
+#: field:ddt.from.pickings,create_date:0
+#: field:stock.ddt.type,create_date:0
 #: field:stock.picking.carriage_condition,create_date:0
 #: field:stock.picking.goods_description,create_date:0
 #: field:stock.picking.transportation_method,create_date:0
@@ -238,7 +239,8 @@ msgstr "Aspetto dei beni"
 #. module: l10n_it_ddt
 #: field:add.pickings.to.ddt,display_name:0
 #: field:ddt.create.invoice,display_name:0
-#: field:ddt.from.pickings,display_name:0 field:stock.ddt.type,display_name:0
+#: field:ddt.from.pickings,display_name:0
+#: field:stock.ddt.type,display_name:0
 #: field:stock.picking.carriage_condition,display_name:0
 #: field:stock.picking.goods_description,display_name:0
 #: field:stock.picking.transportation_method,display_name:0
@@ -247,7 +249,7 @@ msgid "Display Name"
 msgstr "Nome da visualizzare"
 
 #. module: l10n_it_ddt
-#: code:addons/l10n_it_ddt/models/stock_picking_package_preparation.py:225
+#: code:addons/l10n_it_ddt/models/stock_picking_package_preparation.py:242
 #, python-format
 msgid "Document {d} has invoice linked"
 msgstr "Il Documento {d} ha fattura collegata"
@@ -259,9 +261,7 @@ msgstr "Firma del Conducente"
 
 #. module: l10n_it_ddt
 #: help:stock.picking.package.preparation,weight_manual:0
-msgid ""
-"Fill this field with the value you want to be used as weight. Leave empty to"
-" let the system to compute it"
+msgid "Fill this field with the value you want to be used as weight. Leave empty to let the system to compute it"
 msgstr "Compilare questo campo con il peso che si intende impostare. Lasciare vuoto per permettere al sistema di calcolarlo automaticamente"
 
 #. module: l10n_it_ddt
@@ -297,18 +297,18 @@ msgstr "Raggruppa per"
 #. module: l10n_it_ddt
 #: field:ddt.create.invoice,group:0
 msgid "Group DDT by partner"
-msgstr ""
+msgstr "Group DDT by partner"
 
 #. module: l10n_it_ddt
 #: help:stock.ddt.type,message_summary:0
-msgid ""
-"Holds the Chatter summary (number of messages, ...). This summary is "
-"directly in html format in order to be inserted in kanban views."
+msgid "Holds the Chatter summary (number of messages, ...). This summary is directly in html format in order to be inserted in kanban views."
 msgstr "Contiene il riepilogo Chatter (numero di messaggi, ...). Questa sintesi è direttamente in formato HTML, al fine di essere inserita nelle viste kanban."
 
 #. module: l10n_it_ddt
-#: field:add.pickings.to.ddt,id:0 field:ddt.create.invoice,id:0
-#: field:ddt.from.pickings,id:0 field:stock.ddt.type,id:0
+#: field:add.pickings.to.ddt,id:0
+#: field:ddt.create.invoice,id:0
+#: field:ddt.from.pickings,id:0
+#: field:stock.ddt.type,id:0
 #: field:stock.picking.carriage_condition,id:0
 #: field:stock.picking.goods_description,id:0
 #: field:stock.picking.transportation_method,id:0
@@ -322,7 +322,7 @@ msgid "If checked new messages require your attention."
 msgstr "Se selezionato i nuovi messaggi richiedono attenzione."
 
 #. module: l10n_it_ddt
-#: code:addons/l10n_it_ddt/models/stock_picking_package_preparation.py:130
+#: code:addons/l10n_it_ddt/models/stock_picking_package_preparation.py:147
 #, python-format
 msgid "Impossible to put in pack a package without details"
 msgstr "Impossibile mettere nel pacco un pacco senza dettagli"
@@ -372,8 +372,10 @@ msgid "Last Modified on"
 msgstr "Ultima modifica il"
 
 #. module: l10n_it_ddt
-#: field:add.pickings.to.ddt,write_uid:0 field:ddt.create.invoice,write_uid:0
-#: field:ddt.from.pickings,write_uid:0 field:stock.ddt.type,write_uid:0
+#: field:add.pickings.to.ddt,write_uid:0
+#: field:ddt.create.invoice,write_uid:0
+#: field:ddt.from.pickings,write_uid:0
+#: field:stock.ddt.type,write_uid:0
 #: field:stock.picking.carriage_condition,write_uid:0
 #: field:stock.picking.goods_description,write_uid:0
 #: field:stock.picking.transportation_method,write_uid:0
@@ -383,7 +385,8 @@ msgstr "Ultima Modifica di"
 
 #. module: l10n_it_ddt
 #: field:add.pickings.to.ddt,write_date:0
-#: field:ddt.create.invoice,write_date:0 field:ddt.from.pickings,write_date:0
+#: field:ddt.create.invoice,write_date:0
+#: field:ddt.from.pickings,write_date:0
 #: field:stock.ddt.type,write_date:0
 #: field:stock.picking.carriage_condition,write_date:0
 #: field:stock.picking.goods_description,write_date:0
@@ -429,7 +432,7 @@ msgstr "Metodi di trasporto"
 #: code:addons/l10n_it_ddt/wizard/ddt_create_invoice.py:90
 #, python-format
 msgid "Move {m} is not invoiceable ({d})"
-msgstr ""
+msgstr "Move {m} is not invoiceable ({d})"
 
 #. module: l10n_it_ddt
 #: field:stock.ddt.type,name:0
@@ -447,13 +450,14 @@ msgid "None"
 msgstr "Nessuno"
 
 #. module: l10n_it_ddt
-#: code:addons/l10n_it_ddt/models/stock_picking_package_preparation.py:144
+#: code:addons/l10n_it_ddt/models/stock_picking_package_preparation.py:161
 #, python-format
 msgid "Not every picking is in done status"
 msgstr "Non tutti i picking sono completati"
 
 #. module: l10n_it_ddt
-#: field:stock.ddt.type,note:0 field:stock.picking.carriage_condition,note:0
+#: field:stock.ddt.type,note:0
+#: field:stock.picking.carriage_condition,note:0
 #: field:stock.picking.goods_description,note:0
 #: field:stock.picking.transportation_method,note:0
 #: field:stock.picking.transportation_reason,note:0
@@ -486,7 +490,8 @@ msgid "Pallet"
 msgstr "Bancale"
 
 #. module: l10n_it_ddt
-#: field:account.invoice,parcels:0 field:sale.order,parcels:0
+#: field:account.invoice,parcels:0
+#: field:sale.order,parcels:0
 #: field:stock.picking.package.preparation,parcels:0
 #: view:website:l10n_it_ddt.delivery_data
 msgid "Parcels"
@@ -535,6 +540,11 @@ msgid "Pickings"
 msgstr "Picking"
 
 #. module: l10n_it_ddt
+#: help:stock.ddt.type,restrict_pickings:0
+msgid "Pickings already in other DDTs cannot be added to DDTs having this type"
+msgstr "I trasferimenti già in altri DDT non possono essere aggiunti a DDT di questo tipo"
+
+#. module: l10n_it_ddt
 #: view:website:l10n_it_ddt.report_ddt
 msgid "Quantity"
 msgstr "Quantità"
@@ -581,6 +591,11 @@ msgstr "DDT correlati"
 #: field:sale.order,ddt_ids:0
 msgid "Related DdTs"
 msgstr "DDT correlati"
+
+#. module: l10n_it_ddt
+#: field:stock.ddt.type,restrict_pickings:0
+msgid "Restrict pickings"
+msgstr "Limita i trasferimenti"
 
 #. module: l10n_it_ddt
 #: model:stock.picking.transportation_reason,name:l10n_it_ddt.transportation_reason_RES
@@ -725,6 +740,12 @@ msgstr "Tipo Stock DDT"
 #: field:stock.ddt.type,message_summary:0
 msgid "Summary"
 msgstr "Riepilogo"
+
+#. module: l10n_it_ddt
+#: code:addons/l10n_it_ddt/models/stock_picking_package_preparation.py:137
+#, python-format
+msgid "The picking %s is already in DDT %s"
+msgstr "Il trasferimento %s è già incluso nel DDT %s"
 
 #. module: l10n_it_ddt
 #: view:stock.picking.package.preparation:l10n_it_ddt.ddt_stock_picking_package_preparation_search

--- a/l10n_it_ddt/views/stock_picking_package_preparation.xml
+++ b/l10n_it_ddt/views/stock_picking_package_preparation.xml
@@ -132,6 +132,7 @@
                     <field name="name"/>
                     <field name="sequence_id"/>
                     <field name="company_id" groups="base.group_multi_company"/>
+                    <field name="restrict_pickings"/>
                     <field name="note"/>
                 </group>
             </form>


### PR DESCRIPTION
Hi,
in DDT module, pickings can be grouped in different DDTs, this fix adds a configuration in the DDT type to enable/disable this behaviour. Please check.