### PR TITLE
[ADD] l10n_it_riba_commission module

### DIFF
--- a/l10n_it_riba_commission/README.rst
+++ b/l10n_it_riba_commission/README.rst
@@ -1,0 +1,55 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============================
+Ricevute bancarie & commissioni
+===============================
+
+This module extends the functionality of Sales commissions introducing a flag in Commission types: Only paid RiBa.
+If this flag is active and the commission type is Payment Based, sale agents having this commission type
+have their commissions generated only for paid invoices whose RiBa lines are also paid.
+
+Installation
+============
+
+This module is auto-installed by Odoo when *l10n_it_ricevute_bancarie* and
+*sale_commission* are installed.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/l10n-italy/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Simone Rubino <simone.rubino@agilebg.com> (www.agilebg.com)
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_it_riba_commission/__init__.py
+++ b/l10n_it_riba_commission/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models
+from . import wizards

--- a/l10n_it_riba_commission/__manifest__.py
+++ b/l10n_it_riba_commission/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Ricevute bancarie & commissioni",
+    "summary": "Ricevute bancarie & commissioni",
+    "version": "10.0.1.0.0",
+    "category": "Accounting & Finance",
+    "website": "https://github.com/OCA/l10n-italy/tree/10.0/"
+               "l10n_it_riba_commission",
+    "author": "Agile Business Group, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "l10n_it_ricevute_bancarie",
+        "sale_commission"
+    ],
+    "auto_install": True,
+    "data": ["views/sale_commission.xml"]
+}

--- a/l10n_it_riba_commission/i18n/it.po
+++ b/l10n_it_riba_commission/i18n/it.po
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* l10n_it_riba_commission
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-03-07 16:46+0000\n"
+"PO-Revision-Date: 2018-03-07 16:46+0000\n"
+"Last-Translator: Simone Rubino <simone.rubino@agilebg.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it_riba_commission
+#: model:ir.model,name:l10n_it_riba_commission.model_sale_commission
+msgid "Commission in sales"
+msgstr "Commissione in vendite"
+
+#. module: l10n_it_riba_commission
+#: model:ir.model.fields,help:l10n_it_riba_commission.field_sale_commission_only_paid_riba
+msgid "Include only paid RiBas"
+msgstr "Includi solo Ricevute Bancarie pagate"
+
+#. module: l10n_it_riba_commission
+#: model:ir.model.fields,field_description:l10n_it_riba_commission.field_sale_commission_only_paid_riba
+msgid "Only paid riba"
+msgstr "Solo RiBa pagate"

--- a/l10n_it_riba_commission/models/__init__.py
+++ b/l10n_it_riba_commission/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import sale_commission

--- a/l10n_it_riba_commission/models/sale_commission.py
+++ b/l10n_it_riba_commission/models/sale_commission.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields
+
+
+class SaleCommission(models.Model):
+    _inherit = 'sale.commission'
+
+    only_paid_riba = fields.Boolean(
+        help='Include only paid RiBas', default=True)

--- a/l10n_it_riba_commission/tests/__init__.py
+++ b/l10n_it_riba_commission/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_riba

--- a/l10n_it_riba_commission/tests/test_riba.py
+++ b/l10n_it_riba_commission/tests/test_riba.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import dateutil
+from odoo import fields
+from odoo.addons.l10n_it_ricevute_bancarie.tests.test_riba \
+    import TestInvoiceDueCost
+from odoo.addons.sale_commission.tests.test_sale_commission \
+    import TestSaleCommission
+
+
+class TestRiBa(TestInvoiceDueCost, TestSaleCommission):
+
+    def setUp(self, *args, **kwargs):
+        super(TestRiBa, self).setUp()
+        self.sale_order_model = self.env['sale.order']
+        self.account_model = self.env['account.account']
+        self.advance_inv_model = self.env['sale.advance.payment.inv']
+        self.commission_model = self.env['sale.commission']
+
+        self.product = self.env['product.product'].search([], limit=1)
+        self.riba_payment_term = self.env['account.payment.term'].create({
+            'name': 'Ri.Ba. Immediate',
+            'riba': True,
+            'riba_payment_cost': 5.00,
+            'line_ids': [
+                (0, 0,
+                 {'value': 'balance', 'option': 'day_after_invoice_date'})]
+        })
+
+        partners = self.env['res.partner'].search([], limit=3)
+        self.partner = partners[0]
+
+        paid_riba_commission = self.commission_model.create({
+            'name': 'Only paid RiBa commission',
+            'fix_qty': 20,
+            'invoice_state': 'paid',
+            'only_paid_riba': True
+        })
+
+        partners[1].write({
+            'agent': True,
+            'commission': paid_riba_commission.id
+        })
+        self.paid_riba_agent = partners[1]
+
+        all_riba_commission = self.commission_model.create({
+            'name': 'All RiBa commission',
+            'fix_qty': 20,
+            'invoice_state': 'paid',
+            'only_paid_riba': False
+        })
+        partners[2].write({
+            'agent': True,
+            'commission': all_riba_commission.id
+        })
+        self.all_riba_agent = partners[2]
+        self.account_user_type = self.env.ref(
+            'account.data_account_type_receivable')
+
+    def test_only_paid_riba(self):
+        # Create and confirm sale order
+        sale_order = self.sale_order_model.create({
+            'partner_id': self.partner.id,
+            'payment_term_id': self.riba_payment_term.id,
+            'order_line': [(0, 0, {
+                'name': self.product.name,
+                'product_id': self.product.id,
+                'product_uom_qty': 8.0,
+                'qty_delivered': 1.0,
+                'product_uom': self.product.uom_id.id,
+                'price_unit': 100.0,
+                'agents': [(0, 0, {
+                    'agent': self.paid_riba_agent.id,
+                    'commission': self.paid_riba_agent.commission.id
+                })]
+            })]
+        })
+        sale_order.action_confirm()
+
+        # Generate the invoices
+        payment = self.advance_inv_model.create({
+            'advance_payment_method': 'all',
+        })
+        context = {"active_model": 'sale.order',
+                   "active_ids": [sale_order.id],
+                   "active_id": sale_order.id}
+        payment.with_context(context).create_invoices()
+
+        # Validate generated invoices
+        for invoice in sale_order.invoice_ids:
+            invoice.company_id.due_cost_service_id = self.service_due_cost.id
+            invoice.action_invoice_open()
+
+            # Issue the RiBa and confirm it, it will mark the invoice as paid
+            riba_move_line_id = False
+            for move_line in invoice.move_id.line_ids:
+                if move_line.account_id.id == \
+                        self.env.ref('l10n_generic_coa.1_conf_a_recv').id:
+                    riba_move_line_id = move_line.id
+                    self.move_line_model.search([
+                        '&',
+                        '|',
+                        ('riba', '=', 'True'),
+                        ('unsolved_invoice_ids', '!=', False),
+                        ('account_id.internal_type', '=', 'receivable'),
+                        ('reconciled', '=', False),
+                        ('distinta_line_ids', '=', False)
+                    ])
+
+            wizard_riba_issue = self.env['riba.issue'].create({
+                'configuration_id': self.riba_config.id
+            })
+            action = wizard_riba_issue.with_context(
+                {'active_ids': [riba_move_line_id]}
+            ).create_list()
+            riba_list_id = action and action['res_id'] or False
+            riba_list = self.distinta_model.browse(riba_list_id)
+            riba_list.confirm()
+            self.assertEqual(riba_list.state, 'accepted')
+            self.assertEqual(invoice.state, 'paid')
+
+            # Generate settlements for agent, the settlement is not created
+            wizard = self.make_settle_model.create(
+                {'date_to':
+                 (fields.Datetime.from_string(fields.Datetime.now()) +
+                  dateutil.relativedelta.relativedelta(months=1))})
+            wizard.action_settle()
+            settlements = self.settle_model.search([('state', '=', 'settled')])
+            self.assertEquals(len(settlements), 0)
+
+            # Validate the RiBa
+            amount = sum(line.amount for line in riba_list.line_ids)
+            wiz_accreditation = self.env['riba.accreditation'].with_context({
+                "active_model": "riba.distinta",
+                "active_ids": [riba_list_id],
+                "active_id": riba_list_id,
+            }).create({
+                'bank_amount': amount,
+            })
+            wiz_accreditation.create_move()
+            self.assertEqual(riba_list.state, 'accredited')
+            # bank notifies cash in
+            bank_move = self.move_model.create({
+                'journal_id': self.bank_journal.id,
+                'line_ids': [
+                    (0, 0, {
+                        'partner_id': self.partner.id,
+                        'account_id': self.sbf_effects.id,
+                        'credit': amount,
+                        'debit': 0,
+                        'name': 'sbf effects',
+                    }),
+                    (0, 0, {
+                        'partner_id': self.partner.id,
+                        'account_id': self.riba_account.id,
+                        'credit': 0,
+                        'debit': amount,
+                        'name': 'Banca conto ricevute bancarie',
+                    }),
+                ]
+            })
+            to_reconcile = self.env['account.move.line']
+            line_set = (bank_move.line_ids | riba_list.acceptance_move_ids[
+                0].line_ids)
+            for line in line_set:
+                if line.account_id.id == self.sbf_effects.id:
+                    to_reconcile |= line
+            self.assertEqual(len(to_reconcile), 2)
+            to_reconcile.reconcile()
+            # refresh otherwise riba_list.payment_ids is not recomputed
+            riba_list.refresh()
+            self.assertEqual(riba_list.state, 'paid')
+
+            # Generate settlements for agent, the settlement is created
+            wizard = self.make_settle_model.create(
+                {'date_to': (
+                    fields.Datetime.from_string(fields.Datetime.now()) +
+                    dateutil.relativedelta.relativedelta(months=1))})
+            wizard.action_settle()
+            settlements = self.settle_model.search([('state', '=', 'settled')])
+            self.assertEquals(len(settlements), 1)

--- a/l10n_it_riba_commission/views/sale_commission.xml
+++ b/l10n_it_riba_commission/views/sale_commission.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 Simone Rubino - Agile Business Group
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="sale_commission_riba_form" model="ir.ui.view">
+        <field name="name">Include Only paid RiBas flag</field>
+        <field name="model">sale.commission</field>
+        <field name="inherit_id" ref="sale_commission.sale_commission_form"/>
+        <field name="arch" type="xml">
+            <field name="invoice_state" position="after">
+                <field name="only_paid_riba" attrs="{'invisible':[('invoice_state','!=','paid')]}"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/l10n_it_riba_commission/wizards/__init__.py
+++ b/l10n_it_riba_commission/wizards/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import make_settle

--- a/l10n_it_riba_commission/wizards/make_settle.py
+++ b/l10n_it_riba_commission/wizards/make_settle.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, api
+
+
+class MakeSettle(models.TransientModel):
+    _inherit = 'sale.commission.make.settle'
+
+    @api.multi
+    def action_settle(self):
+        self.ensure_one()
+        res = super(MakeSettle, self).action_settle()
+        settlement_obj = self.env['sale.commission.settlement']
+        riba_line_model = self.env['riba.distinta.line']
+        if 'type' in res and res['type'] != 'ir.actions.act_window_close':
+            settlements = settlement_obj.browse(res['domain'][0][2])
+            for settlement in settlements:
+                # Check the configuration of the commission type and all
+                # settlement lines of this settlement
+                commission = settlement.agent.commission
+                self.unlink_settlement_lines_by_commission(
+                    commission, riba_line_model, settlement)
+                if not settlement.lines:
+                    settlement.unlink()
+            # Refresh settlements list to be shown,
+            # just close if there isn't any left
+            settlements = settlements.exists()
+            if settlements:
+                res['domain'][0][2] = settlements.ids
+            else:
+                res = {'type': 'ir.actions.act_window_close'}
+        return res
+
+    @staticmethod
+    def unlink_settlement_lines_by_commission(
+            commission, riba_line_model, settlement):
+        for settlement_line in settlement.lines:
+            if commission.invoice_state == 'paid' \
+                    and commission.only_paid_riba:
+                # Check if invoice has RiBa payment method
+                invoice = settlement_line.invoice
+                if invoice.payment_term_id and invoice.payment_term_id.riba:
+                    # Get Account moves of the payment for this invoice
+                    payments = invoice.payment_move_line_ids
+                    for payment in payments.mapped('move_id'):
+                        # Check if linked RiBa line has been paid
+                        riba_line = riba_line_model.search([
+                            ('acceptance_move_id', '=', payment.id)])
+                        if riba_line.state != 'paid':
+                            # If RiBa hasn't been paid, delete current
+                            # settlement line from settlement
+                            settlement_line.unlink()

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -3,3 +3,4 @@ stock-logistics-workflow
 account-payment
 account-financial-reporting
 server-tools
+commission


### PR DESCRIPTION
Configuration:
* Agent's commission type is payment_based
* Invoice's payment_term is RiBa

The commission for the agent is computed even if the RiBa linked to the payment is not paid yet.
This module adds a configuration in comiission type to exclude such payments.

Please check, thanks