### PR TITLE
[FIX] l10n_it_fiscalcode: add sync of fiscalcode field to descendants

### DIFF
--- a/l10n_it_fiscalcode/README.rst
+++ b/l10n_it_fiscalcode/README.rst
@@ -54,7 +54,7 @@ Contributors
 * Franco Tampieri <franco@tampieri.info>
 * Andrea Cometa <info@andreacometa.it>
 * Andrea Gallina <a.gallina@apuliasoftware.it>
-
+* Alex Comba <alex.comba@agilebg.com>
 
 Maintainer
 ----------

--- a/l10n_it_fiscalcode/__manifest__.py
+++ b/l10n_it_fiscalcode/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Italian Localisation - Fiscal Code',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Localisation/Italy',
     'author': "Odoo Italia Network, Odoo Community Association (OCA)",
     'website': 'https://odoo-community.org/',
@@ -19,6 +19,6 @@
         'wizard/compute_fc_view.xml',
         'data/res.city.it.code.csv',
         "security/ir.model.access.csv"
-        ],
+    ],
     'installable': True
 }

--- a/l10n_it_fiscalcode/migrations/10.0.1.0.1/post-migrate.py
+++ b/l10n_it_fiscalcode/migrations/10.0.1.0.1/post-migrate.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Alex Comba - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from openerp import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """ Sync of fiscalcode field to descendants """
+    if not version:
+        return
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        partners = env['res.partner'].search(
+            [('is_company', '=', True)])
+        for partner in partners:
+            partner._commercial_sync_to_children()

--- a/l10n_it_fiscalcode/model/res_partner.py
+++ b/l10n_it_fiscalcode/model/res_partner.py
@@ -9,6 +9,12 @@ from odoo import models, fields, api
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
+    @api.model
+    def _commercial_fields(self):
+        res = super(ResPartner, self)._commercial_fields()
+        res += ['fiscalcode']
+        return res
+
     @api.multi
     def check_fiscalcode(self):
         for partner in self:

--- a/l10n_it_fiscalcode/tests/test_fiscalcode.py
+++ b/l10n_it_fiscalcode/tests/test_fiscalcode.py
@@ -11,6 +11,7 @@ class TestFiscalCode(TransactionCase):
     def setUp(self):
         super(TestFiscalCode, self).setUp()
         self.partner = self.env.ref('base.res_partner_2')
+        self.partner_address = self.env.ref('base.res_partner_address_31')
 
     def test_fiscalcode_compute(self):
         wizard = self.env['wizard.compute.fc'].with_context(
@@ -25,3 +26,4 @@ class TestFiscalCode(TransactionCase):
         # ---- Compute FiscalCode
         wizard.compute_fc()
         self.assertEqual(self.partner.fiscalcode, 'RSSMRA84H04H501X')
+        self.assertEqual(self.partner_address.fiscalcode, 'RSSMRA84H04H501X')


### PR DESCRIPTION
Serve per quando si vuole aggiungere il `fiscalcode` sulla stampa della fattura.