### PR TITLE
[8.9]  l10n_it_fiscal_document_type error on user without account permission

### DIFF
--- a/l10n_it_fiscal_document_type/view/res_partner_view.xml
+++ b/l10n_it_fiscal_document_type/view/res_partner_view.xml
@@ -5,6 +5,7 @@
             <field name="name">res.partner.fiscal.document.type.form</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='property_payment_term']" position="before">
                         <field name="out_fiscal_document_type" class="oe_inline" />


### PR DESCRIPTION
propongo questa modifica al fine di evitare errore di visualizzazione, con utente che non ha permessi di contabilità