### PR TITLE
[10.0] l10n_it_withholding_tax: set debit/credit_move_id according to account type

### DIFF
--- a/l10n_it_withholding_tax/models/withholding_tax.py
+++ b/l10n_it_withholding_tax/models/withholding_tax.py
@@ -320,10 +320,12 @@ class WithholdingTaxMove(models.Model):
                 line_to_reconcile = line
                 break
         if line_to_reconcile:
+            credit_debit_moves = line_to_reconcile.account_id.user_type_id.type == "payable" and \
+                                 ("debit_move_id", "credit_move_id") or ("credit_move_id", "debit_move_id")
             self.env['account.partial.reconcile'].\
                 with_context(no_generate_wt_move=True).create({
-                    'debit_move_id': line_to_reconcile.id,
-                    'credit_move_id': self.credit_debit_line_id.id,
+                    credit_debit_moves[0]: line_to_reconcile.id,
+                    credit_debit_moves[1]: self.credit_debit_line_id.id,
                     'amount': self.amount,
                 })
 

--- a/l10n_it_withholding_tax/models/withholding_tax.py
+++ b/l10n_it_withholding_tax/models/withholding_tax.py
@@ -320,8 +320,10 @@ class WithholdingTaxMove(models.Model):
                 line_to_reconcile = line
                 break
         if line_to_reconcile:
-            credit_debit_moves = line_to_reconcile.account_id.user_type_id.type == "payable" and \
-                                 ("debit_move_id", "credit_move_id") or ("credit_move_id", "debit_move_id")
+            if line_to_reconcile.account_id.user_type_id.type == "payable":
+                credit_debit_moves = ("debit_move_id", "credit_move_id")
+            else:
+                credit_debit_moves = ("credit_move_id", "debit_move_id")
             self.env['account.partial.reconcile'].\
                 with_context(no_generate_wt_move=True).create({
                     credit_debit_moves[0]: line_to_reconcile.id,


### PR DESCRIPTION
Ciao,
dopo aver creato una **fattura cliente** con ritenuta, quando registro il pagamento, non riporta correttamente l'ammontare della ritenuta, ma il doppio, invece nelle **fatture fornitore** tutto bene. 
Mi pare che il problema sia nel "verso" della riconciliazione ...