### PR TITLE
IMP l10n_it_ricevute_bancarie

### DIFF
--- a/l10n_it_ricevute_bancarie/README.rst
+++ b/l10n_it_ricevute_bancarie/README.rst
@@ -25,7 +25,7 @@ eventualmente da creare).
 La configurazione relativa alla fase di accredito, verrà usata nel momento in
 cui la banca accredita l'importo della distinta.
 E' possibile utilizzare un sezionale creato appositamente, ad esempio "accredito RiBa",
-ed un conto chiamato ad esempio "banche c/RIBA all'incasso".
+ed un conto chiamato ad esempio "banche c/RIBA all'incasso", che non deve essere di tipo 'banca'.
 
 La configurazione relativa all'insoluto verrà utilizzata in caso di mancato pagamento da parte del cliente.
 Il conto può chiamarsi ad esempio "crediti insoluti".

--- a/l10n_it_ricevute_bancarie/__manifest__.py
+++ b/l10n_it_ricevute_bancarie/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': "Ricevute Bancarie",
-    'version': "10.0.1.0.3",
+    'version': "10.0.1.1.0",
     'author': "Odoo Community Association (OCA)",
     'category': "Accounting & Finance",
     'website': "https://odoo-community.org/",

--- a/l10n_it_ricevute_bancarie/models/riba_config.py
+++ b/l10n_it_ricevute_bancarie/models/riba_config.py
@@ -40,7 +40,8 @@ class RibaConfiguration(models.Model):
         help="Journal used when Ri.Ba. amount is accredited by the bank")
     accreditation_account_id = fields.Many2one(
         'account.account', "Ri.Ba. bank account",
-        help='Account used when Ri.Ba. is accepted by the bank')
+        help='Account used when Ri.Ba. is accepted by the bank',
+        domain=[('internal_type', '!=', 'liquidity')])
     bank_account_id = fields.Many2one(
         'account.account', "Bank account",
         domain=[('internal_type', '=', 'liquidity')])


### PR DESCRIPTION
prevent to use a bank accoun tfor "Ri.Ba. bank account", otherwise, if a bank account is used, its move lines will appear as blu lines in bank statement reconciliation