### PR TITLE
[8.0] fix negative riba grouped

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account/account.py
+++ b/l10n_it_ricevute_bancarie/models/account/account.py
@@ -64,6 +64,15 @@ class ResPartnerBankAdd(orm.Model):
 class AccountMoveLine(orm.Model):
     _inherit = "account.move.line"
 
+    def _get_amount_residual_signed(
+            self, cr, uid, ids, name, args, context=None):
+        res = {}
+        for move in self.browse(cr, uid, ids, context=context):
+            res[move.id] = (
+                move.amount_residual if move.debit != 0.0
+                else move.amount_residual * -1)
+        return res
+
     _columns = {
         'distinta_line_ids': fields.one2many(
             'riba.distinta.move.line', 'move_line_id', "Dettaglio riba"),
@@ -76,6 +85,10 @@ class AccountMoveLine(orm.Model):
         'iban': fields.related(
             'partner_id', 'bank_ids', 'iban', type='char', string='IBAN',
             store=False),
+        'amount_residual_signed': fields.function(
+            _get_amount_residual_signed,
+            type='float',
+            string='Amount Residual Signed'),
     }
     _defaults = {
         'distinta_line_ids': None,

--- a/l10n_it_ricevute_bancarie/models/riba.py
+++ b/l10n_it_ricevute_bancarie/models/riba.py
@@ -353,8 +353,10 @@ class RibaListLine(models.Model):
                         'partner_id': line.partner_id.id,
                         'account_id': (
                             riba_move_line.move_line_id.account_id.id),
-                        'credit': riba_move_line.amount,
-                        'debit': 0.0,
+                        'credit': riba_move_line.amount if
+                        riba_move_line.amount > 0 else 0.0,
+                        'debit': 0.0 if riba_move_line.amount > 0 else
+                        riba_move_line.amount * -1,
                         'move_id': move_id,
                     }, self._context)
                 to_be_reconciled.append([move_line_id,

--- a/l10n_it_ricevute_bancarie/views/account_view.xml
+++ b/l10n_it_ricevute_bancarie/views/account_view.xml
@@ -54,7 +54,8 @@
                 <field name="payment_term_id" readonly="1"/>
                 <field name="account_id" readonly="1"/>
                 <field name="debit" readonly="1" sum="Total Debit"/>
-                <field name="amount_residual" readonly="1" sum="Total Amount" />
+                <field name="credit" readonly="1" sum="Total Credit"/>
+                <field name="amount_residual_signed" readonly="1" sum="Total Amount" />
                 <field name="date_maturity"/>
                 <field name="riba" />
                 <field name="distinta_line_ids" invisible="1" />

--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_issue.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_issue.py
@@ -103,22 +103,35 @@ class RibaIssue(models.TransientModel):
                             self.configuration_id.acceptance_account_id.id).id
                         # total = 0.0
                         # invoice_date_group = ''
+                        if sum(x.amount_residual_signed for x in
+                               grouped_lines[key]) < 0.0:
+                            raise exceptions.Warning(
+                                _('Attention!'),
+                                _('Ri.ba. cannot be negative! Group with other'
+                                  ' positive one(s)')
+                            )
                         for grouped_line in grouped_lines[key]:
                             riba_list_move_line.create({
                                 'riba_line_id': rdl_id,
-                                'amount': grouped_line.amount_residual,
+                                'amount': grouped_line.amount_residual_signed,
                                 'move_line_id': grouped_line.id,
                             })
                         del grouped_lines[key]
                         break
             else:
+                if move_line.amount_residual_signed < 0.0:
+                    raise exceptions.Warning(
+                        _('Attention!'),
+                        _('Ri.ba. cannot be negative! Group with other '
+                          'positive one(s).')
+                    )
                 rdl_id = create_rdl(
                     countme, bank_id.id, rd_id, move_line.date_maturity,
                     move_line.partner_id.id,
                     self.configuration_id.acceptance_account_id.id).id
                 riba_list_move_line.create({
                     'riba_line_id': rdl_id,
-                    'amount': move_line.amount_residual,
+                    'amount': move_line.amount_residual_signed,
                     'move_line_id': move_line.id,
                 })
 


### PR DESCRIPTION
Until now refund invoice with ri.ba. type of payment are not managed. With this MP it is possible to group negative amounts with other ri.ba.
Anyway, it is forbidden to create negative ri.ba.