### PR TITLE
[IMP] Improve fiscal position management for corrispettivi

### DIFF
--- a/l10n_it_corrispettivi/README.rst
+++ b/l10n_it_corrispettivi/README.rst
@@ -18,9 +18,13 @@ Configuration
 Creare almeno un sezionale di tipo vendita su cui saranno registrati i corrispettivi,
 deve avere il flag corrispettivi abilitato.
 
+Se necessario, creare una posizione fiscale per i corrispettivi, deve avere il flag corrispettivi abilitato.
+Questa posizione fiscale verrà assegnata a tutti i nuovi partner aventi il flag *Usa corrispettivi* abilitato.
+
 Utilizzando un utente del gruppo Contabilità & Finanza > Contabilità, sul partner associato al public user:
 
 * Modificare, se necessario, i conti di debito e di credito da utilizzare per i corrispettivi;
+* Abilitare il flag *Usa corrispettivi*
 
 Nota: di default, il public user è disabilitato (flag active disabilitato).
 

--- a/l10n_it_corrispettivi/__manifest__.py
+++ b/l10n_it_corrispettivi/__manifest__.py
@@ -4,7 +4,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     'name': 'Italian Localization - Corrispettivi',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'Accounting & Finance',
     'author': 'Odoo Italian Community, Agile Business Group, '
               'Odoo Community Association (OCA)',

--- a/l10n_it_corrispettivi/models/account.py
+++ b/l10n_it_corrispettivi/models/account.py
@@ -75,6 +75,37 @@ class AccountJournal(models.Model):
         return corr_journal_id
 
 
+class AccountFiscalPosition(models.Model):
+    _inherit = 'account.fiscal.position'
+
+    corrispettivi = fields.Boolean(string='Corrispettivi')
+
+    @api.model
+    def get_corr_fiscal_pos(self, company_id):
+        corr_fiscal_pos = self.search([
+            ('corrispettivi', '=', True),
+            ('company_id', '=', company_id.id)], limit=1)
+
+        return corr_fiscal_pos
+
+
 class ResPartner(models.Model):
     _inherit = 'res.partner'
+
     use_corrispettivi = fields.Boolean(string='Use Corrispettivi')
+
+    @api.onchange('use_corrispettivi')
+    def onchange_use_corrispettivi(self):
+        if self.use_corrispettivi:
+            # Partner is corrispettivi, assign a corrispettivi fiscal position
+            # only if there is none
+            if not self.property_account_position_id:
+                company = self.company_id or \
+                    self.default_get(['company_id'])['company_id']
+                self.property_account_position_id = \
+                    self.env['account.fiscal.position'] \
+                        .get_corr_fiscal_pos(company)
+        else:
+            # Unset the fiscal position only if it was corrispettivi
+            if self.property_account_position_id.corrispettivi:
+                self.property_account_position_id = False

--- a/l10n_it_corrispettivi/views/account_view.xml
+++ b/l10n_it_corrispettivi/views/account_view.xml
@@ -78,4 +78,18 @@
             </xpath>
         </field>
     </record>
+
+    <!-- Fiscal position -->
+
+    <record id="view_account_position_form" model="ir.ui.view">
+        <field name="name">account.fiscal.position.form</field>
+        <field name="model">account.fiscal.position</field>
+        <field name="type">form</field>
+        <field name="inherit_id" ref="account.view_account_position_form"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="corrispettivi"/>
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/l10n_it_website_sale_corrispettivi/__manifest__.py
+++ b/l10n_it_website_sale_corrispettivi/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'e-commerce',
     'author': 'Agile Business Group,'
               'Odoo Community Association (OCA)',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
     'website': 'https://github.com/OCA/l10n-italy/tree/10.0/'
                'l10n_it_website_sale_corrispettivi',

--- a/l10n_it_website_sale_corrispettivi/controllers/main.py
+++ b/l10n_it_website_sale_corrispettivi/controllers/main.py
@@ -11,6 +11,55 @@ class WebsiteSaleCorrispettivi(WebsiteSale):
         res = super(WebsiteSaleCorrispettivi, self) \
             ._checkout_form_save(mode, checkout, all_values)
         use_invoice = all_values.get('use_invoice')
+        # Update order
         order = request.website.sale_get_order()
-        order.write({'corrispettivi': not use_invoice})
+        order_values = \
+            self._prepare_corrispettivi_order_values(order, use_invoice)
+        order.write(order_values)
+
+        # Update partner
+        partner = request.env['res.partner'].browse(res)
+        partner_values = \
+            self._prepare_corrispettivi_partner_values(partner, use_invoice)
+        partner.sudo().write(partner_values)
         return res
+
+    def _prepare_corrispettivi_partner_values(self, partner, use_invoice):
+        partner_values = {'use_corrispettivi': not use_invoice}
+        if not partner.property_account_position_id:
+            # No fiscal position: assign a corrispettivi fiscal position
+            # if requested
+            if not use_invoice:
+                company = partner.company_id or \
+                    partner.default_get(['company_id'])['company_id']
+                partner_values['property_account_position_id'] = \
+                    request.env['account.fiscal.position'] \
+                    .get_corr_fiscal_pos(company).id
+        else:
+            # There is a fiscal position:
+            # remove it only if it is a corrispettivi one
+            # and user doesn't want to use corrispettivi
+            if use_invoice:
+                if partner.property_account_position_id.corrispettivi:
+                    partner_values['property_account_position_id'] = False
+        return partner_values
+
+    def _prepare_corrispettivi_order_values(self, order, use_invoice):
+        order_values = {'corrispettivi': not use_invoice}
+        if not order.fiscal_position_id:
+            # No fiscal position: assign a corrispettivi fiscal position
+            # if requested
+            if not use_invoice:
+                company = order.company_id or \
+                    order.default_get(['company_id'])['company_id']
+                order_values['fiscal_position_id'] = \
+                    request.env['account.fiscal.position'] \
+                    .get_corr_fiscal_pos(company).id
+        else:
+            # There is a fiscal position:
+            # remove it only if it is a corrispettivi one
+            # and user doesn't want to use corrispettivi
+            if use_invoice:
+                if order.fiscal_position_id.corrispettivi:
+                    order_values['fiscal_position_id'] = False
+        return order_values


### PR DESCRIPTION
When creating a sale order for a partner having *Use corrispettivi*, it might be useful to register the transaction in particular accounts specifically dedicated to corrispettivi.

With this PR, this can be done by creating a fiscal position having the flag *Corrispettivi* enabled: this fiscal position is automatically assigned to an user having the flag *Use corrispettivi* enabled.