### PR TITLE
[7.0] FIX account_central_journal

### DIFF
--- a/account_central_journal/report/central_journal_report.mako
+++ b/account_central_journal/report/central_journal_report.mako
@@ -14,7 +14,7 @@
     .p_row {
         page-break-inside: avoid; 
         vertical-align:text-top;
-        height: 21px;
+        height: 28px;
         }
     .p_cell {
         overflow: hidden;
@@ -91,7 +91,7 @@
         result_rows = get_movements()
     %>
     <%
-        page_rows = 25
+        page_rows = 18
         
         num_rows = len(result_rows)
         num_row = 0


### PR DESCRIPTION
Quando descrizioni lunghe delle registrazioni vanno su più righe, la pagina del libro giornale va su 2 pagine del PDF, rendendo incoerente la numerazione