### PR TITLE
[10.0] FIX l10n_it_vat_registries: in presenza di  note di credito

### DIFF
--- a/l10n_it_vat_registries/static/src/css/l10n_it_vat_registries.css
+++ b/l10n_it_vat_registries/static/src/css/l10n_it_vat_registries.css
@@ -24,7 +24,7 @@ thead {background: #F5F5F5;}
     text-align:left; vertical-align:text-top; padding:5px; font-weight: bold;
 }
 .right_without_line_bold {
-    text-align:right; vertical-align:text-top; padding:5px; font-weight: bold;
+    text-align:right; vertical-align:text-top; padding:5px; font-weight: bold; white-space: nowrap;
 }
 
 .first_th_row {


### PR DESCRIPTION
il (meno) - e l'importo rimangono stampati sulla stessa riga e non vanno a capo