### PR TITLE
[10.0 ]removed lint=check and pep8: changed digits_compute > digits and set …

### DIFF
--- a/account_central_journal/account.py
+++ b/account_central_journal/account.py
@@ -30,8 +30,8 @@ class account_fiscalyear(orm.Model):
         'date_last_print': fields.date('Last printed date', readonly=True),
         'progressive_page_number': fields.integer('Progressive of the page', required=True, readonly=True),
         'progressive_line_number': fields.integer('Progressive line', required=True, readonly=True),
-        'progressive_credit': fields.float('Progressive Credit', digits_compute=dp.get_precision('Account'), required=True, readonly=True),
-        'progressive_debit': fields.float('Progressive Debit', digits_compute=dp.get_precision('Account'), required=True, readonly=True),
+        'progressive_credit': fields.float('Progressive Credit', digits=dp.get_precision('Account'), required=True, readonly=True),
+        'progressive_debit': fields.float('Progressive Debit', digits=dp.get_precision('Account'), required=True, readonly=True),
     }
     
     _defaults = {

--- a/l10n_it_account_tax_kind/model/account_tax_kind.py
+++ b/l10n_it_account_tax_kind/model/account_tax_kind.py
@@ -7,17 +7,17 @@ from odoo import api, models, fields
 class AccountTaxKind(models.Model):
 
     _name = 'account.tax.kind'
-    _rec_name = 'display_name'
 
     code = fields.Char(string='Code', size=3, required=True)
     name = fields.Char(string='Name', required=True)
-    display_name = fields.Char(string='Name', compute='_compute_display_name')
 
-    @api.depends('code', 'name')
     @api.multi
-    def _compute_display_name(self):
-        for record in self:
-            record.display_name = u'[%s] %s' % (record.code, record.name)
+    def name_get(self):
+        res = []
+        for item in self:
+            name = "[{}] {}".format(item.code, item.name)
+            res.append((item.id, name))
+        return res
 
     @api.model
     def name_search(self, name, args=None, operator='ilike', limit=100):

--- a/l10n_it_account_tax_kind/tests/test_account_tax_kind.py
+++ b/l10n_it_account_tax_kind/tests/test_account_tax_kind.py
@@ -11,12 +11,6 @@ class TestAccountTaxKind(TransactionCase):
         super(TestAccountTaxKind, self).setUp()
         self.tax_kind_n1 = self.env.ref('l10n_it_account_tax_kind.n1')
 
-    def test_compute_display_name(self):
-        self.tax_kind_n1._compute_display_name()
-        self.assertEqual(
-            self.tax_kind_n1.display_name,
-            u'[%s] %s' % (self.tax_kind_n1.code, self.tax_kind_n1.name))
-
     def test_name_search(self):
         result = self.env['account.tax.kind'].name_search('Escluse ex art. 15')
         self.assertEqual(result and result[0][0], self.tax_kind_n1.id)

--- a/l10n_it_central_journal/models/account.py
+++ b/l10n_it_central_journal/models/account.py
@@ -24,9 +24,9 @@ class DateRangeInherit(models.Model):
     progressive_line_number = fields.Integer('Progressive line', default=0)
     progressive_credit = fields.Float(
         'Progressive Credit',
-        digits_compute=dp.get_precision('Account'),
+        digits=dp.get_precision('Account'),
         default=lambda *a: float())
     progressive_debit = fields.Float(
         'Progressive Debit',
-        digits_compute=dp.get_precision('Account'),
+        digits=dp.get_precision('Account'),
         default=lambda *a: float())

--- a/l10n_it_fatturapa/bindings/fatturapa_v_1_2.py
+++ b/l10n_it_fatturapa/bindings/fatturapa_v_1_2.py
@@ -4846,7 +4846,7 @@ Namespace.addCategoryObject(
 # with content type ELEMENT_ONLY
 class AnagraficaType (pyxb.binding.basis.complexTypeDefinition):
     """
-        Il campo Denominazione è in alternativa ai campi Nome e Cognome
+        Il campo Denominazione e' in alternativa ai campi Nome e Cognome
                         """
     _TypeDefinition = None
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY

--- a/l10n_it_fatturapa/data/fatturapa_data.xml
+++ b/l10n_it_fatturapa/data/fatturapa_data.xml
@@ -43,7 +43,7 @@
         </record>
         <record id="fatturapa_RF04" model="fatturapa.fiscal_position">
             <field name="code">RF04</field>
-            <field name="name">Agricoltura e attività connesse e pesca (artt. 34 e 34-bis, D.P.R. 633/1972)</field>
+            <field name="name">Agricoltura e attivita' connesse e pesca (artt. 34 e 34-bis, D.P.R. 633/1972)</field>
         </record>
         <record id="fatturapa_RF05" model="fatturapa.fiscal_position">
             <field name="code">RF05</field>
@@ -67,7 +67,7 @@
         </record>
         <record id="fatturapa_RF10" model="fatturapa.fiscal_position">
             <field name="code">RF10</field>
-            <field name="name">Intrattenimenti, giochi e altre attività di cui alla tariffa allegata al D.P.R. 640/72 (art. 74, c.6, D.P.R. 633/1972)</field>
+            <field name="name">Intrattenimenti, giochi e altre attivita' di cui alla tariffa allegata al D.P.R. 640/72 (art. 74, c.6, D.P.R. 633/1972)</field>
         </record>
         <record id="fatturapa_RF11" model="fatturapa.fiscal_position">
             <field name="code">RF11</field>
@@ -186,7 +186,7 @@
         </record>
         <record id="fatturapa_mp15" model="fatturapa.payment_method">
             <field name="code">MP15</field>
-            <field name="name">giroconto su conti di contabilità speciale</field>
+            <field name="name">giroconto su conti di contabilita' speciale</field>
         </record>
         <record id="fatturapa_mp16" model="fatturapa.payment_method">
             <field name="code">MP16</field>
@@ -214,7 +214,7 @@
         </record>
         <record id="fatturapa_mp22" model="fatturapa.payment_method">
             <field name="code">MP22</field>
-            <field name="name">Trattenuta su somme già riscosse</field>
+            <field name="name">Trattenuta su somme gia' riscosse</field>
         </record>
     </data>
 </openerp>

--- a/l10n_it_fatturapa/i18n/am.po
+++ b/l10n_it_fatturapa/i18n/am.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/ar.po
+++ b/l10n_it_fatturapa/i18n/ar.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/bg.po
+++ b/l10n_it_fatturapa/i18n/bg.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/bs.po
+++ b/l10n_it_fatturapa/i18n/bs.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/ca.po
+++ b/l10n_it_fatturapa/i18n/ca.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/cs.po
+++ b/l10n_it_fatturapa/i18n/cs.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/da.po
+++ b/l10n_it_fatturapa/i18n/da.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/de.po
+++ b/l10n_it_fatturapa/i18n/de.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/el_GR.po
+++ b/l10n_it_fatturapa/i18n/el_GR.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/en_GB.po
+++ b/l10n_it_fatturapa/i18n/en_GB.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es.po
+++ b/l10n_it_fatturapa/i18n/es.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_AR.po
+++ b/l10n_it_fatturapa/i18n/es_AR.po
@@ -1124,9 +1124,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_CL.po
+++ b/l10n_it_fatturapa/i18n/es_CL.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_CO.po
+++ b/l10n_it_fatturapa/i18n/es_CO.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_CR.po
+++ b/l10n_it_fatturapa/i18n/es_CR.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_DO.po
+++ b/l10n_it_fatturapa/i18n/es_DO.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_EC.po
+++ b/l10n_it_fatturapa/i18n/es_EC.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_ES.po
+++ b/l10n_it_fatturapa/i18n/es_ES.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_MX.po
+++ b/l10n_it_fatturapa/i18n/es_MX.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_PE.po
+++ b/l10n_it_fatturapa/i18n/es_PE.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_PY.po
+++ b/l10n_it_fatturapa/i18n/es_PY.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/es_VE.po
+++ b/l10n_it_fatturapa/i18n/es_VE.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/et.po
+++ b/l10n_it_fatturapa/i18n/et.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/eu.po
+++ b/l10n_it_fatturapa/i18n/eu.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/fa.po
+++ b/l10n_it_fatturapa/i18n/fa.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/fi.po
+++ b/l10n_it_fatturapa/i18n/fi.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/fr.po
+++ b/l10n_it_fatturapa/i18n/fr.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/fr_CA.po
+++ b/l10n_it_fatturapa/i18n/fr_CA.po
@@ -537,7 +537,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_welfare_fund_data_line_write_uid
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_welfare_fund_type_write_uid
 msgid "Last Updated by"
-msgstr "Dernière mise à jour par"
+msgstr "Dernie're mise à jour par"
 
 #. module: l10n_it_fatturapa
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_discount_rise_price_write_date
@@ -556,7 +556,7 @@ msgstr "Dernière mise à jour par"
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_welfare_fund_data_line_write_date
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_welfare_fund_type_write_date
 msgid "Last Updated on"
-msgstr "Dernière mise à jour le"
+msgstr "Dernie're mise à jour le"
 
 #. module: l10n_it_fatturapa
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_faturapa_summary_data_law_reference
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/fr_CH.po
+++ b/l10n_it_fatturapa/i18n/fr_CH.po
@@ -518,7 +518,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_welfare_fund_data_line___last_update
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_welfare_fund_type___last_update
 msgid "Last Modified on"
-msgstr "Dernière modification le"
+msgstr "Dernie're modification le"
 
 #. module: l10n_it_fatturapa
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_discount_rise_price_write_uid
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/fr_FR.po
+++ b/l10n_it_fatturapa/i18n/fr_FR.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/gl.po
+++ b/l10n_it_fatturapa/i18n/gl.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/gl_ES.po
+++ b/l10n_it_fatturapa/i18n/gl_ES.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/he.po
+++ b/l10n_it_fatturapa/i18n/he.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/hr.po
+++ b/l10n_it_fatturapa/i18n/hr.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/hr_HR.po
+++ b/l10n_it_fatturapa/i18n/hr_HR.po
@@ -1124,9 +1124,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/hu.po
+++ b/l10n_it_fatturapa/i18n/hu.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/id.po
+++ b/l10n_it_fatturapa/i18n/id.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/it.po
+++ b/l10n_it_fatturapa/i18n/it.po
@@ -51,7 +51,7 @@ msgstr "ABI"
 #. module: l10n_it_fatturapa
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_faturapa_activity_progress_fatturapa_activity_progress
 msgid "Activity Progress"
-msgstr "Progresso Attività"
+msgstr "Progresso Attivita'"
 
 #. module: l10n_it_fatturapa
 #: model:ir.model.fields,field_description:l10n_it_fatturapa.field_account_invoice_line_admin_ref
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/ja.po
+++ b/l10n_it_fatturapa/i18n/ja.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/ko.po
+++ b/l10n_it_fatturapa/i18n/ko.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/l10n_it_fatturapa.pot
+++ b/l10n_it_fatturapa/i18n/l10n_it_fatturapa.pot
@@ -1110,7 +1110,7 @@ msgstr ""
 #. module: l10n_it_fatturapa
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
-msgid "il progressivo univoco del file è rappresentato da una stringa alfanumerica di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da “0” a “9”."
+msgid "il progressivo univoco del file e' rappresentato da una stringa alfanumerica di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da “0” a “9”."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/lt.po
+++ b/l10n_it_fatturapa/i18n/lt.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/lt_LT.po
+++ b/l10n_it_fatturapa/i18n/lt_LT.po
@@ -1124,9 +1124,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/lv.po
+++ b/l10n_it_fatturapa/i18n/lv.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/mk.po
+++ b/l10n_it_fatturapa/i18n/mk.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/mn.po
+++ b/l10n_it_fatturapa/i18n/mn.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/nb.po
+++ b/l10n_it_fatturapa/i18n/nb.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/nb_NO.po
+++ b/l10n_it_fatturapa/i18n/nb_NO.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/nl.po
+++ b/l10n_it_fatturapa/i18n/nl.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/nl_BE.po
+++ b/l10n_it_fatturapa/i18n/nl_BE.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/pl.po
+++ b/l10n_it_fatturapa/i18n/pl.po
@@ -1124,9 +1124,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/pt.po
+++ b/l10n_it_fatturapa/i18n/pt.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/pt_BR.po
+++ b/l10n_it_fatturapa/i18n/pt_BR.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/pt_PT.po
+++ b/l10n_it_fatturapa/i18n/pt_PT.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/ro.po
+++ b/l10n_it_fatturapa/i18n/ro.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/ru.po
+++ b/l10n_it_fatturapa/i18n/ru.po
@@ -1124,9 +1124,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/sk.po
+++ b/l10n_it_fatturapa/i18n/sk.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/sk_SK.po
+++ b/l10n_it_fatturapa/i18n/sk_SK.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/sl.po
+++ b/l10n_it_fatturapa/i18n/sl.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/sr.po
+++ b/l10n_it_fatturapa/i18n/sr.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/sr@latin.po
+++ b/l10n_it_fatturapa/i18n/sr@latin.po
@@ -1124,9 +1124,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/sv.po
+++ b/l10n_it_fatturapa/i18n/sv.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/th.po
+++ b/l10n_it_fatturapa/i18n/th.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/tr.po
+++ b/l10n_it_fatturapa/i18n/tr.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/uk.po
+++ b/l10n_it_fatturapa/i18n/uk.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/vi.po
+++ b/l10n_it_fatturapa/i18n/vi.po
@@ -1122,9 +1122,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/vi_VN.po
+++ b/l10n_it_fatturapa/i18n/vi_VN.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/zh_CN.po
+++ b/l10n_it_fatturapa/i18n/zh_CN.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/i18n/zh_TW.po
+++ b/l10n_it_fatturapa/i18n/zh_TW.po
@@ -1123,9 +1123,9 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_account_config_settings_fatturapa_sequence_id
 #: model:ir.model.fields,help:l10n_it_fatturapa.field_res_company_fatturapa_sequence_id
 msgid ""
-"il progressivo univoco del file è rappresentato da una stringa alfanumerica "
-"di lunghezza massima di 5 caratteri e con valori ammessi da “A” a “Z” e da "
-"“0” a “9”."
+"il progressivo univoco del file e' rappresentato da una stringa alfanumerica "
+"di lunghezza massima di 5 caratteri e con valori ammessi da 'A' a 'Z' e da "
+"'0' a '9'."
 msgstr ""
 
 #. module: l10n_it_fatturapa

--- a/l10n_it_fatturapa/models/company.py
+++ b/l10n_it_fatturapa/models/company.py
@@ -14,9 +14,9 @@ class ResCompany(models.Model):
         )
     fatturapa_sequence_id = fields.Many2one(
         'ir.sequence', 'Sequence',
-        help="il progressivo univoco del file è rappresentato da una "
+        help="il progressivo univoco del file e' rappresentato da una "
              "stringa alfanumerica di lunghezza massima di 5 caratteri "
-             "e con valori ammessi da “A” a “Z” e da “0” a “9”.",
+             "e con valori ammessi da 'A' a 'Z' e da '0' a '9'.",
         )
     fatturapa_art73 = fields.Boolean('Art73')
     fatturapa_pub_administration_ref = fields.Char(
@@ -53,9 +53,9 @@ class AccountConfigSettings(models.TransientModel):
     fatturapa_sequence_id = fields.Many2one(
         related='company_id.fatturapa_sequence_id',
         string="Sequence",
-        help="il progressivo univoco del file è rappresentato da una "
+        help="il progressivo univoco del file e' rappresentato da una "
              "stringa alfanumerica di lunghezza massima di 5 caratteri "
-             "e con valori ammessi da “A” a “Z” e da “0” a “9”.",
+             "e con valori ammessi da 'A' a 'Z' e da '0' a '9'.",
         )
     fatturapa_art73 = fields.Boolean(
         related='company_id.fatturapa_art73',

--- a/l10n_it_fiscalcode/migrations/10.0.1.0.1/post-migrate.py
+++ b/l10n_it_fiscalcode/migrations/10.0.1.0.1/post-migrate.py
@@ -8,7 +8,7 @@ from openerp import api, SUPERUSER_ID
 
 def migrate(cr, version):
     """ Sync of fiscalcode field to descendants """
-    if not version:
+    if version:
         return
     with api.Environment.manage():
         env = api.Environment(cr, SUPERUSER_ID, {})

--- a/l10n_it_ricevute_bancarie/i18n/am.po
+++ b/l10n_it_ricevute_bancarie/i18n/am.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/ar.po
+++ b/l10n_it_ricevute_bancarie/i18n/ar.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/bg.po
+++ b/l10n_it_ricevute_bancarie/i18n/bg.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/bs.po
+++ b/l10n_it_ricevute_bancarie/i18n/bs.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/ca.po
+++ b/l10n_it_ricevute_bancarie/i18n/ca.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/ca_ES.po
+++ b/l10n_it_ricevute_bancarie/i18n/ca_ES.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/cs.po
+++ b/l10n_it_ricevute_bancarie/i18n/cs.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/da.po
+++ b/l10n_it_ricevute_bancarie/i18n/da.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/de.po
+++ b/l10n_it_ricevute_bancarie/i18n/de.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/el_GR.po
+++ b/l10n_it_ricevute_bancarie/i18n/el_GR.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/en_AU.po
+++ b/l10n_it_ricevute_bancarie/i18n/en_AU.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/en_GB.po
+++ b/l10n_it_ricevute_bancarie/i18n/en_GB.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es.po
+++ b/l10n_it_ricevute_bancarie/i18n/es.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_AR.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_AR.po
@@ -642,7 +642,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_CL.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_CL.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_CO.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_CO.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_CR.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_CR.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_DO.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_DO.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_EC.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_EC.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_ES.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_ES.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_MX.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_MX.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_PE.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_PE.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_PY.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_PY.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/es_VE.po
+++ b/l10n_it_ricevute_bancarie/i18n/es_VE.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/et.po
+++ b/l10n_it_ricevute_bancarie/i18n/et.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/eu.po
+++ b/l10n_it_ricevute_bancarie/i18n/eu.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/fa.po
+++ b/l10n_it_ricevute_bancarie/i18n/fa.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/fi.po
+++ b/l10n_it_ricevute_bancarie/i18n/fi.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/fr.po
+++ b/l10n_it_ricevute_bancarie/i18n/fr.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/fr_CA.po
+++ b/l10n_it_ricevute_bancarie/i18n/fr_CA.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/fr_CH.po
+++ b/l10n_it_ricevute_bancarie/i18n/fr_CH.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/fr_FR.po
+++ b/l10n_it_ricevute_bancarie/i18n/fr_FR.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/gl.po
+++ b/l10n_it_ricevute_bancarie/i18n/gl.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/gl_ES.po
+++ b/l10n_it_ricevute_bancarie/i18n/gl_ES.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/he.po
+++ b/l10n_it_ricevute_bancarie/i18n/he.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/hi.po
+++ b/l10n_it_ricevute_bancarie/i18n/hi.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/hr.po
+++ b/l10n_it_ricevute_bancarie/i18n/hr.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/hr_HR.po
+++ b/l10n_it_ricevute_bancarie/i18n/hr_HR.po
@@ -642,7 +642,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/hu.po
+++ b/l10n_it_ricevute_bancarie/i18n/hu.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/id.po
+++ b/l10n_it_ricevute_bancarie/i18n/id.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/it.po
+++ b/l10n_it_ricevute_bancarie/i18n/it.po
@@ -645,8 +645,8 @@ msgstr "Riga distinta"
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
-msgstr "Modalità Emissione"
+msgid "Modalita' Emissione"
+msgstr "Modalita' Emissione"
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.ui.view,arch_db:l10n_it_ricevute_bancarie.view_riba_distinta_line_form

--- a/l10n_it_ricevute_bancarie/i18n/ja.po
+++ b/l10n_it_ricevute_bancarie/i18n/ja.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/ko.po
+++ b/l10n_it_ricevute_bancarie/i18n/ko.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/lo.po
+++ b/l10n_it_ricevute_bancarie/i18n/lo.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/lt.po
+++ b/l10n_it_ricevute_bancarie/i18n/lt.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/lt_LT.po
+++ b/l10n_it_ricevute_bancarie/i18n/lt_LT.po
@@ -642,7 +642,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/lv.po
+++ b/l10n_it_ricevute_bancarie/i18n/lv.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/mk.po
+++ b/l10n_it_ricevute_bancarie/i18n/mk.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/mn.po
+++ b/l10n_it_ricevute_bancarie/i18n/mn.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/nb.po
+++ b/l10n_it_ricevute_bancarie/i18n/nb.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/nb_NO.po
+++ b/l10n_it_ricevute_bancarie/i18n/nb_NO.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/nl.po
+++ b/l10n_it_ricevute_bancarie/i18n/nl.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/nl_BE.po
+++ b/l10n_it_ricevute_bancarie/i18n/nl_BE.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/pl.po
+++ b/l10n_it_ricevute_bancarie/i18n/pl.po
@@ -642,7 +642,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/pt.po
+++ b/l10n_it_ricevute_bancarie/i18n/pt.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/pt_BR.po
+++ b/l10n_it_ricevute_bancarie/i18n/pt_BR.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/pt_PT.po
+++ b/l10n_it_ricevute_bancarie/i18n/pt_PT.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/ro.po
+++ b/l10n_it_ricevute_bancarie/i18n/ro.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/ru.po
+++ b/l10n_it_ricevute_bancarie/i18n/ru.po
@@ -642,7 +642,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/sk.po
+++ b/l10n_it_ricevute_bancarie/i18n/sk.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/sk_SK.po
+++ b/l10n_it_ricevute_bancarie/i18n/sk_SK.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/sl.po
+++ b/l10n_it_ricevute_bancarie/i18n/sl.po
@@ -644,7 +644,7 @@ msgstr "Postavka seznama"
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/sr.po
+++ b/l10n_it_ricevute_bancarie/i18n/sr.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/sr@latin.po
+++ b/l10n_it_ricevute_bancarie/i18n/sr@latin.po
@@ -642,7 +642,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/sv.po
+++ b/l10n_it_ricevute_bancarie/i18n/sv.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/th.po
+++ b/l10n_it_ricevute_bancarie/i18n/th.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/tr.po
+++ b/l10n_it_ricevute_bancarie/i18n/tr.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/uk.po
+++ b/l10n_it_ricevute_bancarie/i18n/uk.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/vi.po
+++ b/l10n_it_ricevute_bancarie/i18n/vi.po
@@ -640,7 +640,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/vi_VN.po
+++ b/l10n_it_ricevute_bancarie/i18n/vi_VN.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/zh_CN.po
+++ b/l10n_it_ricevute_bancarie/i18n/zh_CN.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/i18n/zh_TW.po
+++ b/l10n_it_ricevute_bancarie/i18n/zh_TW.po
@@ -641,7 +641,7 @@ msgstr ""
 
 #. module: l10n_it_ricevute_bancarie
 #: model:ir.model.fields,field_description:l10n_it_ricevute_bancarie.field_riba_configuration_type
-msgid "Modalità Emissione"
+msgid "Modalita' Emissione"
 msgstr ""
 
 #. module: l10n_it_ricevute_bancarie

--- a/l10n_it_ricevute_bancarie/models/riba_config.py
+++ b/l10n_it_ricevute_bancarie/models/riba_config.py
@@ -18,7 +18,7 @@ class RibaConfiguration(models.Model):
     name = fields.Char("Description", size=64, required=True)
     type = fields.Selection(
         (('sbf', 'Salvo buon fine'), ('incasso', 'Al dopo incasso')),
-        "Modalità Emissione", required=True)
+        "Modalita' Emissione", required=True)
     bank_id = fields.Many2one(
         'res.partner.bank', "Banca", required=True,
         help="Bank account used for Ri.Ba. issuing")


### PR DESCRIPTION
…name_get() for tax.kind.

Still missing, but in odoo core:
 
2018-06-22 14:42:20,147 182 WARNING openerp_test py.warnings: /.repo_requirements/odoo/odoo/models.py:362: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
elif not all(cols[field.name][key] == vals[key] for key in vals):