### PR TITLE
[FIX][l10n_it_website_sale_corrispettivi] keep the corrispettivi flag on every created order

### DIFF
--- a/l10n_it_website_sale_corrispettivi/__manifest__.py
+++ b/l10n_it_website_sale_corrispettivi/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'e-commerce',
     'author': 'Agile Business Group,'
               'Odoo Community Association (OCA)',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'license': 'AGPL-3',
     'website': 'https://github.com/OCA/l10n-italy/tree/10.0/'
                'l10n_it_website_sale_corrispettivi',

--- a/l10n_it_website_sale_corrispettivi/models/__init__.py
+++ b/l10n_it_website_sale_corrispettivi/models/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import controllers
-from . import models
+from . import website

--- a/l10n_it_website_sale_corrispettivi/models/website.py
+++ b/l10n_it_website_sale_corrispettivi/models/website.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    @api.multi
+    def _prepare_sale_order_values(self, partner, pricelist):
+        self.ensure_one()
+        values = super(Website, self) \
+            ._prepare_sale_order_values(partner, pricelist)
+        values.update({'corrispettivi': partner.use_corrispettivi})
+        return values


### PR DESCRIPTION
Steps tor reproduce the issue:
1. Log into website with a user whose partner has use_corrispettivi enabled;
2. Buy a product;
3. Fill in address details, note that *Want invoice* is False, confirm and pay;
4. In backend, check that generated SO has corrispettivi enabled;
5. Buy another product
6. Do not edit address details, they should be already filled, confirm and pay;

Before this PR:
The generated SO has the Corrispettivi flag disabled

After this PR:
The generated SO has the Corrispettivi flag enabled