### PR TITLE
[10.0][FIX] Runbot warnings:

### DIFF
--- a/l10n_it_account_tax_kind/model/account_tax_kind.py
+++ b/l10n_it_account_tax_kind/model/account_tax_kind.py
@@ -7,17 +7,17 @@ from odoo import api, models, fields
 class AccountTaxKind(models.Model):
 
     _name = 'account.tax.kind'
-    _rec_name = 'display_name'
 
     code = fields.Char(string='Code', size=3, required=True)
     name = fields.Char(string='Name', required=True)
-    display_name = fields.Char(string='Name', compute='_compute_display_name')
 
-    @api.depends('code', 'name')
     @api.multi
-    def _compute_display_name(self):
-        for record in self:
-            record.display_name = u'[%s] %s' % (record.code, record.name)
+    def name_get(self):
+        res = []
+        for tax_kind in self:
+            res.append(
+                (tax_kind.id, '[%s] %s' % (tax_kind.code, tax_kind.name)))
+        return res
 
     @api.model
     def name_search(self, name, args=None, operator='ilike', limit=100):

--- a/l10n_it_account_tax_kind/tests/test_account_tax_kind.py
+++ b/l10n_it_account_tax_kind/tests/test_account_tax_kind.py
@@ -12,7 +12,6 @@ class TestAccountTaxKind(TransactionCase):
         self.tax_kind_n1 = self.env.ref('l10n_it_account_tax_kind.n1')
 
     def test_compute_display_name(self):
-        self.tax_kind_n1._compute_display_name()
         self.assertEqual(
             self.tax_kind_n1.display_name,
             u'[%s] %s' % (self.tax_kind_n1.code, self.tax_kind_n1.name))

--- a/l10n_it_central_journal/models/account.py
+++ b/l10n_it_central_journal/models/account.py
@@ -24,9 +24,9 @@ class DateRangeInherit(models.Model):
     progressive_line_number = fields.Integer('Progressive line', default=0)
     progressive_credit = fields.Float(
         'Progressive Credit',
-        digits_compute=dp.get_precision('Account'),
+        digits=dp.get_precision('Account'),
         default=lambda *a: float())
     progressive_debit = fields.Float(
         'Progressive Debit',
-        digits_compute=dp.get_precision('Account'),
+        digits=dp.get_precision('Account'),
         default=lambda *a: float())

--- a/l10n_it_fatturapa/models/company.py
+++ b/l10n_it_fatturapa/models/company.py
@@ -14,9 +14,9 @@ class ResCompany(models.Model):
         )
     fatturapa_sequence_id = fields.Many2one(
         'ir.sequence', 'Sequence',
-        help="il progressivo univoco del file è rappresentato da una "
-             "stringa alfanumerica di lunghezza massima di 5 caratteri "
-             "e con valori ammessi da “A” a “Z” e da “0” a “9”.",
+        help="The univocal progressive of the file is represented by "
+             "an alphanumeric sequence of maximum length 5, "
+             "its values are included in 'A'-'Z' and '0'-'9'"
         )
     fatturapa_art73 = fields.Boolean('Art73')
     fatturapa_pub_administration_ref = fields.Char(
@@ -53,9 +53,9 @@ class AccountConfigSettings(models.TransientModel):
     fatturapa_sequence_id = fields.Many2one(
         related='company_id.fatturapa_sequence_id',
         string="Sequence",
-        help="il progressivo univoco del file è rappresentato da una "
-             "stringa alfanumerica di lunghezza massima di 5 caratteri "
-             "e con valori ammessi da “A” a “Z” e da “0” a “9”.",
+        help="The univocal progressive of the file is represented by "
+             "an alphanumeric sequence of maximum length 5, "
+             "its values are included in 'A'-'Z' and '0'-'9'"
         )
     fatturapa_art73 = fields.Boolean(
         related='company_id.fatturapa_art73',

--- a/l10n_it_ricevute_bancarie/models/riba_config.py
+++ b/l10n_it_ricevute_bancarie/models/riba_config.py
@@ -18,7 +18,7 @@ class RibaConfiguration(models.Model):
     name = fields.Char("Description", size=64, required=True)
     type = fields.Selection(
         (('sbf', 'Salvo buon fine'), ('incasso', 'Al dopo incasso')),
-        "Modalità Emissione", required=True)
+        "Emission mode", required=True)
     bank_id = fields.Many2one(
         'res.partner.bank', "Banca", required=True,
         help="Bank account used for Ri.Ba. issuing")


### PR DESCRIPTION
Superseding #545 to fix the warnings:
```
WARNING openerp_test odoo.fields: Field account.tax.kind.display_name depends on itself; please fix its decorator @api.depends().
WARNING openerp_test odoo.fields: Field date.range.progressive_credit: parameter 'digits_compute' is no longer supported; use 'digits' instead.
WARNING openerp_test odoo.fields: Field date.range.progressive_debit: parameter 'digits_compute' is no longer supported; use 'digits' instead.
WARNING openerp_test py.warnings: /home/travis/odoo-10.0/odoo/models.py:362: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
elif not all(cols[field.name][key] == vals[key] for key in vals):
```