### PR TITLE
10.0 fix rc with 2 lines

### DIFF
--- a/l10n_it_reverse_charge/__manifest__.py
+++ b/l10n_it_reverse_charge/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Reverse Charge IVA',
-    'version': '10.0.1.1.2',
+    'version': '10.0.1.1.3',
     'category': 'Localization/Italy',
     'summary': 'Reverse Charge for Italy',
     'author': 'Odoo Italia Network,Odoo Community Association (OCA)',

--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -287,20 +287,21 @@ class AccountInvoice(models.Model):
         for line in self.invoice_line_ids:
             if line.rc:
                 rc_invoice_line = self.rc_inv_line_vals(line)
-                line_tax = line.invoice_line_tax_ids
-                if not line_tax:
+                line_tax_ids = line.invoice_line_tax_ids
+                if not line_tax_ids:
                     raise UserError(_(
                         "Invoice line\n%s\nis RC but has not tax") % line.name)
-                tax_id = None
+                tax_ids = list()
                 for tax_mapping in rc_type.tax_ids:
-                    if tax_mapping.purchase_tax_id == line_tax[0]:
-                        tax_id = tax_mapping.sale_tax_id.id
-                if not tax_id:
+                    for line_tax_id in line_tax_ids:
+                        if tax_mapping.purchase_tax_id == line_tax_id:
+                            tax_ids.append(tax_mapping.sale_tax_id.id)
+                if not tax_ids:
                     raise UserError(_("Tax code used is not a RC tax.\nCan't "
                                       "find tax mapping"))
-                if line_tax:
+                if line_tax_ids:
                     rc_invoice_line['invoice_line_tax_ids'] = [
-                        (6, False, [tax_id])]
+                        (6, False, tax_ids)]
                 rc_invoice_line[
                     'account_id'] = rc_type.transitory_account_id.id
                 rc_invoice_lines.append([0, False, rc_invoice_line])


### PR DESCRIPTION
Steps:
1. Create a supplier invoice where:
   * one line is for 100€ (+22€ tax), RC = True
   * one line is for 100€ (+22€ tax), RC = False
2. Validate the invoice, it correctly generates the reversed invoice having only one line for 100€ (+22€ tax)
3. Reconcile the supplier invoice

Before this PR:
* The supplier invoice is still open for 200€

After this PR:
* The supplier invoice is still open for 222€
