### PR TITLE
[10.0][FIX] Stampa registro IVA non vengono stampate le fatture in esenzione

### DIFF
--- a/l10n_it_vat_registries/__manifest__.py
+++ b/l10n_it_vat_registries/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Italian Localization - VAT Registries',
-    'version': '10.0.1.2.1',
+    'version': '10.0.1.2.2',
     'category': 'Localization/Italy',
     "author": "Agile Business Group, Odoo Community Association (OCA)"
               ", LinkIt Srl",

--- a/l10n_it_vat_registries_cash_basis/wizard/print_registro_iva.py
+++ b/l10n_it_vat_registries_cash_basis/wizard/print_registro_iva.py
@@ -102,7 +102,10 @@ class WizardRegistroIva(models.TransientModel):
         cash_move_ids = {}
         move_ids = []
         # controllare se la contabilità è in regime di cassa
-        move_ids, cash_move_ids = self._get_cash_basis_move_ids(wizard)
+        if self.env.user.company_id.tax_cash_basis_journal_id:
+            move_ids, cash_move_ids = self._get_cash_basis_move_ids(wizard)
+        else:
+            move_ids = super(WizardRegistroIva, self)._get_move_ids(wizard)
 
         if not move_ids:
             raise UserError(_('No documents found in the current selection'))


### PR DESCRIPTION
Caso di instanza multicompany, dove ci sono aziende soggette a iva per cassa e aziende gestite con iva normale.
Con il modulo l10n_it_vat_registries_cash_basis quando si va a stampare il registro iva dell'azienda gestita senza il principio di iva per cassa, non vengono stampate le fatture con iva in esenzione.