### PR TITLE
[FIX][l10n_it_withholding_tax] coeff computation

### DIFF
--- a/l10n_it_withholding_tax/__manifest__.py
+++ b/l10n_it_withholding_tax/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Italian Withholding Tax',
-    'version': '10.0.1.2.2',
+    'version': '10.0.1.2.3',
     'category': 'Account',
     'author': 'Openforce, Odoo Italia Network, '
               'Odoo Community Association (OCA)',

--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -470,14 +470,14 @@ class AccountInvoiceWithholdingTax(models.Model):
             (1 - (line.discount or 0.0) / 100.0)
         return price_unit
 
-    @api.depends('base', 'tax')
+    @api.depends('base', 'tax', 'invoice_id.amount_untaxed')
     def _compute_coeff(self):
         for inv_wt in self:
             if inv_wt.invoice_id.amount_untaxed:
-                inv_wt.base_coeff = round(
-                    inv_wt.base / inv_wt.invoice_id.amount_untaxed, 5)
+                inv_wt.base_coeff = \
+                    inv_wt.base / inv_wt.invoice_id.amount_untaxed
             if inv_wt.base:
-                inv_wt.tax_coeff = round(inv_wt.tax / inv_wt.base, 5)
+                inv_wt.tax_coeff = inv_wt.tax / inv_wt.base
 
     invoice_id = fields.Many2one('account.invoice', string='Invoice',
                                  ondelete="cascade")


### PR DESCRIPTION
Steps:

1. Configure a withholding tax having:
   - Base coeff: 0.5
   - Tax %: 23
2. Open an invoice having:
   - Untaxed amount: 8991.94
   - Tax (22%): 2145
3. In the invoice, add the withholding tax defined in 1, having:
   - Base: 4875
   - Tax: 1121.25
4. Validate the invoice
5. Pay 5015.69, the amount automatically paid is 561.50
6. Pay the remaining 5000

Before this PR:
The amount automatically paid is 559.74 and the invoice remains open for 1 cent!

After this PR:
The amount automatically paid is 559.75 and the invoice is fully paid