### PR TITLE
[8.0][IMP] Registri iva: opzione per ordinamento

### DIFF
--- a/l10n_it_vat_registries/account_tax_registry.py
+++ b/l10n_it_vat_registries/account_tax_registry.py
@@ -28,6 +28,10 @@ class AccountTaxRegistry(models.Model):
         'res.company', 'Company', required=True,
         default=lambda self: self.env['res.company']._company_default_get(
             'account.tax.registry'))
+    order = fields.Selection([
+        ('date_name', 'Date - Number'),
+        ('journal_date_name', 'Journal - Date - Number'),
+        ], 'Order Moves')
     journal_ids = fields.One2many(
         'account.journal', 'tax_registry_id', 'Journals', readonly=True)
     type = fields.Selection([

--- a/l10n_it_vat_registries/account_tax_registry_view.xml
+++ b/l10n_it_vat_registries/account_tax_registry_view.xml
@@ -9,6 +9,7 @@
                     <group>
                         <field name="name"></field>
                         <field name="type"></field>
+                        <field name="order"></field>
                     </group>
                     <separator string="Journals"></separator>
                     <field name="journal_ids"></field>

--- a/l10n_it_vat_registries/vat_registry.py
+++ b/l10n_it_vat_registries/vat_registry.py
@@ -306,6 +306,7 @@ class Parser(report_sxw.rml_parse):
         self.localcontext.update({
             'registry_type': data['form'].get('registry_type'),
             'only_totals': data['form'].get('only_totals'),
+            'order': data['form'].get('order'),
             'tax_registry_name': data['form'].get('tax_registry_name'),
             'l10n_it_count_fiscal_page_base': data['form'].get(
                 'fiscal_page_base'),

--- a/l10n_it_vat_registries/views/report_registro_iva.xml
+++ b/l10n_it_vat_registries/views/report_registro_iva.xml
@@ -63,10 +63,24 @@
                     </thead>
                     
                     <t t-set="counter" t-value="0"/>
+                    <t t-set="sv_journal_id" t-value="False"/>
                     <tbody>
                         <t t-foreach="get_move(data['ids'])" t-as="move">
                             <t t-set="counter" t-value="counter + 1"/>
                             <t t-foreach="tax_lines(move)" t-as="line">
+
+                                <t t-if="order == 'journal_date_name'">
+                                    <t t-if="move.journal_id.id != sv_journal_id">
+	                                    <tr>
+	                                        <td colspan='9'>
+	                                            <h3 style="page-break-inside: avoid;border-top:1px solid;border-bottom:1px solid;" 
+	                                            t-esc="move.journal_id.name"/>
+	                                        </td>
+	                                    </tr>
+                                    </t>
+                                </t>
+                                <t t-set="sv_journal_id" t-value="move.journal_id.id"/>
+
                                 <t t-if="print_details > 0 ">
                                     <t t-set="line_class_left" t-value="left_without_line"/>
                                     <t t-set="line_class_right" t-value="right_without_line"/>

--- a/l10n_it_vat_registries/wizard/print_registro_iva.xml
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.xml
@@ -13,6 +13,7 @@
                         <field name="period_ids" colspan="4" nolabel="1" height="250"/>
                         <separator string="Journals" colspan="4"/>
                         <field name="tax_registry_id"></field>
+                        <field name="order"></field>
                         <field name="journal_ids" colspan="4" nolabel="1" height="250" domain="[('type', 'in', ('sale','purchase','sale_refund','purchase_refund'))]"/>
                         <separator string="Layout" colspan="4"/>
                         <field name="type"/>


### PR DESCRIPTION
Aggiunta l'opzione per ordinare i movimenti sul registro.
Si può scegliere tra:
- Data/numero
- Sezionale/data/numero

Nel caso di ordinamento x Sezionale/data/numero, verrà stampata una riga di intestazione con il nome del sezionale a cui seguiranno i movimenti di competenza
