### PR TITLE
[11.0] FIX  l10n_it_codici_carica api.constrains gets a recordset

### DIFF
--- a/l10n_it_codici_carica/models/codice_carica.py
+++ b/l10n_it_codici_carica/models/codice_carica.py
@@ -11,11 +11,12 @@ class CodiceCarica(models.Model):
 
     @api.constrains('code')
     def _check_code(self):
-        domain = [('code', '=', self.code)]
-        elements = self.search(domain)
-        if len(elements) > 1:
-            raise ValidationError(
-                _("The element with this code already exists"))
+        for codice in self:
+            domain = [('code', '=', codice.code)]
+            elements = self.search(domain)
+            if len(elements) > 1:
+                raise ValidationError(
+                    _("The element with code %s already exists") % codice.code)
 
     code = fields.Char(string='Code', size=2)
     name = fields.Char(string='Name')


### PR DESCRIPTION
https://www.odoo.com/documentation/10.0/howtos/backend.html#model-constraints