### PR TITLE
[FIX] l10n_it_corrispettivi: default for journal

### DIFF
--- a/l10n_it_corrispettivi/__manifest__.py
+++ b/l10n_it_corrispettivi/__manifest__.py
@@ -4,7 +4,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     'name': 'Italian Localization - Corrispettivi',
-    'version': '10.0.1.2.1',
+    'version': '10.0.1.2.2',
     'category': 'Accounting & Finance',
     'author': 'Odoo Italian Community, Agile Business Group, '
               'Odoo Community Association (OCA)',

--- a/l10n_it_corrispettivi/models/account.py
+++ b/l10n_it_corrispettivi/models/account.py
@@ -12,17 +12,17 @@ class AccountInvoice(models.Model):
 
     @api.model
     def _default_partner_id(self):
-        if not self._context.get('default_corrispettivi', False):
+        if not self.env.context.get('default_corrispettivi', False):
             # If this is not a corrispettivo, do nothing
             return False
         return self.env.ref('base.public_user').partner_id.id
 
     @api.model
     def _default_journal(self):
-        if not self._context.get('default_corrispettivi', False):
+        if not self.env.context.get('default_corrispettivi', False):
             # If this is not a corrispettivo, do nothing
             return super(AccountInvoice, self)._default_journal()
-        company_id = self._context.get(
+        company_id = self.env.context.get(
             'company_id', self.env.user.company_id)
         return self.env['account.journal'] \
             .get_corr_journal(company_id)
@@ -36,7 +36,7 @@ class AccountInvoice(models.Model):
 
     @api.onchange('company_id')
     def onchange_company_id_corrispettivi(self):
-        if not self._context.get('default_corrispettivi', False):
+        if not self.env.context.get('default_corrispettivi', False):
             # If this is not a corrispettivo, do nothing
             return
 

--- a/l10n_it_corrispettivi/models/account.py
+++ b/l10n_it_corrispettivi/models/account.py
@@ -17,12 +17,6 @@ class AccountInvoice(models.Model):
             return False
         return self.env.ref('base.public_user').partner_id.id
 
-    # set default option on inherited field
-    corrispettivo = fields.Boolean(
-        string='Corrispettivo', related="journal_id.corrispettivi",
-        readonly=True, store=True)
-    partner_id = fields.Many2one(default=_default_partner_id)
-
     @api.model
     def _default_journal(self):
         if not self._context.get('default_corrispettivi', False):
@@ -32,6 +26,13 @@ class AccountInvoice(models.Model):
             'company_id', self.env.user.company_id)
         return self.env['account.journal'] \
             .get_corr_journal(company_id)
+
+    # set default option on inherited field
+    corrispettivo = fields.Boolean(
+        string='Corrispettivo', related="journal_id.corrispettivi",
+        readonly=True, store=True)
+    partner_id = fields.Many2one(default=_default_partner_id)
+    journal_id = fields.Many2one(default=_default_journal)
 
     @api.onchange('company_id')
     def onchange_company_id_corrispettivi(self):


### PR DESCRIPTION
_default_journal did not correctly override the default function for field journal_id.
Everything was *luckily* working thanks to the method _default_currency that called self._default_journal and this kind of call respects inheritance.