### PR TITLE
[10][IMP]Riconciliazione bancaria con importo al netto della ritenuta

### DIFF
--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -3,11 +3,9 @@
 # Copyright 2018 Lorenzo Battistini - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-
 from odoo import models, fields, api, _
 import odoo.addons.decimal_precision as dp
 from odoo.exceptions import ValidationError
-from odoo.tools.misc import formatLang
 
 
 class AccountPartialReconcile(models.Model):
@@ -278,38 +276,32 @@ class AccountMoveLine(models.Model):
 
         return super(AccountMoveLine, self).remove_move_reconcile()
 
-
     @api.multi
     def prepare_move_lines_for_reconciliation_widget(
             self, target_currency=False, target_date=False):
         """
         Net amount for invoices with withholding tax
         """
-        res = super(AccountMoveLine, self).prepare_move_lines_for_reconciliation_widget(
+        res = super(
+            AccountMoveLine, self
+        ).prepare_move_lines_for_reconciliation_widget(
             target_currency, target_date)
         for dline in res:
             if 'id' in dline and dline['id']:
                 line = self.browse(dline['id'])
-                company_currency = line.account_id.company_id.currency_id
-                line_currency = (line.currency_id and line.amount_currency) \
-                    and line.currency_id or company_currency
                 if line.withholding_tax_amount:
-                    dline['debit'] = line.debit - line.withholding_tax_amount \
-                        if line.debit else 0
-                    dline['credit'] = line.credit - line.withholding_tax_amount \
+                    dline['debit'] = (
+                        line.debit - line.withholding_tax_amount if line.debit
+                        else 0
+                    )
+                    dline['credit'] = (
+                        line.credit - line.withholding_tax_amount
                         if line.credit else 0
-                    amount = line.debit or line.credit
-                    amount_str = formatLang(
-                        self.env, abs(amount), currency_obj=target_currency)
-                    amount_currency_str = ""
-                    total_amount_currency_str = ""
-                    if line_currency != target_currency:
-                        amount_currency_str = formatLang(self.env, abs(actual_debit or actual_credit), currency_obj=line_currency)
-                        total_amount_currency_str = formatLang(self.env, total_amount, currency_obj=line_currency)
-                    dline['amount_str'] = amount_str
-                    dline['total_amount_str'] = amount_str
-                    dline['amount_currency_str'] = total_amount_currency_str
-                    dline['total_amount_currency_str'] = total_amount_currency_str
+                    )
+                    dline['name'] += (
+                        _(' (Net to pay: %s)')
+                        % (dline['debit'] or dline['credit'])
+                    )
         return res
 
 

--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -7,6 +7,7 @@
 from odoo import models, fields, api, _
 import odoo.addons.decimal_precision as dp
 from odoo.exceptions import ValidationError
+from odoo.tools.misc import formatLang
 
 
 class AccountPartialReconcile(models.Model):
@@ -276,6 +277,40 @@ class AccountMoveLine(models.Model):
                 wt_move.unlink()
 
         return super(AccountMoveLine, self).remove_move_reconcile()
+
+
+    @api.multi
+    def prepare_move_lines_for_reconciliation_widget(
+            self, target_currency=False, target_date=False):
+        """
+        Net amount for invoices with withholding tax
+        """
+        res = super(AccountMoveLine, self).prepare_move_lines_for_reconciliation_widget(
+            target_currency, target_date)
+        for dline in res:
+            if 'id' in dline and dline['id']:
+                line = self.browse(dline['id'])
+                company_currency = line.account_id.company_id.currency_id
+                line_currency = (line.currency_id and line.amount_currency) \
+                    and line.currency_id or company_currency
+                if line.withholding_tax_amount:
+                    dline['debit'] = line.debit - line.withholding_tax_amount \
+                        if line.debit else 0
+                    dline['credit'] = line.credit - line.withholding_tax_amount \
+                        if line.credit else 0
+                    amount = line.debit or line.credit
+                    amount_str = formatLang(
+                        self.env, abs(amount), currency_obj=target_currency)
+                    amount_currency_str = ""
+                    total_amount_currency_str = ""
+                    if line_currency != target_currency:
+                        amount_currency_str = formatLang(self.env, abs(actual_debit or actual_credit), currency_obj=line_currency)
+                        total_amount_currency_str = formatLang(self.env, total_amount, currency_obj=line_currency)
+                    dline['amount_str'] = amount_str
+                    dline['total_amount_str'] = amount_str
+                    dline['amount_currency_str'] = total_amount_currency_str
+                    dline['total_amount_currency_str'] = total_amount_currency_str
+        return res
 
 
 class AccountFiscalPosition(models.Model):


### PR DESCRIPTION
Ho una riga bancaria con addebito di 801 euro per aver pagato una fattura di 1.000 con ritenuta del 20% + 1 euro di spese bancarie.
La vista della riconciliazione mostrerà la fattura aperta di 1.000.
PRIMA:
andando a riconciliare la fattura, Odoo chiudeva completamente la riga di 801, senza dare la possibilità di specificare la spesa bancaria.
CON QUESTA PR:
andando a riconciliare la fattura, verrà preso solo l'importo al netto della ritenuta (800) e quindi si avrà poi al possibilità di chiudere la riconciliazione con l'imputazione delle spese bancarie
