### PR TITLE
FIX l10n_it_fatturapa_out when decimal precision is different from 2

### DIFF
--- a/l10n_it_fatturapa_out/__manifest__.py
+++ b/l10n_it_fatturapa_out/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Italian Localization - Fattura Elettronica - Emission',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'category': 'Localization/Italy',
     'summary': 'Electronic invoices emission',
     'author': 'Davide Corio, Agile Business Group, Innoviu,'

--- a/l10n_it_fatturapa_out/tests/data/CHE114993395IVA_00007.xml
+++ b/l10n_it_fatturapa_out/tests/data/CHE114993395IVA_00007.xml
@@ -90,7 +90,7 @@
             <DettaglioLinee>
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>Mouse Optical</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>10.00</PrezzoUnitario>
                 <PrezzoTotale>10.00</PrezzoTotale>

--- a/l10n_it_fatturapa_out/tests/data/IT03297040366_00005.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT03297040366_00005.xml
@@ -85,7 +85,7 @@
             <DettaglioLinee>
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>Mouse, Optical</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>10.00</PrezzoUnitario>
                 <ScontoMaggiorazione>

--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00001.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00001.xml
@@ -72,7 +72,7 @@
             <DettaglioLinee>
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>Mouse, Optical</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>10.00</PrezzoUnitario>
                 <PrezzoTotale>10.00</PrezzoTotale>
@@ -81,7 +81,7 @@
             <DettaglioLinee>
                 <NumeroLinea>2</NumeroLinea>
                 <Descrizione>Zed+ Antivirus</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>4.00</PrezzoUnitario>
                 <PrezzoTotale>4.00</PrezzoTotale>

--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00002.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00002.xml
@@ -79,7 +79,7 @@
             <DettaglioLinee>
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>Mouse, Optical</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>10.00</PrezzoUnitario>
                 <PrezzoTotale>10.00</PrezzoTotale>
@@ -88,7 +88,7 @@
             <DettaglioLinee>
                 <NumeroLinea>2</NumeroLinea>
                 <Descrizione>Zed+ Antivirus</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>4.00</PrezzoUnitario>
                 <PrezzoTotale>4.00</PrezzoTotale>

--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00003.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00003.xml
@@ -79,7 +79,7 @@
             <DettaglioLinee>
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>Mouse, Optical</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>10.00</PrezzoUnitario>
                 <PrezzoTotale>10.00</PrezzoTotale>
@@ -89,7 +89,7 @@
             <DettaglioLinee>
                 <NumeroLinea>2</NumeroLinea>
                 <Descrizione>Zed+ Antivirus</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>4.00</PrezzoUnitario>
                 <PrezzoTotale>4.00</PrezzoTotale>

--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00004.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00004.xml
@@ -72,7 +72,7 @@
             <DettaglioLinee>
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>Mouse, Optical</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>10.00</PrezzoUnitario>
                 <PrezzoTotale>10.00</PrezzoTotale>
@@ -81,7 +81,7 @@
             <DettaglioLinee>
                 <NumeroLinea>2</NumeroLinea>
                 <Descrizione>Zed+ Antivirus</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>4.00</PrezzoUnitario>
                 <PrezzoTotale>4.00</PrezzoTotale>

--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00006.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00006.xml
@@ -77,7 +77,7 @@
                     <CodiceValore>ODOOCODE</CodiceValore>
                 </CodiceArticolo>
                 <Descrizione>Mouse Optical</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>10.00</PrezzoUnitario>
                 <PrezzoTotale>10.00</PrezzoTotale>
@@ -90,7 +90,7 @@
                     <CodiceValore>987654</CodiceValore>
                 </CodiceArticolo>
                 <Descrizione>Zed+ Antivirus</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>4.00</PrezzoUnitario>
                 <PrezzoTotale>4.00</PrezzoTotale>

--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00008.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00008.xml
@@ -73,7 +73,7 @@
             <DettaglioLinee>
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>Mouse Optical</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>8.20</PrezzoUnitario>
                 <PrezzoTotale>8.20</PrezzoTotale>
@@ -82,7 +82,7 @@
             <DettaglioLinee>
                 <NumeroLinea>2</NumeroLinea>
                 <Descrizione>Zed+ Antivirus</Descrizione>
-                <Quantita>1.00</Quantita>
+                <Quantita>1.000</Quantita>
                 <UnitaMisura>Unit(s)</UnitaMisura>
                 <PrezzoUnitario>3.28</PrezzoUnitario>
                 <PrezzoTotale>3.28</PrezzoTotale>

--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -570,6 +570,10 @@ class WizardExportFatturapa(models.TransientModel):
         # TipoCessionePrestazione not handled
 
         line_no = 1
+        price_precision = self.env['decimal.precision'].precision_get(
+            'Product Price')
+        uom_precision = self.env['decimal.precision'].precision_get(
+            'Product Unit of Measure')
         for line in invoice.invoice_line_ids:
             if not line.invoice_line_tax_ids:
                 raise UserError(
@@ -584,8 +588,12 @@ class WizardExportFatturapa(models.TransientModel):
             DettaglioLinea = DettaglioLineeType(
                 NumeroLinea=str(line_no),
                 Descrizione=line.name,
-                PrezzoUnitario='%.2f' % prezzo_unitario,
-                Quantita='%.2f' % line.quantity,
+                PrezzoUnitario=('%.' + str(
+                    price_precision
+                ) + 'f') % prezzo_unitario,
+                Quantita=('%.' + str(
+                    uom_precision
+                ) + 'f') % line.quantity,
                 UnitaMisura=line.uom_id and (
                     unidecode(line.uom_id.name)) or None,
                 PrezzoTotale='%.2f' % line.price_subtotal,

--- a/l10n_it_fatturapa_out_ddt/__manifest__.py
+++ b/l10n_it_fatturapa_out_ddt/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Fattura Elettronica & DDT",
     "summary": "Bridge module",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "development_status": "Beta",
     "category": "Hidden",
     "website": "https://github.com/OCA/l10n-italy",

--- a/l10n_it_fatturapa_out_ddt/tests/data/IT06363391001_00006.xml
+++ b/l10n_it_fatturapa_out_ddt/tests/data/IT06363391001_00006.xml
@@ -83,7 +83,7 @@
          <DettaglioLinee>
             <NumeroLinea>1</NumeroLinea>
             <Descrizione>Mouse Optical</Descrizione>
-            <Quantita>2.00</Quantita>
+            <Quantita>2.000</Quantita>
             <UnitaMisura>Unit(s)</UnitaMisura>
             <PrezzoUnitario>10.00</PrezzoUnitario>
             <PrezzoTotale>20.00</PrezzoTotale>
@@ -92,7 +92,7 @@
          <DettaglioLinee>
             <NumeroLinea>2</NumeroLinea>
             <Descrizione>Mouse Optical</Descrizione>
-            <Quantita>3.00</Quantita>
+            <Quantita>3.000</Quantita>
             <UnitaMisura>Unit(s)</UnitaMisura>
             <PrezzoUnitario>10.00</PrezzoUnitario>
             <PrezzoTotale>30.00</PrezzoTotale>

--- a/l10n_it_fatturapa_out_ddt/tests/data/IT06363391001_00007.xml
+++ b/l10n_it_fatturapa_out_ddt/tests/data/IT06363391001_00007.xml
@@ -90,7 +90,7 @@
          <DettaglioLinee>
             <NumeroLinea>1</NumeroLinea>
             <Descrizione>Mouse Optical</Descrizione>
-            <Quantita>2.00</Quantita>
+            <Quantita>2.000</Quantita>
             <UnitaMisura>Unit(s)</UnitaMisura>
             <PrezzoUnitario>10.00</PrezzoUnitario>
             <PrezzoTotale>20.00</PrezzoTotale>


### PR DESCRIPTION
Steps:

 - Set 'Product Price' Decimal Accuracy with Digits = 4
 - Create an invoice with 1 line with quantity = 24 and price 1.2519
 - Export XML

In the XML you get
Quantità: 24.00
Valore unitario: 1.25
Valore totale: 30.05

While you should have
Valore unitario: 1.2519