### PR TITLE
[IMP] l10n_it_ddt: avoid print useless time part of field 'Date'

### DIFF
--- a/l10n_it_ddt/__manifest__.py
+++ b/l10n_it_ddt/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     'name': 'DDT',
-    'version': '10.0.1.7.0',
+    'version': '10.0.1.7.1',
     'category': 'Localization/Italy',
     'summary': 'Documento di Trasporto',
     'author': 'Davide Corio, Odoo Community Association (OCA),'

--- a/l10n_it_ddt/views/report_ddt.xml
+++ b/l10n_it_ddt/views/report_ddt.xml
@@ -42,7 +42,7 @@
                     </td>
                     <td>
                         <h6>Date</h6>
-                        <div class="signature" t-field="ddt.date"></div>
+                        <div class="signature" t-field="ddt.date" t-field-options='{"widget": "date"}'></div>
                     </td>
                     <td>
                         <h6>Pick up time</h6>


### PR DESCRIPTION
To avoid print useless time part of field 'Date' in the ddt report.