### PR TITLE
[10.0] FIX l10n_it_fatturapa_in when writing attachment name without file

### DIFF
--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Fattura Elettronica - Reception',
-    'version': '10.0.1.2.1',
+    'version': '10.0.1.2.2',
     'category': 'Localization/Italy',
     'summary': 'Electronic invoices reception',
     'author': 'Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa_in/views/account_view.xml
+++ b/l10n_it_fatturapa_in/views/account_view.xml
@@ -11,7 +11,7 @@
                         <group>
                             <field filename="datas_fname" name="datas"></field>
                             <field name="datas_fname" invisible="1"></field>
-                            <field name="name"></field>
+                            <field name="name" invisible="1"></field>
                         </group>
                         <group>
                             <field name="xml_supplier_id"/>


### PR DESCRIPTION
Steps:

1 - Accounting → Purchases → Incoming E-Bill Files
2 - Click on Create
3 - Fill in Attachment Name
4 - Click Save

File "/home/odoo/build/OCA/l10n-italy/l10n_it_fatturapa/models/ir_attachment.py", line 117, in get_xml_string
if fatturapa_attachment.datas_fname.lower().endswith('.p7m'):
AttributeError: 'bool' object has no attribute 'lower'