### PR TITLE
[10.0][FIX] l10n_it_fatturapa_out: Error sting encoding

### DIFF
--- a/l10n_it_fatturapa_out/__manifest__.py
+++ b/l10n_it_fatturapa_out/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura Elettronica - Emissione',
-    'version': '10.0.1.2.3',
+    'version': '10.0.1.2.4',
     'category': 'Localization/Italy',
     'summary': 'Emissione fatture elettroniche',
     'author': 'Davide Corio, Agile Business Group, Innoviu,'

--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -207,7 +207,7 @@ class WizardExportFatturapa(models.TransientModel):
             raise UserError(_(
                 'Fiscal position for electronic invoice not set '
                 'for company %s. '
-                '(Go to Accounting →  Configuration →  Settings →  '
+                '(Go to Accounting / Configuration / Settings / '
                 'Electronic Invoice)' % company.name
             ))
         CedentePrestatore.DatiAnagrafici.IdFiscaleIVA = IdFiscaleType(


### PR DESCRIPTION
Steps to reproduce:
0. Create an empty DB (no demo data) and install l10n_it_fatturapa_out
1. In the company, set VAT and phone number
2. Create a customer invoice for a newly created _customer_ and a newly created _product_
3. From context menu, select _Export Electronic Invoice_ and confirm

Behavior before this PR:
<details>
<summary>Error</summary>

```
2018-12-06 14:08:17,125 15207 ERROR odoo10-9321 odoo.http: Exception during JSON request handling.
Traceback (most recent call last):
  File "/home/user/work/odoo10/odoo/odoo/http.py", line 642, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/user/work/odoo10/odoo/odoo/http.py", line 684, in dispatch
    result = self._call_function(**self.params)
  File "/home/user/work/odoo10/odoo/odoo/http.py", line 334, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/home/user/work/odoo10/odoo/odoo/service/model.py", line 101, in wrapper
    return f(dbname, *args, **kwargs)
  File "/home/user/work/odoo10/odoo/odoo/http.py", line 327, in checked_call
    result = self.endpoint(*a, **kw)
  File "/home/user/work/odoo10/odoo/odoo/http.py", line 942, in __call__
    return self.method(*args, **kw)
  File "/home/user/work/odoo10/odoo/odoo/http.py", line 507, in response_wrap
    response = f(*args, **kw)
  File "/home/user/work/odoo10/odoo/addons/web/controllers/main.py", line 899, in call_button
    action = self._call_kw(model, method, args, {})
  File "/home/user/work/odoo10/odoo/addons/web/controllers/main.py", line 887, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/user/work/odoo10/odoo/odoo/api.py", line 689, in call_kw
    return call_kw_multi(method, model, args, kwargs)
  File "/home/user/work/odoo10/odoo/odoo/api.py", line 680, in call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/user/work/odoo10/l10n-italy/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py", line 784, in exportFatturaPA
    company, partner, fatturapa)
  File "/home/user/work/odoo10/l10n-italy/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py", line 726, in setFatturaElettronicaHeader
    self.setCedentePrestatore(company, fatturapa)
  File "/home/user/work/odoo10/l10n-italy/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py", line 320, in setCedentePrestatore
    company)
  File "/home/user/work/odoo10/l10n-italy/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py", line 211, in _setDatiAnagraficiCedente
    'Electronic Invoice)' % company.name
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 22: ordinal not in range(128)
```
</details>

Behavior after this PR:
Error popup (expected): 

_Fiscal position for electronic invoice not set for company My Company. (Go to Accounting / Configuration / Settings / Electronic Invoice)_