### PR TITLE
[11.0] ADD TD20 doc type - set default document type in invoice

### DIFF
--- a/l10n_it_fiscal_document_type/__manifest__.py
+++ b/l10n_it_fiscal_document_type/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Italian Localization - '
             'Tipi di documento fiscale per dichiarativi',
-    'version': '11.0.1.1.1',
+    'version': '11.0.1.1.2',
     'category': 'Localisation/Italy',
     'author': "Link It srl, Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/l10n-italy/tree/11.0/'

--- a/l10n_it_fiscal_document_type/data/fiscal.document.type.csv
+++ b/l10n_it_fiscal_document_type/data/fiscal.document.type.csv
@@ -11,3 +11,4 @@ id,code,name,out_invoice,in_invoice,out_refund,in_refund,priority
 6,TD10,fattura di acquisto intracomunitario beni,False,True,False,False,3
 7,TD11,fattura di acquisto intracomunitario servizi,False,True,False,False,3
 8,TD12,documento riepilogativo,False,True,False,False,3
+13,TD20,autofattura,True,False,False,False,3

--- a/l10n_it_fiscal_document_type/models/account_invoice.py
+++ b/l10n_it_fiscal_document_type/models/account_invoice.py
@@ -12,6 +12,19 @@ class AccountInvoice(models.Model):
         if len(dt) == 1:
             self.fiscal_document_type_id = dt[0]
 
+    @api.model
+    def create(self, vals):
+        invoice = super().create(vals)
+        if not invoice.fiscal_document_type_id:
+            dt = self._get_document_fiscal_type(
+                invoice.type, invoice.partner_id,
+                invoice.fiscal_position_id,
+                invoice.journal_id)
+            if dt:
+                invoice.fiscal_document_type_id = dt[0]
+
+        return invoice
+
     def _get_document_fiscal_type(self, type=None, partner=None,
                                   fiscal_position=None, journal=None):
         dt = []

--- a/l10n_it_fiscal_document_type/tests/test_doc_type.py
+++ b/l10n_it_fiscal_document_type/tests/test_doc_type.py
@@ -22,3 +22,8 @@ class TestDocType(TransactionCase):
         })
         invoice._set_document_fiscal_type()
         self.assertEqual(invoice.fiscal_document_type_id.id, self.TD01.id)
+
+        invoice2 = self.inv_model.create({
+            'partner_id': self.partner3.id
+        })
+        self.assertEqual(invoice2.fiscal_document_type_id.id, self.TD01.id)


### PR DESCRIPTION
IMP l10n_it_fiscal_document_type to be sure that doc type is always set