### PR TITLE
[10.0][UPD] removed constraint of empty fiscal code for electronic invoice …

### DIFF
--- a/l10n_it_fatturapa/models/partner.py
+++ b/l10n_it_fatturapa/models/partner.py
@@ -79,7 +79,7 @@ class ResPartner(models.Model):
                         "Partner %s Addressee Code "
                         "must be 7 characters long."
                     ) % partner.name)
-                if not partner.vat and not partner.fiscalcode:
+                if not partner.vat and not partner.fiscalcode and partner.codice_destinatario != 'XXXXXXX':
                     raise ValidationError(_(
                         "Partner %s must have VAT Number or Fiscal Code."
                     ) % partner.name)

--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -342,7 +342,7 @@ class WizardExportFatturapa(models.TransientModel):
     def _setDatiAnagraficiCessionario(self, partner, fatturapa):
         fatturapa.FatturaElettronicaHeader.CessionarioCommittente.\
             DatiAnagrafici = DatiAnagraficiCessionarioType()
-        if not partner.vat and not partner.fiscalcode:
+        if not partner.vat and not partner.fiscalcode and partner.codice_destinatario != 'XXXXXXX':
             raise UserError(
                 _('VAT number and fiscal code are not set for %s.') %
                 partner.name)


### PR DESCRIPTION
…when customer is a foreign customer without it.

Fiscal code for recipient is not mandatory for foreign customers without it. So when you use the seven "X" code, constraint on fiscal code field will not raise error message anymore.