### PR TITLE
[8.0][FIX] If there are characters '\t' (tab) or '\r' (cr) on description of invoice li…

### DIFF
--- a/l10n_it_fatturapa_out/__openerp__.py
+++ b/l10n_it_fatturapa_out/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Fattura Elettronica - Emission',
-    'version': '8.0.3.1.0',
+    'version': '8.0.3.1.1',
     'category': 'Localization/Italy',
     'summary': 'Electronic invoices emission',
     'author': 'Davide Corio, Agile Business Group, Innoviu,'

--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -600,7 +600,8 @@ class WizardExportFatturapa(models.TransientModel):
                 # see https://tinyurl.com/ycem923t
                 # and '&#10;' would not be correctly visualized anyway
                 # (for example firefox replaces '&#10;' with space
-                Descrizione=line.name.replace('\n', ' ').encode(
+                Descrizione=line.name.replace('\n', ' ').replace
+                ('\t', ' ').replace('\r', ' ').encode(
                     'latin', 'ignore').decode('latin'),
                 PrezzoUnitario=('%.' + str(
                     price_precision


### PR DESCRIPTION
…ne, the invoice can't be exported. With this fix the problem.