### PR TITLE
[8.0][FIX] l10n_it_fatturapa_pec: Fetchmail errors

### DIFF
--- a/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
+++ b/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
@@ -118,16 +118,14 @@ class FatturaPAAttachmentOut(models.Model):
         message_dict['res_id'] = 0
 
         regex = re.compile(RESPONSE_MAIL_REGEX)
-        attachments = [x for x in message_dict['attachments']
-                       if regex.match(x.fname)]
-
-        for attachment in attachments:
-            response_name = attachment.fname
+        message_attachments = message_dict['attachments']
+        attachments = [x for x in message_attachments if regex.match(x[0])]
+        for response_name, content in attachments:
             message_type = response_name.split('_')[2]
-            if attachment.fname.lower().endswith('.zip'):
+            if response_name.lower().endswith('.zip'):
                 # not implemented, case of AT, todo
                 continue
-            root = etree.fromstring(attachment.content)
+            root = etree.fromstring(content)
             file_name = root.find('NomeFile')
             fatturapa_attachment_out = False
 

--- a/l10n_it_fatturapa_pec/models/mail_thread.py
+++ b/l10n_it_fatturapa_pec/models/mail_thread.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Author(s): Andrea Colangelo (andreacolangelo@openforce.it)
 # Copyright 2018 Openforce Srls Unipersonale (www.openforce.it)
-# Copyright 2018 Sergio Corato (https://efatto.it)
+# Copyright 2018 Sergio Corato (https://efatto.it)ftpa_out_cls
 # Copyright 2018 Lorenzo Battistini <https://github.com/eLBati>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
@@ -85,9 +85,9 @@ class MailThread(models.AbstractModel):
 
             else:
                 # this is an SDI notification
-                ftpa_out_cls = self.env['fatturapa.attachment.out']
-                message_dict = ftpa_out_cls.parse_pec_response(message_dict)
-
+                message_dict = self.env['fatturapa.attachment.out']\
+                    .parse_pec_response(message_dict)
+                
                 message_dict['record_name'] = message_dict['subject']
 
                 attachment_ids = self._message_preprocess_attachments(

--- a/l10n_it_fatturapa_pec/models/mail_thread.py
+++ b/l10n_it_fatturapa_pec/models/mail_thread.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Author(s): Andrea Colangelo (andreacolangelo@openforce.it)
 # Copyright 2018 Openforce Srls Unipersonale (www.openforce.it)
-# Copyright 2018 Sergio Corato (https://efatto.it)ftpa_out_cls
+# Copyright 2018 Sergio Corato (https://efatto.it)
 # Copyright 2018 Lorenzo Battistini <https://github.com/eLBati>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 

--- a/l10n_it_fatturapa_pec/models/mail_thread.py
+++ b/l10n_it_fatturapa_pec/models/mail_thread.py
@@ -33,7 +33,7 @@ class MailThread(models.AbstractModel):
     def message_route(self, message, message_dict, model=None, thread_id=None,
                       custom_values=None):
 
-        mail_cls = self.env['mail.message'].with_context(
+        mail_model = self.env['mail.message'].with_context(
             message_create_from_mail_mail=True)
 
         if any("@pec.fatturapa.it" in x for x in [
@@ -78,7 +78,7 @@ class MailThread(models.AbstractModel):
 
                 # message_create_from_mail_mail to avoid to notify message
                 # (see mail.message.create)
-                mail_cls.create(message_dict)
+                mail_model.create(message_dict)
                 _logger.info('Routing FatturaPA PEC E-Mail with Message-Id: {}'
                              .format(message.get('Message-Id')))
                 return []
@@ -99,7 +99,7 @@ class MailThread(models.AbstractModel):
 
                 # message_create_from_mail_mail to avoid to notify message
                 # (see mail.message.create)
-                mail_cls.create(message_dict)
+                mail_model.create(message_dict)
                 _logger.info('Routing FatturaPA PEC E-Mail with Message-Id: {}'
                              .format(message.get('Message-Id')))
                 return []
@@ -113,7 +113,7 @@ class MailThread(models.AbstractModel):
                     message_dict['model'] = 'fatturapa.attachment.out'
                     message_dict['res_id'] = att.id
                     self.clean_message_dict(message_dict)
-                    mail_cls.create(message_dict)
+                    mail_model.create(message_dict)
                 else:
                     _logger.error('Can\'t route PEC E-Mail with Message-Id: {}'
                                   .format(message.get('Message-Id')))

--- a/l10n_it_fatturapa_pec/models/mail_thread.py
+++ b/l10n_it_fatturapa_pec/models/mail_thread.py
@@ -87,7 +87,7 @@ class MailThread(models.AbstractModel):
                 # this is an SDI notification
                 message_dict = self.env['fatturapa.attachment.out']\
                     .parse_pec_response(message_dict)
-                
+
                 message_dict['record_name'] = message_dict['subject']
 
                 attachment_ids = self._message_preprocess_attachments(


### PR DESCRIPTION
 [FIX] resolved AttributeError: 'tuple' object has no attribute 'fname'  when filtering message_dict['attachments'] via regex expression

 [FIX] _message_post_process_attachments is not defined in odoo 8.0.
         In order to create the attachment, should be used _message_preprocess_attachments method instead.