### PR TITLE
[12.0] [FIX] workaround for openssl signature verification failure

### DIFF
--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Base',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'category': 'Localization/Italy',
     'summary': 'Fatture elettroniche',
     'author': 'Davide Corio, Agile Business Group, Innoviu, '


### PR DESCRIPTION
Workaround for a (likely) openssl bug (v.1.1.0x).
Some signed .xml.p7m files, coming from Exchange System channel (SdI), are correctly decrypted but openssl gives an error in signature verification like the following one:

140093892985280:error:04091068:rsa routines:int_rsa_verify:bad signature:../crypto/rsa/rsa_sign.c:220:
140093892985280:error:21071069:PKCS7 routines:PKCS7_signatureVerify:signature failure:../crypto/pkcs7/pk7_doit.c:1035:
140093892985280:error:21075069:PKCS7 routines:PKCS7_verify:signature failure:../crypto/pkcs7/pk7_smime.c:353:

Tested versions:
1.0.1t-1+deb8u8    - Debian 8     - OK  
1.0.2g-1ubuntu4.14 - Ubuntu 16.04 - OK
1.1.0f-3+deb9u2    - Debian 9     - affected
1.1.0g-2ubuntu4.3  - Ubuntu 18.04 - affected

It's quite urgent, it prevents Odoo from loading some xml signed files as well as importing them as invoices.


Depends on #755