### PR TITLE
[10.0] FIX l10n_it_fatturapa allowing to import XML elements with blank spaces, as already done for String*LatinType

### DIFF
--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Base',
-    'version': '10.0.2.3.3',
+    'version': '10.0.2.3.4',
     'category': 'Localization/Italy',
     'summary': 'Fatture elettroniche',
     'author': 'Davide Corio, Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa/bindings/fatturapa_v_1_2.py
+++ b/l10n_it_fatturapa/bindings/fatturapa_v_1_2.py
@@ -1153,7 +1153,7 @@ class String10Type (pyxb.binding.datatypes.normalizedString):
         2)
     _Documentation = None
 String10Type._CF_pattern = pyxb.binding.facets.CF_pattern()
-String10Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,10})')
+String10Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{0,10})')
 String10Type._InitializeFacetMap(String10Type._CF_pattern)
 Namespace.addCategoryObject('typeBinding', 'String10Type', String10Type)
 _module_typeBindings.String10Type = String10Type
@@ -1175,7 +1175,7 @@ class String15Type (pyxb.binding.datatypes.normalizedString):
         2)
     _Documentation = None
 String15Type._CF_pattern = pyxb.binding.facets.CF_pattern()
-String15Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,15})')
+String15Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{0,15})')
 String15Type._InitializeFacetMap(String15Type._CF_pattern)
 Namespace.addCategoryObject('typeBinding', 'String15Type', String15Type)
 _module_typeBindings.String15Type = String15Type
@@ -1197,7 +1197,7 @@ class String20Type (pyxb.binding.datatypes.normalizedString):
         2)
     _Documentation = None
 String20Type._CF_pattern = pyxb.binding.facets.CF_pattern()
-String20Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,20})')
+String20Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{0,20})')
 String20Type._InitializeFacetMap(String20Type._CF_pattern)
 Namespace.addCategoryObject('typeBinding', 'String20Type', String20Type)
 _module_typeBindings.String20Type = String20Type
@@ -1219,7 +1219,7 @@ class String35Type (pyxb.binding.datatypes.normalizedString):
         2)
     _Documentation = None
 String35Type._CF_pattern = pyxb.binding.facets.CF_pattern()
-String35Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,35})')
+String35Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{0,35})')
 String35Type._InitializeFacetMap(String35Type._CF_pattern)
 Namespace.addCategoryObject('typeBinding', 'String35Type', String35Type)
 _module_typeBindings.String35Type = String35Type
@@ -1241,7 +1241,7 @@ class String60Type (pyxb.binding.datatypes.normalizedString):
         2)
     _Documentation = None
 String60Type._CF_pattern = pyxb.binding.facets.CF_pattern()
-String60Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,60})')
+String60Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{0,60})')
 String60Type._InitializeFacetMap(String60Type._CF_pattern)
 Namespace.addCategoryObject('typeBinding', 'String60Type', String60Type)
 _module_typeBindings.String60Type = String60Type
@@ -1263,7 +1263,7 @@ class String80Type (pyxb.binding.datatypes.normalizedString):
         2)
     _Documentation = None
 String80Type._CF_pattern = pyxb.binding.facets.CF_pattern()
-String80Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,80})')
+String80Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{0,80})')
 String80Type._InitializeFacetMap(String80Type._CF_pattern)
 Namespace.addCategoryObject('typeBinding', 'String80Type', String80Type)
 _module_typeBindings.String80Type = String80Type
@@ -1285,7 +1285,7 @@ class String100Type (pyxb.binding.datatypes.normalizedString):
         2)
     _Documentation = None
 String100Type._CF_pattern = pyxb.binding.facets.CF_pattern()
-String100Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,100})')
+String100Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{0,100})')
 String100Type._InitializeFacetMap(String100Type._CF_pattern)
 Namespace.addCategoryObject('typeBinding', 'String100Type', String100Type)
 _module_typeBindings.String100Type = String100Type


### PR DESCRIPTION
Strings of blank spaces are allowed by SDI.
{1,60} would produce
SimpleFacetValueError: Type
{http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2}
String60Type pattern constraint violated by value

v12: https://github.com/OCA/l10n-italy/pull/815