### PR TITLE
[10.0] FIX l10n_it_account_stamp: recompute taxes when adding stamp to lines

### DIFF
--- a/l10n_it_account_stamp/__manifest__.py
+++ b/l10n_it_account_stamp/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Tax Stamp',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Localization/Italy',
     'summary': 'Tax stamp automatic management',
     'author': 'Ermanno Gnan, Sergio Corato, Enrico Ganzaroli, '

--- a/l10n_it_account_stamp/models/invoice.py
+++ b/l10n_it_account_stamp/models/invoice.py
@@ -69,6 +69,7 @@ class AccountInvoice(models.Model):
                     (6, 0, stamp_product_id.taxes_id.ids)],
                 'account_analytic_id': None,
             })
+            inv.compute_taxes()
 
     def is_tax_stamp_line_present(self):
         for l in self.invoice_line_ids:


### PR DESCRIPTION
This is needed as stamp line should be under VAT exemption

v12: https://github.com/OCA/l10n-italy/pull/818