### PR TITLE
[8.0][IMP] update fatturapa_out version

### DIFF
--- a/l10n_it_fatturapa_out/__openerp__.py
+++ b/l10n_it_fatturapa_out/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Fattura Elettronica - Emission',
-    'version': '8.0.1.2.4',
+    'version': '8.0.3.0.0',
     'category': 'Localization/Italy',
     'summary': 'Electronic invoices emission',
     'author': 'Davide Corio, Agile Business Group, Innoviu,'


### PR DESCRIPTION
This https://github.com/OCA/l10n-italy/commit/57c8bfdeb39106b2c90f5b0b5d44ab2847db4b07#diff-38398b63046830d1d3dec4b6921cd662 caused some pypi builds with version 10.0.2.0.0 that are actually older than the current version.