### PR TITLE
[8.0] Set reply_to and Return-Path to build explicitly email message, witho…

### DIFF
--- a/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
+++ b/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
@@ -26,9 +26,10 @@ class FatturaPAAttachmentOut(models.Model):
     state = fields.Selection([('ready', 'Ready to Send'),
                               ('sent', 'Sent'),
                               ('sender_error', 'Sender Error'),
-                              ('recipient_error', 'Recipient Error'),
+                              ('recipient_error', 'Not delivered'),
                               ('rejected', 'Rejected (PA)'),
                               ('validated', 'Delivered'),
+                              ('accepted', 'Accepted'),
                               ],
                              string='State',
                              default='ready',)
@@ -36,22 +37,37 @@ class FatturaPAAttachmentOut(models.Model):
     last_sdi_response = fields.Text(
         string='Last Response from Exchange System', default='No response yet',
         readonly=True)
-    sending_date = fields.Datetime("Sent date", readonly=True)
-    delivered_date = fields.Datetime("Delivered date", readonly=True)
-    sending_user = fields.Many2one("res.users", "Sending user", readonly=True)
+    sending_date = fields.Datetime("Sent Date", readonly=True)
+    delivered_date = fields.Datetime("Delivered Date", readonly=True)
+    sending_user = fields.Many2one("res.users", "Sending User", readonly=True)
 
     @api.multi
     def reset_to_ready(self):
         for att in self:
             if att.state != 'sender_error':
-                raise UserError(_("Yo can only reset 'sender error' files"))
+                raise UserError(
+                    _("You can only reset files in 'Sender Error' state.")
+                )
             att.state = 'ready'
+
+    @api.model
+    def _check_fetchmail(self):
+        server = self.env['fetchmail.server'].search([
+            ('is_fatturapa_pec', '=', True),
+            ('state', '=', 'done')
+        ])
+        if not server:
+            raise UserError(_(
+                "No incoming PEC server found. Please configure it."))
 
     @api.multi
     def send_via_pec(self):
+        self._check_fetchmail()
         states = self.mapped('state')
         if set(states) != set(['ready']):
-            raise UserError(_("You can only send 'ready to send' files"))
+            raise UserError(
+                _("You can only send files in 'Ready to Send' state.")
+            )
         for att in self:
             mail_message = self.env['mail.message'].create({
                 'model': self._name,
@@ -65,6 +81,8 @@ class FatturaPAAttachmentOut(models.Model):
                 'attachment_ids': [(6, 0, att.ir_attachment_id.ids)],
                 'email_from': (
                     self.env.user.company_id.email_from_for_fatturaPA),
+                'reply_to': (
+                    self.env.user.company_id.email_from_for_fatturaPA),
                 'mail_server_id': self.env.user.company_id.sdi_channel_id.
                 pec_server_id.id,
             })
@@ -72,27 +90,13 @@ class FatturaPAAttachmentOut(models.Model):
                 'mail_message_id': mail_message.id,
                 'body_html': mail_message.body,
                 'email_to': self.env.user.company_id.email_exchange_system,
+                'headers': {
+                    'Return-Path':
+                    self.env.user.company_id.email_from_for_fatturaPA
+                }
             })
 
             if mail:
-                    config_parameter = self.env['ir.config_parameter'].sudo()
-                    bounce_alias = config_parameter.get_param(
-                        "mail.bounce.alias")
-                    catchall_domain = config_parameter.get_param(
-                        "mail.catchall.domain")
-                    catchall_alias = config_parameter.get_param(
-                        "mail.catchall.alias")
-                    # temporary disable email parameters incompatible with PEC
-                    if bounce_alias:
-                        config_parameter.set_param(
-                            'mail.bounce.alias', 'False')
-                    if catchall_domain:
-                        config_parameter.set_param(
-                            'mail.catchall.domain', 'False')
-                    if catchall_alias:
-                        config_parameter.set_param(
-                            'mail.catchall.alias', 'False')
-
                     try:
                         mail.send(raise_exception=True)
                         att.state = 'sent'
@@ -101,16 +105,6 @@ class FatturaPAAttachmentOut(models.Model):
                     except MailDeliveryException as e:
                         att.state = 'sender_error'
                         mail.body = e[1]
-
-                    if bounce_alias:
-                        config_parameter.set_param(
-                            'mail.bounce.alias', bounce_alias)
-                    if catchall_domain:
-                        config_parameter.set_param(
-                            'mail.catchall.domain', catchall_domain)
-                    if catchall_alias:
-                        config_parameter.set_param(
-                            'mail.catchall.alias', catchall_alias)
 
     @api.multi
     def parse_pec_response(self, message_dict):
@@ -231,7 +225,7 @@ class FatturaPAAttachmentOut(models.Model):
                     description = root.find('Descrizione')
                     if description is not None:
                         fatturapa_attachment_out.write({
-                            'state': 'validated',
+                            'state': 'accepted',
                             'last_sdi_response': (
                                 u'SdI ID: {}; Message ID: {}; '
                                 u'Receipt date: {};'
@@ -249,6 +243,6 @@ class FatturaPAAttachmentOut(models.Model):
         for att in self:
             if att.state != 'ready':
                 raise UserError(_(
-                    "You can only delete 'ready to send' files"
+                    "You can only delete files in 'Ready to Send' state."
                 ))
         return super(FatturaPAAttachmentOut, self).unlink()


### PR DESCRIPTION
…ut using mail.catchall parameters anyway, using always 'email_from_for_fatturaPA' (#695)

FIX missing body_html