### PR TITLE
[12.0] REF l10n_it_fatturapa_in for cases of partners (contacts) with wrong fiscal code (=TIN)

### DIFF
--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.1.1',
     "development_status": "Beta",
     'category': 'Localization/Italy',
     'summary': 'Ricezione fatture elettroniche',


### PR DESCRIPTION
First search by VAT number, otherwise by fiscal code.
Correctly check commercial partner