### PR TITLE
[10.0][IMP][l10n_it_fatturapa_out] Do not export descriptive invoice lines

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -592,7 +592,7 @@ class WizardExportFatturapa(models.TransientModel):
             'Product Unit of Measure')
         if uom_precision < 2:
             uom_precision = 2
-        for line in invoice.invoice_line_ids:
+        for line in self.getAccountInvoiceLines(invoice):
             if not line.invoice_line_tax_ids:
                 raise UserError(
                     _("Invoice line %s does not have tax.") % line.name)
@@ -655,6 +655,12 @@ class WizardExportFatturapa(models.TransientModel):
             body.DatiBeniServizi.DettaglioLinee.append(DettaglioLinea)
 
         return True
+
+    def getAccountInvoiceLines(self, invoice):
+        lines = invoice.mapped('invoice_line_ids').filtered(lambda r: (
+                r.quantity != 0 and r.price_unit != 0 and
+                r.invoice_line_tax_ids))
+        return lines
 
     def setDatiRiepilogo(self, invoice, body):
         for tax_line in invoice.tax_line_ids:


### PR DESCRIPTION
Account invoice permit to have descriptive lines with quantity = 0, price_unit = 0 and no taxes specified.
This patch filter out such lines and avoid ADE to complain and report errors. 

As side effect this patch add an hook to permit module to extend or change the filtering logic.