### PR TITLE
FIX l10n_it_fatturapa: capture also stderr of openssl

### DIFF
--- a/l10n_it_fatturapa/models/ir_attachment.py
+++ b/l10n_it_fatturapa/models/ir_attachment.py
@@ -51,7 +51,8 @@ class Attachment(models.Model):
         ) % (pem_file, tmp_der_file)
         cmd = shlex.split(strcmd)
         try:
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
             stdoutdata, stderrdata = proc.communicate()
             if proc.wait() != 0:
                 _logger.warning(stdoutdata)
@@ -93,7 +94,8 @@ class Attachment(models.Model):
         ) % (signed_file, xml_file)
         cmd = shlex.split(strcmd)
         try:
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
             stdoutdata, stderrdata = proc.communicate()
             if proc.wait() != 0:
                 _logger.warning(stdoutdata)


### PR DESCRIPTION
nelle chiamate a openssl lo stderr viene ignorato e l'errore è sempre vuoto