### PR TITLE
[8.0][l10n_it_fatturapa] Fix einvoice extraction when the p7m file is alre…

### DIFF
--- a/l10n_it_fatturapa/models/ir_attachment.py
+++ b/l10n_it_fatturapa/models/ir_attachment.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import subprocess
 import logging
+import base64
 from io import BytesIO
 from openerp import models, api, fields
 from openerp.modules import get_module_resource
@@ -127,6 +128,12 @@ class Attachment(models.Model):
                 elem.text = elem.text.strip()
         return ET.tostring(root)
 
+    def isBase64(self, s):
+        try:
+            return base64.b64encode(base64.b64decode(s)) == s
+        except Exception:
+            return False
+
     def get_xml_string(self):
         fatturapa_attachment = self
         # decrypt  p7m file
@@ -136,7 +143,10 @@ class Attachment(models.Model):
             temp_der_file_name = (
                 '/tmp/%s_tmp' % fatturapa_attachment.datas_fname.lower())
             with open(temp_file_name, 'w') as p7m_file:
-                p7m_file.write(fatturapa_attachment.datas.decode('base64'))
+                txt = fatturapa_attachment.datas.decode('base64')
+                if self.isBase64(txt):
+                    txt = base64.b64decode(txt)
+                p7m_file.write(txt)
             xml_file_name = os.path.splitext(temp_file_name)[0]
 
             # check if temp_file_name is a PEM file


### PR DESCRIPTION
…ady base64 encoded. Odoo will base64 encode yet again when creating the attachment avoid to extract it
v12 #899 