### PR TITLE
[10.0] FIX import XML with invalid URI

### DIFF
--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Base',
-    'version': '10.0.2.3.2',
+    'version': '10.0.2.3.3',
     'category': 'Localization/Italy',
     'summary': 'Fatture elettroniche',
     'author': 'Davide Corio, Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa/models/ir_attachment.py
+++ b/l10n_it_fatturapa/models/ir_attachment.py
@@ -113,7 +113,14 @@ class Attachment(models.Model):
         return xml_file
 
     def remove_xades_sign(self, xml):
-        root = ET.XML(xml)
+        # Recovering parser is needed for files where strings like
+        # xmlns:ds="http://www.w3.org/2000/09/xmldsig#&quot;"
+        # are present: even if lxml raises
+        # {XMLSyntaxError}xmlns:ds:
+        # 'http://www.w3.org/2000/09/xmldsig#"' is not a valid URI
+        # such files are accepted by SDI
+        recovering_parser = ET.XMLParser(recover=True)
+        root = ET.XML(xml, parser=recovering_parser)
         for elem in root.iter('*'):
             if elem.tag.find('Signature') > -1:
                 elem.getparent().remove(elem)
@@ -121,7 +128,8 @@ class Attachment(models.Model):
         return ET.tostring(root)
 
     def strip_xml_content(self, xml):
-        root = ET.XML(xml)
+        recovering_parser = ET.XMLParser(recover=True)
+        root = ET.XML(xml, parser=recovering_parser)
         for elem in root.iter('*'):
             if elem.text is not None:
                 elem.text = elem.text.strip()
@@ -167,7 +175,8 @@ class Attachment(models.Model):
         xslt = ET.parse(xsl_path)
         xml_string = self.get_xml_string()
         xml_file = BytesIO(xml_string)
-        dom = ET.parse(xml_file)
+        recovering_parser = ET.XMLParser(recover=True)
+        dom = ET.parse(xml_file, parser=recovering_parser)
         transform = ET.XSLT(xslt)
         newdom = transform(dom)
         return ET.tostring(newdom, pretty_print=True)

--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '10.0.1.4.1',
+    'version': '10.0.1.4.2',
     'category': 'Localization/Italy',
     'summary': 'Ricezione fatture elettroniche',
     'author': 'Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<p:FatturaElettronica versione="FPA12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+<p:FatturaElettronica versione="FPA12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#&quot;"
 xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">


### PR DESCRIPTION
Recovering parser is needed for files where strings like
`xmlns:ds="http://www.w3.org/2000/09/xmldsig#&quot;"`
are present: even if lxml raises
`{XMLSyntaxError}xmlns:ds: 'http://www.w3.org/2000/09/xmldsig#"' is not a valid URI`
such files are accepted by SDI

Fixes https://github.com/OCA/l10n-italy/issues/905
Fixes https://github.com/OCA/l10n-italy/issues/902

v11: https://github.com/OCA/l10n-italy/pull/910
v12: https://github.com/OCA/l10n-italy/pull/911