### PR TITLE
[11.0] FIX import XML with invalid URI

### DIFF
--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Italian Localization - Fattura Elettronica - Base',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Localization/Italy',
     'summary': 'Electronic invoices',
     'author': 'Davide Corio, Agile Business Group, Innoviu, '


### PR DESCRIPTION
Recovering parser is needed for files where strings like
xmlns:ds="http://www.w3.org/2000/09/xmldsig#&quot;"
are present: even if lxml raises
{XMLSyntaxError}xmlns:ds: 'http://www.w3.org/2000/09/xmldsig#"' is not a valid URI
such files are accepted by SDI