### PR TITLE
[10.0][l10n_it_ricevute_bancarie] Add support to setup RiBa payment result …

### DIFF
--- a/l10n_it_ricevute_bancarie/__manifest__.py
+++ b/l10n_it_ricevute_bancarie/__manifest__.py
@@ -9,7 +9,7 @@
 
 {
     'name': "Ricevute Bancarie",
-    'version': "10.0.1.2.0",
+    'version': "10.0.1.3.0",
     'author': "Odoo Community Association (OCA)",
     'category': "Accounting & Finance",
     'website': "https://odoo-community.org/",

--- a/l10n_it_ricevute_bancarie/models/account_config.py
+++ b/l10n_it_ricevute_bancarie/models/account_config.py
@@ -7,7 +7,7 @@
 # Copyright (C) 2012-2017 Lorenzo Battistini - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from openerp import models, fields, api
+from odoo import models, fields, api
 
 
 class AccountConfigSettings(models.TransientModel):
@@ -19,6 +19,14 @@ class AccountConfigSettings(models.TransientModel):
         help='Default Service for RiBa Due Cost (collection fees) on invoice',
         domain=[('type', '=', 'service')])
 
+    riba_payment_response = fields.Selection(
+        [('1', 'Required'),
+         ('2', 'Not Required'),
+         (' ', 'Bank Agreement')],
+        related='company_id.riba_payment_response',
+        default=' ',
+        string='Require to send back the response of the RiBa payment')
+
     @api.model
     def default_get(self, fields):
         res = super(AccountConfigSettings, self).default_get(fields)
@@ -26,6 +34,9 @@ class AccountConfigSettings(models.TransientModel):
             res[
                 'due_cost_service_id'
             ] = self.env.user.company_id.due_cost_service_id.id
+            res[
+                'riba_payment_response'
+            ] = self.env.user.company_id.riba_payment_response
         return res
 
 
@@ -34,3 +45,10 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     due_cost_service_id = fields.Many2one('product.product')
+
+    riba_payment_response = fields.Selection(
+        [('1', 'Required'),
+         ('2', 'Not Required'),
+         (' ', 'Bank Agreement')],
+        default=' ',
+        string='Require to send back the response of the RiBa payment')

--- a/l10n_it_ricevute_bancarie/views/account_config_view.xml
+++ b/l10n_it_ricevute_bancarie/views/account_config_view.xml
@@ -8,12 +8,19 @@
         <field name="inherit_id" ref="account.view_account_config_settings"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='bank_cash']" position="after">
-                <separator string="Ri.Ba. Due Cost Config"/>
+                <separator string="Ri.Ba. Config"/>
                 <group name="riba_config">
                     <label for="id" string="Due Cost Service"/>
                         <div>
                             <div>
                                 <field name="due_cost_service_id"
+                                       class="oe_inline"/>
+                            </div>
+                        </div>
+                    <label for="id" string="Payment Response"/>
+                        <div>
+                            <div>
+                                <field name="riba_payment_response"
                                        class="oe_inline"/>
                             </div>
                         </div>

--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
@@ -146,7 +146,9 @@ class RibaFileExport(models.TransientModel):
 
     def _Record70(self):
         return " 70" + str(self._progressivo).rjust(
-            7, '0') + " " * 110 + "\r\n"
+            7, '0') + " " * 91 + \
+            self.env.user.company_id.riba_payment_response + \
+            " " * 18 + "\r\n"
 
     def _RecordEF(self):  # record di coda
         return (


### PR DESCRIPTION
This patch add the possibility to specify the whether or not to receive payment result notification from the bank using the flag 'richiesta esito' on record 70 position 102. The default has been kept blank (==following the agreement with the bank)