### PR TITLE
[10.0][IMP] l10n_it_website_sale_fiscalcode: Show is_company in checkout

### DIFF
--- a/l10n_it_website_sale_fiscalcode/__manifest__.py
+++ b/l10n_it_website_sale_fiscalcode/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'e-commerce',
     'author': "Agile Business Group,"
               "Odoo Community Association (OCA)",
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.1.0',
     'license': 'LGPL-3',
     'website': 'http://www.agilebg.com',
     'depends': [

--- a/l10n_it_website_sale_fiscalcode/controllers/main.py
+++ b/l10n_it_website_sale_fiscalcode/controllers/main.py
@@ -10,13 +10,6 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 class WebsiteSaleFiscalCode(WebsiteSale):
 
-    def _get_mandatory_billing_fields(self):
-        res = super(
-            WebsiteSaleFiscalCode, self
-        )._get_mandatory_billing_fields()
-        res.append('fiscalcode')
-        return res
-
     def _checkout_form_save(self, mode, checkout, all_values):
         res = super(WebsiteSaleFiscalCode, self)._checkout_form_save(
             mode, checkout, all_values)

--- a/l10n_it_website_sale_fiscalcode/controllers/main.py
+++ b/l10n_it_website_sale_fiscalcode/controllers/main.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Nicola Malcontenti - Agile Business Group
+# Copyright 2019 Simone Rubino
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+from odoo import _
 from odoo.http import request
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 
@@ -18,7 +20,32 @@ class WebsiteSaleFiscalCode(WebsiteSale):
     def _checkout_form_save(self, mode, checkout, all_values):
         res = super(WebsiteSaleFiscalCode, self)._checkout_form_save(
             mode, checkout, all_values)
+        partner_values = dict()
+        # checkout contains some fields of the form
+        # (see WebsiteSale.values_postprocess).
+        # all_values instead contains all the values of the form.
+        # The fields in checkout have already been written in the partner
+        # by the super() call then we don't need to write them again.
         if 'fiscalcode' not in checkout and 'fiscalcode' in all_values:
-            request.env['res.partner'].browse(res).sudo().write(
-                {'fiscalcode': all_values['fiscalcode']})
+            partner_values['fiscalcode'] = all_values['fiscalcode']
+        if 'is_company' not in checkout and 'is_company' in all_values:
+            partner_values['is_company'] = all_values['is_company']
+            partner_values['individual'] = not all_values['is_company']
+        if partner_values:
+            request.env['res.partner'].browse(res).sudo().write(partner_values)
         return res
+
+    def checkout_form_validate(self, mode, all_form_values, data):
+        error, error_message = super(WebsiteSaleFiscalCode, self) \
+            .checkout_form_validate(mode, all_form_values, data)
+        data['individual'] = not data.get('is_company')
+        dummy_partner = request.env['res.partner'].new({
+            'fiscalcode': data.get('fiscalcode'),
+            'individual': data.get('individual'),
+            'is_company': data.get('is_company')
+        })
+        if not dummy_partner.check_fiscalcode():
+            error['fiscalcode'] = 'error'
+            error['is_company'] = 'error'
+            error_message.append(_('Fiscal Code not valid'))
+        return error, error_message

--- a/l10n_it_website_sale_fiscalcode/views/templates.xml
+++ b/l10n_it_website_sale_fiscalcode/views/templates.xml
@@ -1,14 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2017 Nicola Malcontenti - Agile Business Group
-     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
+     Copyright 2019 Simone Rubino
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 
 <odoo>
-<template id="l10n_it_website_sale_fiscalcode" inherit_id="website_sale.address">
-  <xpath expr="//div[@id='div_phone']" position="after">
-    <div t-attf-class="form-group #{error.get('fiscalcode') and 'has-error' or ''} col-md-6" id="div_fiscalcode">
-        <label class="control-label" for="fiscalcode">Fiscal Code</label>
-        <input name="fiscalcode" class="form-control" t-att-value="'fiscalcode' in checkout and checkout['fiscalcode']" />
-    </div>
-  </xpath>
-</template>
+    <template id="l10n_it_website_sale_fiscalcode" inherit_id="website_sale.address">
+        <xpath expr="//div[@id='div_phone']" position="after">
+            <t t-if="mode[1] == 'billing'">
+                <div t-attf-class="form-group #{error.get('is_company') and 'has-error' or ''} col-md-6" id="div_is_company">
+                    <label class="control-label">
+                        Are you acting on behalf of a company?
+                        <input type="checkbox" name="is_company" class="form-control"
+                               style="width: auto;"
+                               t-att-checked="'is_company' in checkout and bool(checkout['is_company'])"
+                               t-att-value="'is_company' in checkout and bool(checkout['is_company'])"/>
+                        <!-- Used to post company field even if it is False,
+                        see https://stackoverflow.com/questions/1809494/post-unchecked-html-checkboxes/1992745#1992745-->
+                        <input type="hidden" name="is_company" t-att-value="False"/>
+                    </label>
+                </div>
+            </t>
+            <div t-attf-class="form-group #{error.get('fiscalcode') and 'has-error' or ''} col-md-6" id="div_fiscalcode">
+                <label class="control-label" for="fiscalcode">Fiscal Code</label>
+                <input name="fiscalcode" class="form-control" t-att-value="'fiscalcode' in checkout and checkout['fiscalcode']"/>
+            </div>
+        </xpath>
+    </template>
 </odoo>

--- a/l10n_it_website_sale_fiscalcode/views/templates.xml
+++ b/l10n_it_website_sale_fiscalcode/views/templates.xml
@@ -8,7 +8,7 @@
         <xpath expr="//div[@id='div_phone']" position="after">
             <t t-if="mode[1] == 'billing'">
                 <div t-attf-class="form-group #{error.get('is_company') and 'has-error' or ''} col-md-6" id="div_is_company">
-                    <label class="control-label">
+                    <label class="control-label label-optional">
                         Are you acting on behalf of a company?
                         <input type="checkbox" name="is_company" class="form-control"
                                style="width: auto;"
@@ -21,7 +21,7 @@
                 </div>
             </t>
             <div t-attf-class="form-group #{error.get('fiscalcode') and 'has-error' or ''} col-md-6" id="div_fiscalcode">
-                <label class="control-label" for="fiscalcode">Fiscal Code</label>
+                <label class="control-label label-optional" for="fiscalcode">Fiscal Code</label>
                 <input name="fiscalcode" class="form-control" t-att-value="'fiscalcode' in checkout and checkout['fiscalcode']"/>
             </div>
         </xpath>


### PR DESCRIPTION
Applico quanto discusso in https://github.com/OCA/l10n-italy/pull/867:

- Codice fiscale non più obbligatorio nel checkout
- Campo `is_company` modificabile da checkout (visto che viene utilizzato per validare il codice fiscale)