### PR TITLE
[10.0] FIX l10n_it_fatturapa_pec when user removes file content and tries to send PEC

### DIFF
--- a/l10n_it_fatturapa_pec/__manifest__.py
+++ b/l10n_it_fatturapa_pec/__manifest__.py
@@ -7,7 +7,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     'name': 'Italian Localization - Fattura elettronica - Supporto PEC',
-    'version': '10.0.1.5.0',
+    'version': '10.0.1.5.1',
     'category': 'Localization/Italy',
     'summary': 'Invio fatture elettroniche tramite PEC',
     'author': 'Openforce Srls Unipersonale, Odoo Community Association (OCA)',

--- a/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
+++ b/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
@@ -69,6 +69,8 @@ class FatturaPAAttachmentOut(models.Model):
                 _("You can only send files in 'Ready to Send' state.")
             )
         for att in self:
+            if not att.datas or not att.datas_fname:
+                raise UserError(_("File content and file name are mandatory"))
             mail_message = self.env['mail.message'].create({
                 'model': self._name,
                 'res_id': att.id,

--- a/l10n_it_fatturapa_pec/tests/test_e_invoice_send.py
+++ b/l10n_it_fatturapa_pec/tests/test_e_invoice_send.py
@@ -29,6 +29,15 @@ class TestEInvoiceSend(EInvoiceCommon):
         e_invoice.send_via_pec()
         self.assertEqual(e_invoice.state, 'sent')
 
+    def test_send_empty_file(self):
+        """Sending e-invoice without file content must be blocked"""
+        e_invoice = self._create_e_invoice()
+
+        self._create_fetchmail_pec_server()
+        e_invoice.datas = False
+        with self.assertRaises(UserError):
+            e_invoice.send_via_pec()
+
     def test_wizard_send(self):
         """Sending e-invoice with wizard changes its state to 'sent'"""
         e_invoice = self._create_e_invoice()


### PR DESCRIPTION
Otherwise they would get
```
odoo/addons/mail/models/mail_mail.py", line 226, in send
    for a in mail.attachment_ids.sudo().read(['datas_fname', 'datas'])]
  File "/usr/lib/python2.7/base64.py", line 75, in b64decode
    return binascii.a2b_base64(s)
TypeError: a2b_base64() argument 1 must be string or buffer, not bool
```

TODO
v12: https://github.com/OCA/l10n-italy/pull/999