### PR TITLE
[10.0] Fix fatturapa ddt vuoti

### DIFF
--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -44,12 +44,22 @@
                         </group>
                     </group>
                 </page>
-                <page string="DDT Vuoti !"
-                    attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}">
+                <page string="DDT Vuoti" attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}">
                     <group>
-                        <group string="DDT Vuoti">
-                            <field name="fatturapa_attachment_out_id"></field>
-                        </group>
+                        <field name="ftpa_related_ddts" nolabel="1" >
+                            <tree string="DDTs">
+                                <field name="name"></field>
+                                <field name="date"></field>
+                            </tree>
+                            <form string="Attachments">
+                                <group>
+                                    <group>
+                                        <field name="name"></field>
+                                        <field name="date"></field>
+                                    </group>
+                                </group>
+                            </form>
+                        </field>
                     </group>
                 </page>
                 <page string="Electronic Invoice Attachments"

--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -44,6 +44,14 @@
                         </group>
                     </group>
                 </page>
+                <page string="DDT Vuoti !"
+                    attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}">
+                    <group>
+                        <group string="DDT Vuoti">
+                            <field name="fatturapa_attachment_out_id"></field>
+                        </group>
+                    </group>
+                </page>
                 <page string="Electronic Invoice Attachments"
                     attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}">
                     <group string="Attachments">

--- a/l10n_it_fatturapa_out_ddt/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out_ddt/wizard/wizard_export_fatturapa.py
@@ -41,7 +41,14 @@ class WizardExportFatturapa(models.TransientModel):
     def setDatiDDT(self, invoice, body):
         res = super(WizardExportFatturapa, self).setDatiDDT(
             invoice, body)
-        if self.include_ddt_data == 'dati_ddt':
+        if self.include_ddt_data == 'descrizione_ddt':
+            for ddt in invoice.ftpa_related_ddts:
+                DatiDDT = DatiDDTType(
+                    NumeroDDT=ddt.name,
+                    DataDDT=ddt.date
+                )
+                body.DatiGenerali.DatiDDT.append(DatiDDT)
+        elif  self.include_ddt_data == 'dati_ddt':
             inv_lines_by_ddt = {}
             for line in invoice.invoice_line_ids:
                 if (

--- a/l10n_it_fatturapa_out_ddt/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out_ddt/wizard/wizard_export_fatturapa.py
@@ -30,6 +30,7 @@ class WizardExportFatturapa(models.TransientModel):
     include_ddt_data = fields.Selection([
         ('dati_ddt', 'Include DDT Data'),
         ('dati_trasporto', 'Include transport data'),
+        ('descrizione_ddt', 'Includi DDT - Descrizione')
         ],
         string="DDT Data",
         help="Include DDT data: The field must be entered when a transport "


### PR DESCRIPTION
Il file xml 1.2 della fatturazione elettronica prevede 0 o illimitate righe .. 
Su branch 10 ,i dati dei ddt vengono riportati solamente se ci sono linee che collimano con la fattura. Nei casi reali di fattura differita si citano i ddt senza includere i dettagli 
