### PR TITLE
[12.0] FIX If there are characters '\t' (tab) on description of invoice line, the invoice can't be exported

### DIFF
--- a/l10n_it_fatturapa_out/__manifest__.py
+++ b/l10n_it_fatturapa_out/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Emissione',
-    'version': '12.0.1.0.3',
+    'version': '12.0.1.0.4',
     'development_status': 'Beta',
     'category': 'Localization/Italy',
     'summary': 'Emissione fatture elettroniche',

--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -639,8 +639,8 @@ class WizardExportFatturapa(models.TransientModel):
                 # see https://tinyurl.com/ycem923t
                 # and '&#10;' would not be correctly visualized anyway
                 # (for example firefox replaces '&#10;' with space)
-                Descrizione=line.name.replace('\n', ' ').encode(
-                    'latin', 'ignore').decode('latin'),
+                Descrizione=line.name.replace('\n', ' ').replace(
+                    '\t', ' ').encode('latin', 'ignore').decode('latin'),
                 PrezzoUnitario='{prezzo:.{precision}f}'.format(
                     prezzo=prezzo_unitario, precision=price_precision),
                 Quantita='{qta:.{precision}f}'.format(


### PR DESCRIPTION
From https://github.com/OCA/l10n-italy/pull/781