### PR TITLE
[10.0] FIX If there are characters '\t' (tab) on description of invoice line, the invoice can't be exported

### DIFF
--- a/l10n_it_fatturapa_out/__manifest__.py
+++ b/l10n_it_fatturapa_out/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Emissione',
-    'version': '10.0.1.3.2',
+    'version': '10.0.1.3.3',
     'category': 'Localization/Italy',
     'summary': 'Emissione fatture elettroniche',
     'author': 'Davide Corio, Agile Business Group, Innoviu,'

--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -645,8 +645,8 @@ class WizardExportFatturapa(models.TransientModel):
             # see https://tinyurl.com/ycem923t
             # and '&#10;' would not be correctly visualized anyway
             # (for example firefox replaces '&#10;' with space)
-            Descrizione=line.name.replace('\n', ' ').encode(
-                'latin', 'ignore').decode('latin'),
+            Descrizione=line.name.replace('\n', ' ').replace('\t', ' ').
+            replace('\r', ' ').encode('latin', 'ignore').decode('latin'),
             PrezzoUnitario=('%.' + str(
                 price_precision
             ) + 'f') % prezzo_unitario,


### PR DESCRIPTION
From https://github.com/OCA/l10n-italy/pull/781