### PR TITLE
[8.0] FIX l10n_it_fatturapa_pec when user removes file content and tries to…

### DIFF
--- a/l10n_it_fatturapa_pec/__openerp__.py
+++ b/l10n_it_fatturapa_pec/__openerp__.py
@@ -6,7 +6,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     'name': 'Italian Localization - Fattura elettronica - Supporto PEC',
-    'version': '8.0.1.3.1',
+    'version': '8.0.1.3.2',
     'category': 'Localization/Italy',
     'summary': 'Send electronic invoices via PEC',
     'author': 'Openforce Srls Unipersonale, Odoo Community Association (OCA)',

--- a/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
+++ b/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
@@ -69,6 +69,8 @@ class FatturaPAAttachmentOut(models.Model):
                 _("You can only send files in 'Ready to Send' state.")
             )
         for att in self:
+            if not att.datas or not att.datas_fname:
+                raise UserError(_("File content and file name are mandatory"))
             mail_message = self.env['mail.message'].create({
                 'model': self._name,
                 'res_id': att.id,


### PR DESCRIPTION
… send PEC

Otherwise they would get
odoo/addons/mail/models/mail_mail.py", line 226, in send
    for a in mail.attachment_ids.sudo().read(['datas_fname', 'datas'])]
  File "/usr/lib/python2.7/base64.py", line 75, in b64decode
    return binascii.a2b_base64(s)
TypeError: a2b_base64() argument 1 must be string or buffer, not bool

backport from v. 12 #999 