### PR TITLE
[12.0][l10n_it_fatturapa_in] Relax check on tax natura to permit to i…

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -278,16 +278,11 @@ class WizardImportFatturapa(models.TransientModel):
                     ('type_tax_use', '=', 'purchase'),
                     ('kind_id.code', '=', line.Natura),
                     ('amount', '=', 0.0),
-                ])
+                ], order='sequence', limit=1)
             if not account_taxes:
                 self.log_inconsistency(
                     _('No tax with percentage '
                       '%s and nature %s found. Please configure this tax.')
-                    % (line.AliquotaIVA, line.Natura))
-            if len(account_taxes) > 1:
-                self.log_inconsistency(
-                    _('Too many taxes with percentage '
-                      '%s and nature %s found.')
                     % (line.AliquotaIVA, line.Natura))
         else:
             account_taxes = account_tax_model.search(
@@ -297,8 +292,7 @@ class WizardImportFatturapa(models.TransientModel):
                     ('price_include', '=', False),
                     # partially deductible VAT must be set by user
                     ('children_tax_ids', '=', False),
-                ]
-            )
+                ], order='sequence')
             if not account_taxes:
                 self.log_inconsistency(
                     _(


### PR DESCRIPTION
@OCA/local-italy-developers

This PR relax a bit the tax checks against natura by choosing the first tax with the given natura ordered by sequence. It's a compromise to permit to import the e-invoice anyway and later change accordingly with the right tax code.

As suggested in #1042 this PR should be listed in #1048 