### PR TITLE
[FIX][11.0]l10n_it_fatturapa_in - dati cassa previdenziale

### DIFF
--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '11.0.1.0.2',
+    'version': '11.0.1.0.3',
     "development_status": "Beta",
     'category': 'Localization/Italy',
     'summary': 'Ricezione fatture elettroniche',

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -313,7 +313,7 @@ class WizardImportFatturapa(models.TransientModel):
                 _logger.warning(_(
                     "Line '%s': Too many taxes with percentage equals "
                     "to '%s'.\nFix it if required"
-                ) % (line.Descrizione, line.AliquotaIVA))
+                ) % (getattr('line', 'Descrizione', ''), line.AliquotaIVA))
                 # if there are multiple taxes with same percentage
                 # and there is a default tax with this percentage,
                 # set taxes list equal to supplier_taxes_id, loaded before


### PR DESCRIPTION
In caso di fattura con riga di tipo Cassa Previdenziale, e database con più imposte con la stessa aliquota.
```
  File "/usr/local/lib/python3.5/dist-packages/odoo/addons/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 316, in _prepare_generic_line_data
    ) % (line.Descrizione, line.AliquotaIVA))
AttributeError: 'DatiCassaPrevidenzialeType' object has no attribute 'Descrizione'
```