### PR TITLE
[10.0][FIX] l10n_it_reverse_charge: Assign RC flag when invoice line is created from PO

### DIFF
--- a/l10n_it_reverse_charge/__manifest__.py
+++ b/l10n_it_reverse_charge/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Reverse Charge IVA',
-    'version': '10.0.1.1.3',
+    'version': '10.0.1.1.4',
     'category': 'Localization/Italy',
     'summary': 'Reverse Charge for Italy',
     'author': 'Odoo Italia Network,Odoo Community Association (OCA)',

--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -46,6 +46,15 @@ class AccountInvoice(models.Model):
         for line in self.invoice_line_ids:
             line._set_rc_flag(self)
 
+    @api.onchange('partner_id', 'company_id')
+    def _onchange_partner_id(self):
+        res = super(AccountInvoice, self)._onchange_partner_id()
+        # In some cases (like creating the invoice from PO),
+        # fiscal position's onchange is triggered
+        # before than being changed by this method.
+        self.onchange_rc_fiscal_position_id()
+        return res
+
     def rc_inv_line_vals(self, line):
         return {
             'product_id': line.product_id.id,

--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -16,8 +16,9 @@ class AccountInvoiceLine(models.Model):
     @api.multi
     def _set_rc_flag(self, invoice):
         self.ensure_one()
-        fposition = invoice.fiscal_position_id
-        self.rc = bool(fposition.rc_type_id)
+        if invoice.type == 'in_invoice':
+            fposition = invoice.fiscal_position_id
+            self.rc = bool(fposition.rc_type_id)
 
     @api.onchange('invoice_line_tax_ids')
     def onchange_invoice_line_tax_id(self):

--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -26,6 +26,11 @@ class AccountInvoiceLine(models.Model):
 
     rc = fields.Boolean("RC")
 
+    def _set_additional_fields(self, invoice):
+        res = super(AccountInvoiceLine, self)._set_additional_fields(invoice)
+        self._set_rc_flag(invoice)
+        return res
+
 
 class AccountInvoice(models.Model):
     _inherit = 'account.invoice'


### PR DESCRIPTION
Steps to reproduce the issue:

0. Install Purchase
1. Set Reverse Charge type for a new fiscal position _fp_rc_
2. Assign _fp_rc_ to a new partner _partner_rc_
3. Create a new PO with one line for _partner_rc_, confirm, receive the products
4. Create a new vendor bill and add the created PO

Before this PR:
RC flag is not set in the line of the created invoice

After this PR:
RC flag is set in the line of the created invoice