### PR TITLE
[11.0][IMP][l10n_it_fatturapa_in] Format Italian VAT to always have 11 chars

### DIFF
--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '11.0.1.0.3',
+    'version': '11.0.1.1.1',
     "development_status": "Beta",
     'category': 'Localization/Italy',
     'summary': 'Ricezione fatture elettroniche',
@@ -18,7 +18,7 @@
     "depends": [
         'l10n_it_fatturapa',
         'l10n_it_withholding_tax_causali',
-        ],
+    ],
     "data": [
         'views/account_view.xml',
         'views/partner_view.xml',

--- a/l10n_it_fatturapa_in/tests/data/IT05979361218_011.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT05979361218_011.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:FatturaElettronica versione="FPA12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>05979361218</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>001</ProgressivoInvio>
+            <FormatoTrasmissione>FPA12</FormatoTrasmissione>
+            <CodiceDestinatario>UFPQ1O</CodiceDestinatario>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>05979361218</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>SOCIETA' ALPHA BETA SRL</Denominazione>
+                </Anagrafica>
+                <AlboProfessionale>Albo di test</AlboProfessionale>
+                <ProvinciaAlbo>TO</ProvinciaAlbo>
+                <NumeroIscrizioneAlbo>TO1258B</NumeroIscrizioneAlbo>
+                <DataIscrizioneAlbo>2010-01-16</DataIscrizioneAlbo>
+                <RegimeFiscale>RF02</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIALE ROMA 543B</Indirizzo>
+                <CAP>07100</CAP>
+                <Comune>SASSARI</Comune>
+                <Provincia>SS</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <CodiceFiscale>80213330584</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>AMMINISTRAZIONE BETA</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIA TORINO 38-B</Indirizzo>
+                <CAP>00145</CAP>
+                <Comune>ROMA</Comune>
+                <Provincia>RM</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+        <TerzoIntermediarioOSoggettoEmittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>3339130126</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>Rappresentante fiscale</Denominazione>
+                    <CodEORI>1234567890123</CodEORI>
+                </Anagrafica>
+            </DatiAnagrafici>
+        </TerzoIntermediarioOSoggettoEmittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2015-02-16</Data>
+                <Numero>FT/2015/0006</Numero>
+                <DatiCassaPrevidenziale>
+                    <TipoCassa>TC22</TipoCassa>
+                    <AlCassa>0.00</AlCassa>
+                    <ImportoContributoCassa>3.00</ImportoContributoCassa>
+                    <ImponibileCassa>3.00</ImponibileCassa>
+                    <AliquotaIVA>0.00</AliquotaIVA>
+                    <Natura>N4</Natura>
+                </DatiCassaPrevidenziale>
+                <Causale>Rif ordine MAPA: --- Nr. Identificativo Ordine 1234567</Causale>
+            </DatiGeneraliDocumento>
+            <DatiTrasporto>
+                <PesoLordo>0.00</PesoLordo>
+                <PesoNetto>0.00</PesoNetto>
+            </DatiTrasporto>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>Prodotto di test al giorno</Descrizione>
+                <Quantita>15.00</Quantita>
+                <UnitaMisura>Giorno(i)</UnitaMisura>
+                <PrezzoUnitario>3.60</PrezzoUnitario>
+                <PrezzoTotale>54.00</PrezzoTotale>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N4</Natura>
+                <AltriDatiGestionali>
+                    <TipoDato>Vostro RIF</TipoDato>
+                    <RiferimentoTesto>Riferimento</RiferimentoTesto>
+                    <RiferimentoNumero>3.00</RiferimentoNumero>
+                </AltriDatiGestionali>
+                <AltriDatiGestionali>
+                    <TipoDato>Vostro RIF</TipoDato>
+                    <RiferimentoTesto>Riferimento2</RiferimentoTesto>
+                </AltriDatiGestionali>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N4</Natura>
+                <ImponibileImporto>57.00</ImponibileImporto>
+                <Imposta>0.00</Imposta>
+                <RiferimentoNormativo>Operazioni senza addebito imposta regime contribuenti minimi art.27 c.1-2 DL.98/11</RiferimentoNormativo>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP01</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2015-03-18</DataScadenzaPagamento>
+                <ImportoPagamento>27.00</ImportoPagamento>
+            </DettaglioPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2015-04-17</DataScadenzaPagamento>
+                <ImportoPagamento>27.00</ImportoPagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -144,6 +144,12 @@ class TestFatturaPAXMLValidation(SingleTransactionCase):
         self.assertEqual(invoice.fiscal_document_type_id.code, 'TD01')
         self.assertTrue(invoice.art73)
 
+    def test_02_xml_import(self):
+        res = self.run_wizard('test02', 'IT05979361218_011.xml')
+        invoice_id = res.get('domain')[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertEqual(invoice.intermediary.vat, 'IT03339130126')
+
     def test_04_xml_import(self):
         res = self.run_wizard('test4', 'IT02780790107_11005.xml')
         invoice_id = res.get('domain')[0][2][0]
@@ -289,7 +295,7 @@ class TestFatturaPAXMLValidation(SingleTransactionCase):
         res = self.run_wizard_multi([
             'IT02780790107_11005.xml',
             'IT02780790107_11005.xml',
-            ])
+        ])
         invoice1_id = res.get('domain')[0][2][0]
         invoice2_id = res.get('domain')[0][2][1]
         invoice1 = self.invoice_model.browse(invoice1_id)


### PR DESCRIPTION
Ref: https://github.com/OCA/l10n-italy/issues/1067