### PR TITLE
[8.0][FIX] pass skip_update_line_ids in ctx

### DIFF
--- a/l10n_it_ddt/wizard/ddt_create_invoice.py
+++ b/l10n_it_ddt/wizard/ddt_create_invoice.py
@@ -97,6 +97,7 @@ class DdTCreateInvoice(models.TransientModel):
                 ctx['ddt_partner_id'] = partner_id
                 ctx['inv_type'] = 'out_invoice'
                 ctx['date_inv'] = self.date
+                ctx['skip_update_line_ids'] = True
                 picking_list = [p.picking_ids for p in ddt_partner[partner_id]]
                 for pll in picking_list:
                     for p in pll:


### PR DESCRIPTION
Risolve il problema della lentezza nella fatturazione di DDT, vedi thread `Performance DDT e scelta prodotti in Odoo10` nella mail italy@odoo-community.org, con questo fix il tempo si riduce drasticamente (senza è circa 5-6 secondi per riga :worried: )