### PR TITLE
[10.0][FIX][l10n_it_fatturapa_in] Set the supplier flag only where necessary

### DIFF
--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '10.0.1.6.1',
+    'version': '10.0.1.6.2',
     'category': 'Localization/Italy',
     'summary': 'Ricezione fatture elettroniche',
     'author': 'Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -105,7 +105,7 @@ class WizardImportFatturapa(models.TransientModel):
                 % (DatiAnagrafici.Anagrafica.Cognome, partner.lastname)
             )
 
-    def getPartnerBase(self, DatiAnagrafici):
+    def getPartnerBase(self, DatiAnagrafici, supplier=True):
         if not DatiAnagrafici:
             return False
         partner_model = self.env['res.partner']
@@ -159,7 +159,7 @@ class WizardImportFatturapa(models.TransientModel):
                 'vat': vat,
                 'fiscalcode': cf,
                 'customer': False,
-                'supplier': True,
+                'supplier': supplier,
                 'is_company': (
                     DatiAnagrafici.Anagrafica.Denominazione and True or False),
                 'eori_code': DatiAnagrafici.Anagrafica.CodEORI or '',
@@ -1227,7 +1227,7 @@ class WizardImportFatturapa(models.TransientModel):
                 self.set_StabileOrganizzazione(cedentePrestatore, invoice)
                 if TaxRappresentative:
                     tax_partner_id = self.getPartnerBase(
-                        TaxRappresentative.DatiAnagrafici)
+                        TaxRappresentative.DatiAnagrafici, supplier=False)
                     invoice.write(
                         {
                             'tax_representative_id': tax_partner_id
@@ -1235,7 +1235,7 @@ class WizardImportFatturapa(models.TransientModel):
                     )
                 if Intermediary:
                     Intermediary_id = self.getPartnerBase(
-                        Intermediary.DatiAnagrafici)
+                        Intermediary.DatiAnagrafici, supplier=False)
                     invoice.write(
                         {
                             'intermediary': Intermediary_id


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Quando si importa un fattura elettronica sia il rappresentate fiscale che l'eventuale intermediario vengono creati come fornitori se non presenti nel sistema.

Comportamento attuale prima di questa PR:

Rappresentanti fiscali e intermediari vengono creati come fornitori

Comportamento desiderato dopo questa PR:

I rappresentanti fiscali ed eventuali intemediari non sono fornitori di una azienda e pertanto la PR corrente non li imposta più come tali


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
