### PR TITLE
[12.0][FIX][l10n_it_fatturapa_in] Set the supplier flag only where necessary

### DIFF
--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '12.0.1.1.4',
+    'version': '12.0.1.1.5',
     "development_status": "Beta",
     'category': 'Localization/Italy',
     'summary': 'Ricezione fatture elettroniche',

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -104,7 +104,7 @@ class WizardImportFatturapa(models.TransientModel):
                 % (DatiAnagrafici.Anagrafica.Cognome, partner.lastname)
             )
 
-    def getPartnerBase(self, DatiAnagrafici):
+    def getPartnerBase(self, DatiAnagrafici, supplier=True):
         if not DatiAnagrafici:
             return False
         partner_model = self.env['res.partner']
@@ -159,7 +159,7 @@ class WizardImportFatturapa(models.TransientModel):
                 'vat': vat,
                 'fiscalcode': cf,
                 'customer': False,
-                'supplier': True,
+                'supplier': supplier,
                 'is_company': (
                     DatiAnagrafici.Anagrafica.Denominazione and True or False),
                 'eori_code': DatiAnagrafici.Anagrafica.CodEORI or '',
@@ -1206,7 +1206,7 @@ class WizardImportFatturapa(models.TransientModel):
                 self.set_StabileOrganizzazione(cedentePrestatore, invoice)
                 if TaxRappresentative:
                     tax_partner_id = self.getPartnerBase(
-                        TaxRappresentative.DatiAnagrafici)
+                        TaxRappresentative.DatiAnagrafici, supplier=False)
                     invoice.write(
                         {
                             'tax_representative_id': tax_partner_id
@@ -1214,7 +1214,7 @@ class WizardImportFatturapa(models.TransientModel):
                     )
                 if Intermediary:
                     Intermediary_id = self.getPartnerBase(
-                        Intermediary.DatiAnagrafici)
+                        Intermediary.DatiAnagrafici, supplier=False)
                     invoice.write(
                         {
                             'intermediary': Intermediary_id


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Quando si importa un fattura elettronica sia il rappresentate fiscale che l'eventuale intermediario vengono creati come fornitori se non presenti nel sistema.

Comportamento attuale prima di questa PR:

Rappresentanti fiscali e intermediari vengono creati come fornitori

Comportamento desiderato dopo questa PR:

I rappresentanti fiscali ed eventuali intemediari non sono fornitori di una azienda e pertanto la PR corrente non li imposta più come tali

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
