### PR TITLE
[11.0] IMP shipping address in xml

### DIFF
--- a/l10n_it_fatturapa_out_ddt/README.rst
+++ b/l10n_it_fatturapa_out_ddt/README.rst
@@ -81,6 +81,7 @@ Contributors
 * Lorenzo Battistini
 * Sergio Zanchetta
 * Ruben Tonetto
+* Alessandro Camilli
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_it_fatturapa_out_ddt/__init__.py
+++ b/l10n_it_fatturapa_out_ddt/__init__.py
@@ -1,3 +1,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import wizard
+from . import models

--- a/l10n_it_fatturapa_out_ddt/__manifest__.py
+++ b/l10n_it_fatturapa_out_ddt/__manifest__.py
@@ -6,7 +6,7 @@
 {
     'name': 'Italian Localization - Fattura elettronica - Integrazione DDT',
     "summary": "Modulo ponte tra emissione fatture elettroniche e DDT",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "development_status": "Beta",
     "category": "Hidden",
     'website': 'https://github.com/OCA/l10n-italy/tree/11.0/'
@@ -22,6 +22,7 @@
         "l10n_it_ddt",
     ],
     "data": [
-        "wizard/wizard_export_fatturapa_view.xml"
+        "wizard/wizard_export_fatturapa_view.xml",
+        "views/company_view.xml"
     ],
 }

--- a/l10n_it_fatturapa_out_ddt/models/__init__.py
+++ b/l10n_it_fatturapa_out_ddt/models/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2019 Alessandro Camilli - Openforce
+
+from . import company

--- a/l10n_it_fatturapa_out_ddt/models/company.py
+++ b/l10n_it_fatturapa_out_ddt/models/company.py
@@ -1,0 +1,21 @@
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    fatturapa_ddt_shipping_address = fields.Boolean(
+        string='Shipping address in XML',
+        default=True
+        )
+
+
+class AccountConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    fatturapa_ddt_shipping_address = fields.Boolean(
+        related='company_id.fatturapa_ddt_shipping_address',
+        string='Shipping address in XML',
+        readonly=False
+        )

--- a/l10n_it_fatturapa_out_ddt/views/company_view.xml
+++ b/l10n_it_fatturapa_out_ddt/views/company_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_config_settings" model="ir.ui.view">
+        <field name="name">view_account_config_settings</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="l10n_it_fatturapa.view_account_config_settings"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='fatturapa_sender_partner']/.." position="after">
+                <div class="row">
+                     <label for="fatturapa_ddt_shipping_address" class="col-lg-3 o_light_label"/>
+                     <field name="fatturapa_ddt_shipping_address"/>
+                 </div>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Aggiunge alla sezione dati di trasporto dell'XML la destinazione della merce.
Questa funzione è attivabile mediante opzione nella configurazione della fattura elettronica

Comportamento attuale prima di questa PR:
L'indirizzo di destinazione della merce non veniva indicato nell'xml

Comportamento desiderato dopo questa PR:
Se impostata nella configurazione della fattura elettronica l'opzione per includere l'indirizzo di destinazione nell'xml, questa PR permette di includere i dati della destinazione della merce nel file esportato.




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
