### PR TITLE
[10.0] l10n_it_reverse_charge: avoid creating autoinvoice with payment term

### DIFF
--- a/l10n_it_reverse_charge/__manifest__.py
+++ b/l10n_it_reverse_charge/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Reverse Charge IVA',
-    'version': '10.0.1.1.4',
+    'version': '10.0.1.1.5',
     'category': 'Localization/Italy',
     'summary': 'Reverse Charge for Italy',
     'author': 'Odoo Italia Network,Odoo Community Association (OCA)',

--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -86,7 +86,8 @@ class AccountInvoice(models.Model):
             'origin': self.number,
             'rc_purchase_invoice_id': self.id,
             'name': rc_type.self_invoice_text,
-            'fiscal_position_id': None
+            'fiscal_position_id': False,
+            'payment_term_id': False,
             }
 
     def get_inv_line_to_reconcile(self):


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
nel caso in cui sul fornitore è impostato come termini di pagamento del cliente un pagamento scaglionato (es. 15/30 giorni), l'autofattura generata non risulta totalmente pagata.

Comportamento attuale prima di questa PR:
creo una fattura fornitore intra UE (con termini di pagamento del cliente che prevede un pagamento scaglionato), l'autofattura generata non risulta totalmente pagata.

Comportamento desiderato dopo questa PR:
creo una fattura fornitore intra UE (con termini di pagamento del cliente che prevede un pagamento scaglionato), l'autofattura generata risulta totalmente pagata.



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
