### PR TITLE
[10.0] l10n_it_reverse_charge: fix compute_rc_amount_tax

### DIFF
--- a/l10n_it_reverse_charge/__manifest__.py
+++ b/l10n_it_reverse_charge/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Reverse Charge IVA',
-    'version': '10.0.1.1.5',
+    'version': '10.0.1.1.6',
     'category': 'Localization/Italy',
     'summary': 'Reverse Charge for Italy',
     'author': 'Odoo Italia Network,Odoo Community Association (OCA)',

--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -113,25 +113,26 @@ class AccountInvoice(models.Model):
             'date': self.date,
             }
 
-    def compute_rc_amount(self):
-        amount_rc_tax = 0.0
+    def compute_rc_amount_tax(self):
+        rc_amount_tax = 0.0
+        round_curr = self.currency_id.round
         rc_lines = self.invoice_line_ids.filtered(lambda l: l.rc)
         for rc_line in rc_lines:
             price_unit = \
                 rc_line.price_unit * (1 - (rc_line.discount or 0.0) / 100.0)
-            res = rc_line.invoice_line_tax_ids.compute_all(
+            taxes = rc_line.invoice_line_tax_ids.compute_all(
                 price_unit,
-                rc_line.currency_id,
+                self.currency_id,
                 rc_line.quantity,
                 product=rc_line.product_id,
-                partner=rc_line.partner_id)
-            amount_rc_tax += res['total_included'] - res['total_excluded']
+                partner=rc_line.partner_id)['taxes']
+            rc_amount_tax += sum([tax['amount'] for tax in taxes])
 
-        return amount_rc_tax
+        return round_curr(rc_amount_tax)
 
     def rc_credit_line_vals(self, journal):
         credit = debit = 0.0
-        amount_rc_tax = self.compute_rc_amount()
+        amount_rc_tax = self.compute_rc_amount_tax()
 
         if self.type == 'in_invoice':
             credit = amount_rc_tax
@@ -148,7 +149,7 @@ class AccountInvoice(models.Model):
 
     def rc_debit_line_vals(self, amount=None):
         credit = debit = 0.0
-        amount_rc_tax = self.compute_rc_amount()
+        amount_rc_tax = self.compute_rc_amount_tax()
 
         if self.type == 'in_invoice':
             if amount:


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
in alcuni casi come ad esempio quello evidenziato nell'immagine seguente
![round_amount_tax](https://user-images.githubusercontent.com/3512779/54749826-05913e00-4bd6-11e9-8034-1150a84785a7.png)
**(si veda il test aggiunto per ulteriori dettagli)** si ha una discrepanza tra quanto pagato e l'imposta.
Per porre rimedio a questa anomalia ho modificato il calcolo di `amount_tax` prendendo spunto da quanto viene fatto da Odoo in [link 1](https://github.com/odoo/odoo/blob/10.0/addons/account/models/account_invoice.py#L653) e in [link 2](https://github.com/odoo/odoo/blob/10.0/addons/account/models/account_invoice.py#L49).

Comportamento attuale prima di questa PR:
imposto **Arrotondamento sul Totale** come **Metodo di arrotondamento per calcolo imposte**,
creo una fattura fornitore intra UE (con dati come quelli presenti nell'immagine), si ha differenza tra quanto mostrato in pagato (`29,18€`) e quanto mostrato in imposta (`29,17€`).

Comportamento desiderato dopo questa PR:
imposto **Arrotondamento sul Totale** come **Metodo di arrotondamento per calcolo imposte**,
creo una fattura fornitore intra UE (con dati come quelli presenti nell'immagine), non si ha differenza tra quanto mostrato in pagato (`29,17€`) e quanto mostrato in imposta (`29,17€`).

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
