### PR TITLE
[12.0] FIX l10n_it_fatturapa_in: log inconsistency when multiple exemption taxes are found, so that user is informed

### DIFF
--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -5,7 +5,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 {
-    'name': 'Italian Localization - Fattura elettronica - Ricezione',
+    'name': 'ITA - Fattura elettronica - Ricezione',
     'version': '12.0.1.2.1',
     "development_status": "Beta",
     'category': 'Localization/Italy',

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -286,12 +286,19 @@ class WizardImportFatturapa(models.TransientModel):
                     ('type_tax_use', '=', 'purchase'),
                     ('kind_id.code', '=', line.Natura),
                     ('amount', '=', 0.0),
-                ], order='sequence', limit=1)
+                ], order='sequence')
             if not account_taxes:
                 self.log_inconsistency(
                     _('No tax with percentage '
                       '%s and nature %s found. Please configure this tax.')
                     % (line.AliquotaIVA, line.Natura))
+            if len(account_taxes) > 1:
+                self.log_inconsistency(
+                    _('Too many taxes with percentage '
+                      '%s and nature %s found. Tax %s with lower priority has '
+                      'been set on invoice lines.')
+                    % (line.AliquotaIVA, line.Natura,
+                       account_taxes[0].description))
         else:
             account_taxes = account_tax_model.search(
                 [


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

https://github.com/OCA/l10n-italy/issues/1048
In particolare https://github.com/OCA/l10n-italy/pull/1096#discussion_r264001479

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
