### PR TITLE
[10.0] fix missind depend on l10n_it_rea  for field

### DIFF
--- a/l10n_it_fiscalcode/__manifest__.py
+++ b/l10n_it_fiscalcode/__manifest__.py
@@ -5,12 +5,13 @@
 
 {
     'name': 'Italian Localisation - Fiscal Code',
-    'version': '10.0.1.3.0',
+    'version': '10.0.1.3.1',
     'category': 'Localisation/Italy',
     'author': "Odoo Italia Network, Odoo Community Association (OCA)",
     'website': 'https://odoo-community.org/',
     'license': 'AGPL-3',
     'depends': [
+        'l10n_it_rea',
         'base_vat'
     ],
     'external_dependencies': {


### PR DESCRIPTION
Descrizione del problema o della funzionalità: manca la dipendenza da `l10n_it_rea` nel modulo `l10n_it_fiscalcode`

Comportamento attuale prima di questa PR: l'installazione del modulo `l10n_it_fiscalcode` segnala la mancata presenza del campo `rea_member_type`

Comportamento desiderato dopo questa PR: non segnala l'errore




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
