### PR TITLE
[11.0][IMP][l10n_it_fatturapa_in] Add to a supplier invoice the valid…

### DIFF
--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '11.0.1.0.3',
+    'version': '11.0.1.1.0',
     "development_status": "Beta",
     'category': 'Localization/Italy',
     'summary': 'Ricezione fatture elettroniche',

--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -1,5 +1,7 @@
 
-from odoo import fields, models, api
+from odoo import fields, models, api, _
+from odoo.exceptions import ValidationError
+from odoo.tools import float_compare
 import odoo.addons.decimal_precision as dp
 
 
@@ -13,6 +15,57 @@ class AccountInvoice(models.Model):
     e_invoice_line_ids = fields.One2many(
         "einvoice.line", "invoice_id", string="Lines Detail",
         readonly=True, copy=False)
+
+    e_invoice_amount_untaxed = fields.Monetary(
+        string='E-Invoice Untaxed Amount', readonly=True)
+    e_invoice_amount_tax = fields.Monetary(string='E-Invoice Tax Amount',
+                                           readonly=True)
+    e_invoice_amount_total = fields.Monetary(string='E-Invoice Total Amount',
+                                             readonly=True)
+    e_invoice_validation_error = fields.Boolean(
+        compute='_compute_e_invoice_validation_error')
+
+    e_invoice_force_validation = fields.Boolean(
+        string='Force E-Invoice Validation')
+
+    @api.multi
+    def invoice_validate(self):
+        for invoice in self:
+            if (invoice.e_invoice_validation_error and
+                    not invoice.e_invoice_force_validation):
+                raise ValidationError(
+                    _("The invoice '%s' doesn't match the related e-invoice") %
+                    invoice.display_name)
+        return super(AccountInvoice, self).invoice_validate()
+
+    @api.depends('amount_untaxed', 'amount_tax', 'amount_total', 'state')
+    def _compute_e_invoice_validation_error(self):
+        for invoice in self:
+            if (invoice.type in ['in_invoice', 'in_refund'] and
+                    invoice.state in ['draft', 'open', 'paid'] and
+                    invoice.fatturapa_attachment_in_id):
+                if (invoice.e_invoice_amount_untaxed and
+                        float_compare(invoice.amount_untaxed,
+                                      invoice.e_invoice_amount_untaxed,
+                                      precision_rounding=invoice.currency_id
+                                      .rounding) != 0):
+                    invoice.e_invoice_validation_error = True
+                elif (invoice.e_invoice_amount_tax and
+                        float_compare(invoice.amount_tax,
+                                      invoice.e_invoice_amount_tax,
+                                      precision_rounding=invoice.currency_id
+                                      .rounding) != 0):
+                    invoice.e_invoice_validation_error = True
+                elif (invoice.e_invoice_amount_total and
+                        float_compare(invoice.amount_total,
+                                      invoice.e_invoice_amount_total,
+                                      precision_rounding=invoice.currency_id
+                                      .rounding) != 0):
+                    invoice.e_invoice_validation_error = True
+                else:
+                    invoice.e_invoice_validation_error = False
+            else:
+                invoice.e_invoice_validation_error = False
 
     @api.multi
     def name_get(self):
@@ -38,6 +91,36 @@ class AccountInvoice(models.Model):
         self.ensure_one()
         self.fatturapa_attachment_in_id = False
         return {'type': 'ir.actions.client', 'tag': 'reload'}
+
+    @api.model
+    def compute_xml_amount_untaxed(self, DatiRiepilogo):
+        amount_untaxed = 0.0
+        for Riepilogo in DatiRiepilogo:
+            amount_untaxed += float(Riepilogo.ImponibileImporto)
+        return amount_untaxed
+
+    @api.model
+    def compute_xml_amount_tax(self, DatiRiepilogo):
+        amount_tax = 0.0
+        for Riepilogo in DatiRiepilogo:
+            amount_tax += float(Riepilogo.Imposta)
+        return amount_tax
+
+    def set_einvoice_amount(self, fattura):
+        self.ensure_one()
+        amount_untaxed = self.compute_xml_amount_untaxed(
+            fattura.DatiBeniServizi.DatiRiepilogo)
+        amount_tax = self.compute_xml_amount_tax(
+            fattura.DatiBeniServizi.DatiRiepilogo)
+        amount_total = float(
+            fattura.DatiGenerali.DatiGeneraliDocumento.
+            ImportoTotaleDocumento or 0.0)
+
+        self.update({
+            'e_invoice_amount_untaxed': amount_untaxed,
+            'e_invoice_amount_tax': amount_tax,
+            'e_invoice_amount_total': amount_total,
+        })
 
 
 class fatturapa_article_code(models.Model):

--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -27,6 +27,15 @@ class FatturaPAAttachmentIn(models.Model):
     registered = fields.Boolean(
         "Registered", compute="_compute_registered", store=True)
 
+    e_invoice_validation_error = fields.Boolean(
+        compute='_compute_e_invoice_validation_error')
+
+    @api.depends('in_invoice_ids.e_invoice_validation_error')
+    def _compute_e_invoice_validation_error(self):
+        for rec in self:
+            rec.e_invoice_validation_error = \
+                any(rec.mapped('in_invoice_ids.e_invoice_validation_error'))
+
     @api.onchange('datas_fname')
     def onchagne_datas_fname(self):
         self.name = self.datas_fname

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -216,6 +216,13 @@ class TestFatturaPAXMLValidation(SingleTransactionCase):
         self.assertAlmostEqual(invoice.amount_untaxed, 1173.60)
         self.assertEqual(invoice.amount_tax, 258.19)
         self.assertEqual(invoice.amount_total, 1431.79)
+        self.assertAlmostEqual(
+            invoice.e_invoice_amount_untaxed, invoice.amount_untaxed,
+            places=invoice.currency_id.decimal_places)
+        self.assertAlmostEqual(
+            invoice.e_invoice_amount_tax, invoice.amount_tax,
+            places=invoice.currency_id.decimal_places)
+        self.assertEqual(invoice.e_invoice_validation_error, False)
         self.assertEqual(invoice.invoice_line_ids[0].admin_ref, 'D122353')
 
     def test_08_xml_import(self):

--- a/l10n_it_fatturapa_in/views/account_view.xml
+++ b/l10n_it_fatturapa_in/views/account_view.xml
@@ -6,6 +6,10 @@
         <field name="model">fatturapa.attachment.in</field>
         <field name="arch" type="xml">
             <form string="Import e-bill" duplicate="false">
+                <div class="alert alert-info" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('e_invoice_validation_error','=',False)]}">
+                     <bold>One or more invoice doesn't match the amount (tax or untaxed or total) of the original e-invoice. Please check</bold>
+                </div>
+                <field name="e_invoice_validation_error" invisible="1"/>
                 <div>
                     <group>
                         <group>
@@ -109,6 +113,12 @@
         <field name="model">account.invoice</field>
         <field name="inherit_id" ref="account.invoice_supplier_form"></field>
         <field name="arch" type="xml">
+            <xpath expr="//div[@role='alert']" position="after">
+                <div class="alert alert-info" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('e_invoice_validation_error','=',False)]}">
+                     <bold>The invoice doesn't match one of the amount untaxed, tax amount or total amount of the original e-invoice. Please check</bold>
+                </div>
+                <field name="e_invoice_validation_error" invisible="1"/>
+            </xpath>
             <field name="partner_id" position="after">
                 <field name="electronic_invoice_subjected" invisible="1"/>
                 <field name="tax_representative_id" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
@@ -126,9 +136,19 @@
             </field>
             <xpath expr="//notebook" position="inside">
                 <page string="E-bill Inconsistencies" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}">
+                    <group>
+                        <field name="e_invoice_force_validation" attrs="{'invisible': [('e_invoice_validation_error','=',False)]}"/>
+                    </group>
                     <field name="inconsistencies" nolabel="1" colspan="4" readonly="1"></field>
                 </page>
                 <page string="E-bill Details" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}">
+                    <group>
+                        <group string="Amount Summary">
+                            <field name="e_invoice_amount_untaxed"/>
+                            <field name="e_invoice_amount_tax"/>
+                            <field name="e_invoice_amount_total"/>
+                        </group>
+                    </group>
                     <group string="Lines Detail">
                         <field name="e_invoice_line_ids" nolabel="1">
                             <tree string="Lines Detail">

--- a/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.py
+++ b/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.py
@@ -17,3 +17,16 @@ class WizardLinkToInvoice(models.TransientModel):
         if len(active_ids) != 1:
             raise UserError(_("You can select only one XML file to link."))
         self.invoice_id.fatturapa_attachment_in_id = active_ids[0]
+        # extract pdf if attached
+        fatturapa_attachment_obj = self.env['fatturapa.attachment.in']
+        for fatturapa_attachment_id in active_ids:
+            fatturapa_attachment = fatturapa_attachment_obj.browse(
+                fatturapa_attachment_id)
+            fatt = self.get_invoice_obj(fatturapa_attachment)
+            for FatturaBody in fatt.FatturaElettronicaBody:
+                self.invoice_id.set_einvoice_amount(FatturaBody)
+                # 2.5
+                AttachmentsData = FatturaBody.Allegati
+                if AttachmentsData and self.invoice_id:
+                    fatturapa_attachment_obj.extract_attachments(
+                        AttachmentsData, self.invoice_id.id)

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1130,12 +1130,6 @@ class WizardImportFatturapa(models.TransientModel):
         invoice.compute_taxes()
         return invoice_id
 
-    def compute_xml_amount_untaxed(self, DatiRiepilogo):
-        amount_untaxed = 0.0
-        for Riepilogo in DatiRiepilogo:
-            amount_untaxed += float(Riepilogo.ImponibileImporto)
-        return amount_untaxed
-
     def check_invoice_amount(self, invoice, FatturaElettronicaBody):
         if (
             FatturaElettronicaBody.DatiGenerali.DatiGeneraliDocumento.
@@ -1162,7 +1156,7 @@ class WizardImportFatturapa(models.TransientModel):
             # DatiGeneraliDocumento.ScontoMaggiorazione is not present,
             # because otherwise DatiRiepilogo and odoo invoice total would
             # differ
-            amount_untaxed = self.compute_xml_amount_untaxed(
+            amount_untaxed = invoice.compute_xml_amount_untaxed(
                 FatturaElettronicaBody.DatiBeniServizi.DatiRiepilogo)
             if not float_is_zero(
                 invoice.amount_untaxed-amount_untaxed, precision_digits=2
@@ -1238,6 +1232,8 @@ class WizardImportFatturapa(models.TransientModel):
                     )
                 new_invoices.append(invoice_id)
                 self.check_invoice_amount(invoice, fattura)
+
+                invoice.set_einvoice_amount(fattura)
 
                 if self.env.context.get('inconsistencies'):
                     invoice_inconsistencies = (


### PR DESCRIPTION
…ation of the amount when coming from a e-invoice source
Descrizione del problema o della funzionalità:

Aggiunge il check di congruenza al momento della validazione delle fatture d'acquisto permettendo di verificare se gli importi delle fattura elettronica originaria sono coerenti con la registrazione in validazione.

Comportamento attuale prima di questa PR:

Dopo l'importazione di un fattura elettronica non esiste un controllo che effettui la congruenza degli importi della fattura registrata con quella arrivata in formato elettronico.

Comportamento desiderato dopo questa PR:

Segnalare l'incogruenza tra la fattura in validazione con gli importi della fattura elettronica ed averli identici.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
