### PR TITLE
[12.0] FIX l10n_it_corrispettivi_sale auto_install

### DIFF
--- a/l10n_it_corrispettivi_sale/__manifest__.py
+++ b/l10n_it_corrispettivi_sale/__manifest__.py
@@ -20,5 +20,5 @@
         'views/sale_view.xml'
     ],
     'installable': True,
-    'auto-install': True,
+    'auto_install': True,
 }


### PR DESCRIPTION
Pare che tutte le versioni siano affette
