### PR TITLE
[12.0] [FIX] l10n_it_corrispettivi: Find fiscal positions without company

### DIFF
--- a/l10n_it_corrispettivi/__manifest__.py
+++ b/l10n_it_corrispettivi/__manifest__.py
@@ -4,7 +4,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     'name': 'Italian Localization - Ricevute',
-    'version': '12.0.1.1.1',
+    'version': '12.0.1.1.2',
     'category': 'Accounting & Finance',
     'author': 'Odoo Italian Community, Agile Business Group, '
               'Odoo Community Association (OCA)',

--- a/l10n_it_corrispettivi/models/account.py
+++ b/l10n_it_corrispettivi/models/account.py
@@ -93,9 +93,22 @@ class AccountFiscalPosition(models.Model):
     def get_corr_fiscal_pos(self, company_id=None):
         if not company_id:
             company_id = self.env.user.company_id
-        corr_fiscal_pos = self.search([
-            ('corrispettivi', '=', True),
-            ('company_id', '=', company_id.id)], limit=1)
+        corr_fiscal_pos = self.search(
+            [
+                ('company_id', '=', company_id.id),
+                ('corrispettivi', '=', True),
+            ],
+            limit=1
+        )
+        if not corr_fiscal_pos:
+            # Fall back to fiscal positions without company
+            corr_fiscal_pos = self.search(
+                [
+                    ('company_id', '=', False),
+                    ('corrispettivi', '=', True),
+                ],
+                limit=1
+            )
 
         return corr_fiscal_pos
 


### PR DESCRIPTION
Fall back to fiscal positions without company when no corrispettivi fiscal position is found in current company

https://github.com/OCA/l10n-italy/issues/1156