### PR TITLE
[8.0] fix record in fatturapa preview

### DIFF
--- a/l10n_it_fatturapa/__openerp__.py
+++ b/l10n_it_fatturapa/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura Elettronica - Base',
-    'version': '8.0.2.2.5',
+    'version': '8.0.2.2.6',
     'category': 'Localization/Italy',
     'summary': 'Electronic invoices',
     'author': 'Davide Corio, Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa/models/ir_attachment.py
+++ b/l10n_it_fatturapa/models/ir_attachment.py
@@ -33,7 +33,7 @@ class Attachment(models.Model):
     @api.multi
     def _compute_ftpa_preview_link(self):
         for att in self:
-            att.ftpa_preview_link = '/fatturapa/preview/%s' % self.id
+            att.ftpa_preview_link = '/fatturapa/preview/%s' % att.id
 
     def remove_xades_sign(self, xml):
         # Recovering parser is needed for files where strings like


### PR DESCRIPTION
Descrizione del problema o della funzionalità: in caso di installazione del modulo `l10n_it_fatturapa_export_zip`, l'attachment contiene più di un record e il metodo `_compute_ftpa_preview_link` segnala un errore perchè in `self` sono presente più record. Non mi è chiaro se l'errore sia dovuto al modulo esterno, perchè non dovrebbe trovare l'attachment dello zip in questo file, però in ogni caso la correzione è logica.

Comportamento attuale prima di questa PR: in caso di installazione del modulo `l10n_it_fatturapa_export_zip` e dopo avere esportato un file zip, non sono più leggibili le e-fatture in acquisto

Comportamento desiderato dopo questa PR: le e-fatture in acquisto sono leggibili




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
