### PR TITLE
[10.0][IMP] add pyxb version dependency

### DIFF
--- a/setup/l10n_it_fatturapa/setup.py
+++ b/setup/l10n_it_fatturapa/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'pyxb': 'PyXB==1.2.6',
+            },
+        },
+    },
 )


### PR DESCRIPTION
Descrizione del problema o della funzionalità: mancanza della versione di pyxb nell'installazione da pip

Comportamento attuale prima di questa PR: versione da aggiornare manualmente

Comportamento desiderato dopo questa PR: versione inserita nei requirements di pip




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
