### PR TITLE
[10.0] [l10n_it_rea] Use rea_office in sql_constraints to avoid 'false' uniqueness

### DIFF
--- a/l10n_it_rea/__manifest__.py
+++ b/l10n_it_rea/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Italian Localization - Registro REA',
-    'version': '10.0.1.1.1',
+    'version': '10.0.1.1.2',
     'category': 'Localisation/Italy',
     'summary': 'Gestisce i campi del Repertorio Economico Amministrativo',
     'author': 'Agile Business Group, Odoo Italia Network,'

--- a/l10n_it_rea/models/res_partner.py
+++ b/l10n_it_rea/models/res_partner.py
@@ -19,6 +19,6 @@ class ResPartner(models.Model):
          ('LN', 'Not in liquidation')], 'Liquidation State')
 
     _sql_constraints = [
-        ('rea_code_uniq', 'unique (rea_code, company_id)',
+        ('rea_code_uniq', 'unique (rea_office, rea_code, company_id)',
          'The rea code code must be unique per company !'),
     ]


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Il `rea_code` ha un `_sql_constraints` che non tiene in considerazione `rea_office` per garantire l'unicità del codice. Tuttavia, capita spesso che il `rea_code` abbia valori tipo `0` che creano il problema di non importare le fatture di acquisto.

Comportamento attuale prima di questa PR:

Se due `rea_code` uguali sono stati assegnati in due province diverse, non sarà possibile creare il partner e neppure importare automaticamente un fattura di acquisto elettronica. 

Comportamento desiderato dopo questa PR:

Viene aggiunto il `rea_office` all'`_sql_constraints` per evitare di avere una restrizione troppo forte e non corretta. Personalmente eliminerei totalmente questo constraint.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
