### PR TITLE
10.0 fix bad tz in data transport

### DIFF
--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Base',
-    'version': '10.0.2.5.0',
+    'version': '10.0.2.5.1',
     'category': 'Localization/Italy',
     'summary': 'Fatture elettroniche',
     'author': 'Davide Corio, Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa/bindings/__init__.py
+++ b/l10n_it_fatturapa/bindings/__init__.py
@@ -3,6 +3,12 @@ import logging
 _logger = logging.getLogger(__name__)
 
 try:
-    from . import fatturapa_v_1_2
-except Exception as e:  # ImportError or pyxb.PyXBVersionError
-    _logger.warning('%s: %s' % (e.__class__.__name__, e))
+    import pyxb
+except ImportError as e:
+    _logger.warning(e)
+else:
+    pyxb.PreserveInputTimeZone(True)
+    try:
+        from . import fatturapa_v_1_2
+    except pyxb.PyXBVersionError as e:
+        _logger.warning('%s: %s' % (e.__class__.__name__, e))

--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '10.0.1.5.0',
+    'version': '10.0.1.5.1',
     'category': 'Localization/Italy',
     'summary': 'Ricezione fatture elettroniche',
     'author': 'Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
@@ -142,7 +142,7 @@ xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.
                     <Provincia>CN</Provincia>
                     <Nazione>IT</Nazione>
                 </IndirizzoResa>
-                <DataOraConsegna>2012-10-22T16:46:12.000+02:00</DataOraConsegna>
+                <DataOraConsegna>0001-01-01T00:00:00.000+02:00</DataOraConsegna>
             </DatiTrasporto>
         </DatiGenerali>
         <DatiBeniServizi>


### PR DESCRIPTION
Descrizione del problema o della funzionalità: #1184 

Comportamento attuale prima di questa PR: si blocca la visualizzazione delle e-fatture fornitori

Comportamento desiderato dopo questa PR: la visualizzazione e il processo è normale

N.B.: questa PR ignora l'interpretazione dell'orario che opera pyxb sui campi datetime della sezione DataOraConsegna per allinearli al timezone corretto, per cui chi avesse la necessità di avere quei dati corretti dovrebbe proporre una PR che ne tenga conto e risolva il problema.


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
