### PR TITLE
[10.0] OverflowError with <DataOraConsegna>0001-01-01T00:00:00.000+02:00</DataOraConsegna>

### DIFF
--- a/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
@@ -142,7 +142,7 @@ xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.
                     <Provincia>CN</Provincia>
                     <Nazione>IT</Nazione>
                 </IndirizzoResa>
-                <DataOraConsegna>2012-10-22T16:46:12.000+02:00</DataOraConsegna>
+                <DataOraConsegna>0001-01-01T00:00:00.000+02:00</DataOraConsegna>
             </DatiTrasporto>
         </DatiGenerali>
         <DatiBeniServizi>


### PR DESCRIPTION
Rif https://github.com/OCA/l10n-italy/issues/1172

L'XML con `0001-01-01T00:00:00.000+02:00` passa la validazione dell'ADE, non quella di pyxb