### PR TITLE
[8.0][FIX] l10n_it_fatturapa_pec: correctly parse P7M files

### DIFF
--- a/l10n_it_fatturapa_pec/models/mail_thread.py
+++ b/l10n_it_fatturapa_pec/models/mail_thread.py
@@ -17,7 +17,7 @@ _logger = logging.getLogger(__name__)
 
 FATTURAPA_IN_REGEX = '^(IT[a-zA-Z0-9]{11,16}|'\
                      '(?!IT)[A-Z]{2}[a-zA-Z0-9]{2,28})'\
-                     '_[a-zA-Z0-9]{1,5}[.](xml|XML|zip|ZIP)$'
+                     '_[a-zA-Z0-9]{1,5}\\.(xml|XML|zip|ZIP)(\\.(p7m|P7M))?$'
 RESPONSE_MAIL_REGEX = '(IT[a-zA-Z0-9]{11,16}|'\
                       '(?!IT)[A-Z]{2}[a-zA-Z0-9]{2,28})'\
                       '_[a-zA-Z0-9]{1,5}'\


### PR DESCRIPTION
 * Fix FATTURAPA_IN_REGEX to allow signed incoming invoices.

Descrizione del problema o della funzionalità:
Quando vengono caricate le fatture ricevute a sistema, quelle firmate digitalmente vengono scartate.

Comportamento attuale prima di questa PR:
Le fatture ricevute rimangono memorizzate nella model mail.message ed attribuite erroneamente alla model fatturapa.attachment.out.

Comportamento desiderato dopo questa PR:
Le fatture ricevute vengono memorizzate e in mail.message e viene creato un oggetto in fatturapa.attachment.in relativo alla nuova fattura.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
