### PR TITLE
[12.0] FIX l10n_it_website_portal_fatturapa view dependency

### DIFF
--- a/l10n_it_website_portal_fatturapa/__manifest__.py
+++ b/l10n_it_website_portal_fatturapa/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Italian Localization - Fattura elettronica - Portale",
     "summary": "Add fatturapa fields and checks in frontend user's details",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "author": "Odoo Community Association (OCA)",
     "category": "Localization/Italy",
     "website": "https://github.com/OCA/l10n-italy/tree/"

--- a/l10n_it_website_portal_fatturapa/views/l10n_it_website_portal_fatturapa_templates.xml
+++ b/l10n_it_website_portal_fatturapa/views/l10n_it_website_portal_fatturapa_templates.xml
@@ -5,8 +5,8 @@
   License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
   -->
 <odoo>
-    <template id="assets_frontend" inherit_id="website.assets_frontend" name="Website Portal Electronic Invoice">
-        <xpath expr="." position="inside">
+    <template id="assets_frontend" inherit_id="web.assets_frontend" name="Website Portal Electronic Invoice">
+        <xpath expr="//script[last()]" position="after">
             <script type="text/javascript"
                     src="/l10n_it_website_portal_fatturapa/static/src/js/l10n_it_website_portal_fatturapa.js"/>
         </xpath>


### PR DESCRIPTION
Otherwise, when installed directly:

```
  File "odoo/addons/base/models/ir_model.py", line 1380, in xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
odoo.tools.convert.ParseError: "External ID not found in the system: website.assets_frontend" while parsing None:8, near
<data inherit_id="website.assets_frontend" name="Website Portal Electronic Invoice">
        <xpath expr="." position="inside">
            <script type="text/javascript" src="/l10n_it_website_portal_fatturapa/static/src/js/l10n_it_website_portal_fatturapa.js"/>
        </xpath>
    </data>
```





--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
