### PR TITLE
[12.0] IMP l10n_it_ddt error messages and do not block if SO has not shipping info

### DIFF
--- a/l10n_it_ddt/__manifest__.py
+++ b/l10n_it_ddt/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Italian Localization - DDT: documento di trasporto',
-    'version': '12.0.1.0.1',
+    'version': '12.0.1.0.2',
     'category': 'Localization/Italy',
     'summary': 'Documento di Trasporto',
     'author': 'Davide Corio, Odoo Community Association (OCA),'

--- a/l10n_it_ddt/wizard/add_picking_to_ddt.py
+++ b/l10n_it_ddt/wizard/add_picking_to_ddt.py
@@ -37,26 +37,50 @@ class AddPickingToDdt(models.TransientModel):
                     _("Selected Picking %s have"
                       " different Partner") % picking.name)
             if picking.sale_id:
-                if picking.sale_id.carriage_condition_id != (
-                        self.ddt_id.carriage_condition_id):
+                if (
+                    picking.sale_id.carriage_condition_id and
+                    picking.sale_id.carriage_condition_id !=
+                    self.ddt_id.carriage_condition_id
+                ):
                     raise UserError(
-                        _("Selected Picking %s have"
-                          " different carriage condition") % picking.name)
-                elif picking.sale_id.goods_description_id != (
-                        self.ddt_id.goods_description_id):
+                        _("Sale order %s and DDT %s have"
+                          " different carriage condition") % (
+                            picking.sale_id.display_name,
+                            self.ddt_id.display_name
+                        ))
+                elif (
+                    picking.sale_id.goods_description_id and
+                    picking.sale_id.goods_description_id !=
+                    self.ddt_id.goods_description_id
+                ):
                     raise UserError(
-                        _("Selected Picking %s have "
-                          "different goods description") % picking.name)
-                elif picking.sale_id.transportation_reason_id != (
-                        self.ddt_id.transportation_reason_id):
+                        _("Sale order %s and DDT %s have "
+                          "different goods description") % (
+                            picking.sale_id.display_name,
+                            self.ddt_id.display_name
+                        ))
+                elif (
+                    picking.sale_id.transportation_reason_id and
+                    picking.sale_id.transportation_reason_id !=
+                    self.ddt_id.transportation_reason_id
+                ):
                     raise UserError(
-                        _("Selected Picking %s have"
-                          " different transportation reason") % picking.name)
-                elif picking.sale_id.transportation_method_id != (
-                        self.ddt_id.transportation_method_id):
+                        _("Sale order %s and DDT %s have"
+                          " different transportation reason") % (
+                            picking.sale_id.display_name,
+                            self.ddt_id.display_name
+                        ))
+                elif (
+                    picking.sale_id.transportation_method_id and
+                    picking.sale_id.transportation_method_id !=
+                    self.ddt_id.transportation_method_id
+                ):
                     raise UserError(
-                        _("Selected Picking %s have"
-                          " different transportation method") % picking.name)
+                        _("Sale order %s and DDT %s have"
+                          " different transportation method") % (
+                            picking.sale_id.display_name,
+                            self.ddt_id.display_name
+                        ))
             self.ddt_id.picking_ids = [(4, picking.id)]
         ir_model_data = self.env['ir.model.data']
         form_res = ir_model_data.get_object_reference(


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

 - Creare un SO senza inserire informazioni di spedizione
 - Confermarlo e creare il DDT
 - Nel DDT inserire le informazioni di spedizione
 - Creare un altro SO, senza informazioni di spedizione, e confermarlo
 - Aggiungere quest'ultimo picking al DDT precedentemente creato

Comportamento attuale prima di questa PR:

Si ottiene errore

Comportamento desiderato dopo questa PR:

Il picking viene aggiunto al DDT


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
