### PR TITLE
[10.0] FIX l10n_it_fatturapa NumeroCivico with empty space

### DIFF
--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Base',
-    'version': '10.0.2.6.0',
+    'version': '10.0.2.6.1',
     'category': 'Localization/Italy',
     'summary': 'Fatture elettroniche',
     'author': 'Davide Corio, Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa/bindings/FatturaPA_versione_1.2.1.xsd.diff
+++ b/l10n_it_fatturapa/bindings/FatturaPA_versione_1.2.1.xsd.diff
@@ -96,6 +96,15 @@
      </xs:restriction>
    </xs:simpleType>
    <xs:simpleType name="ProvinciaType">
+@@ -1238,7 +1243,7 @@
+   </xs:simpleType>
+   <xs:simpleType name="NumeroCivicoType">
+     <xs:restriction base="xs:normalizedString">
+-      <xs:pattern value="(\p{IsBasicLatin}{1,8})" />
++      <xs:pattern value="(\p{IsBasicLatin}{0,8})" />
+     </xs:restriction>
+   </xs:simpleType>
+   <xs:simpleType name="BolloVirtualeType">
 @@ -1265,18 +1270,17 @@
      </xs:restriction>
    </xs:simpleType>

--- a/l10n_it_fatturapa/bindings/fatturapa_v_1_2.py
+++ b/l10n_it_fatturapa/bindings/fatturapa_v_1_2.py
@@ -821,7 +821,7 @@ class NumeroCivicoType (pyxb.binding.datatypes.normalizedString):
     _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2.1/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1244, 2)
     _Documentation = None
 NumeroCivicoType._CF_pattern = pyxb.binding.facets.CF_pattern()
-NumeroCivicoType._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,8})')
+NumeroCivicoType._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{0,8})')
 NumeroCivicoType._InitializeFacetMap(NumeroCivicoType._CF_pattern)
 Namespace.addCategoryObject('typeBinding', 'NumeroCivicoType', NumeroCivicoType)
 _module_typeBindings.NumeroCivicoType = NumeroCivicoType

--- a/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
@@ -136,7 +136,7 @@ xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.
                 <TipoResa>DAP</TipoResa>
                 <IndirizzoResa>
                     <Indirizzo>strada dei test</Indirizzo>
-                    <NumeroCivico>150/B</NumeroCivico>
+                    <NumeroCivico> </NumeroCivico>
                     <CAP>12042</CAP>
                     <Comune>Bra</Comune>
                     <Provincia>CN</Provincia>


### PR DESCRIPTION
SimpleFacetValueError: Type {http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2}NumeroCivicoType pattern constraint violated by value

Descrizione del problema o della funzionalità:

https://github.com/OCA/l10n-italy/issues/1220




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
