### PR TITLE
[FIX] l10n_it_fatturapa_out: DatiRiepilogo is mandatory but tax_line_…

### DIFF
--- a/l10n_it_fatturapa_out/__openerp__.py
+++ b/l10n_it_fatturapa_out/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Emissione',
-    'version': '8.0.3.3.1',
+    'version': '8.0.3.3.2',
     'category': 'Localization/Italy',
     'summary': 'Electronic invoices emission',
     'author': 'Davide Corio, Agile Business Group, Innoviu,'

--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -676,6 +676,10 @@ class WizardExportFatturapa(models.TransientModel):
 
     def setDatiRiepilogo(self, invoice, body):
         model_tax = self.env['account.tax']
+        if not invoice.tax_line:
+            raise UserError(
+                _("Invoice {invoice} has no tax lines")
+                .format(invoice=invoice.display_name))
         for tax_line in invoice.tax_line:
             tax = model_tax.get_tax_by_invoice_tax(tax_line.name)
             riepilogo = DatiRiepilogoType(


### PR DESCRIPTION
…ids is not required

Without this, when generating the e-invoice for an invoice that has no tax lines, the following exception is raised:
IncompleteElementContentError: (<odoo.addons.l10n_it_fatturapa.bindings.fatturapa_v_1_2.DatiBeniServiziType object at 0x7f6fb8653ad0>, <pyxb.utils.fac.Configuration object at 0x7f6fb7d137d0>, [<pyxb.binding.basis.ElementContent object at 0x7f6fb8168410>, <pyxb.binding.basis.ElementContent object at 0x7f6fb8168350>, <pyxb.binding.basis.ElementContent object at 0x7f6fb87d8c90>], {})

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
