### PR TITLE
[10.0][FIX] l10n_it_invoices_data_communication: Aliquota is the same amount of account.tax.amount

### DIFF
--- a/l10n_it_invoices_data_communication/__manifest__.py
+++ b/l10n_it_invoices_data_communication/__manifest__.py
@@ -7,7 +7,7 @@
     'name': 'Italian Localization - Comunicazione dati fatture',
     'summary': 'Comunicazione dati fatture (c.d. "nuovo spesometro" o '
                '"esterometro")',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'category': 'Account',
     'author': "Openforce di Camilli Alessandro, "
               "Odoo Community Association (OCA)",

--- a/l10n_it_invoices_data_communication/models/communication.py
+++ b/l10n_it_invoices_data_communication/models/communication.py
@@ -2491,16 +2491,14 @@ class ComunicazioneDatiIvaFattureRicevuteBody(models.Model):
                     fattura.invoice_id.date
                 # tax
                 tax_lines = []
-                for tax_line in fattura.invoice_id.tax_line:
+                for tax_line in fattura.invoice_id.tax_line_ids:
                     # aliquota
                     aliquota = 0
-                    domain = [('tax_code_id', '=', tax_line.tax_code_id.id)]
-                    tax = self.env['account.tax'].search(
-                        domain, order='id', limit=1)
+                    tax = tax_line.tax_id
                     if tax:
-                        aliquota = tax.amount * 100
+                        aliquota = tax.amount
                     val = {
-                        'ImponibileImporto': tax_line.base_amount,
+                        'ImponibileImporto': tax_line.base,
                         'Imposta': tax_line.amount,
                         'Aliquota': aliquota,
                     }


### PR DESCRIPTION
Credo sia un rimasuglio di v8, quando il campo account.tax.amount non rappresentava la percentuale.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
