### PR TITLE
[10.0] Fattura elettronica per indirizzi di fatturazione

### DIFF
--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Base',
-    'version': '10.0.2.7.0',
+    'version': '10.0.2.7.1',
     'category': 'Localization/Italy',
     'summary': 'Fatture elettroniche',
     'author': 'Davide Corio, Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa/models/account.py
+++ b/l10n_it_fatturapa/models/account.py
@@ -419,4 +419,5 @@ class AccountInvoice(models.Model):
              "documents with same number)", copy=False)
     electronic_invoice_subjected = fields.Boolean(
         'Subjected to Electronic Invoice',
-        related='partner_id.electronic_invoice_subjected', readonly=True)
+        related='commercial_partner_id.electronic_invoice_subjected',
+        readonly=True)


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

La fattura elettronica ha un campo "Soggetto a fattura elettronica" (electronic_invoice_subjected)  che viene ereditato dal cliente (campo related). Se questo campo è True, si vedono diversi tab con i dati della fatturazione elettronica. Se però la fattura è indirizzata all'indirizzo di fatturazione e NON al cliente principale, il campo risulta False, i tab non vengono quindi correttamente visualizzati.

Comportamento attuale prima di questa PR:

Se fatturo all'indirizzo di fatturazione di un cliente soggetto a fattura elettronica non vedo i tab aggiuntivi sulla fattura.

Comportamento desiderato dopo questa PR:

Se fatturo all'indirizzo di fatturazione di un cliente soggetto a fattura elettronica vedo correttamente i tab aggiuntivi.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
