### PR TITLE
[10.0] [FIX]  l10n_it_central_journal: Use journals to filter move lines

### DIFF
--- a/l10n_it_central_journal/__manifest__.py
+++ b/l10n_it_central_journal/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Italian Localization - Account central journal',
-    'version': '10.0.0.0.1',
+    'version': '10.0.0.0.2',
     'category': 'Localization/Italy',
     'author': 'Dinamiche Aziendali, Odoo Community Association (OCA)',
     'website': 'http://www.dinamicheaziendali.it',

--- a/l10n_it_central_journal/wizard/print_giornale.py
+++ b/l10n_it_central_journal/wizard/print_giornale.py
@@ -89,6 +89,7 @@ class WizardGiornale(models.TransientModel):
         move_line_ids = move_line_obj.search([
             ('date', '>=', wizard.date_move_line_from),
             ('date', '<=', wizard.date_move_line_to),
+            ('journal_id', 'in', [j.id for j in wizard.journal_ids]),
             ('move_id.state', 'in', target_type)
         ], order='date, move_id asc')
         if not move_line_ids:


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Nonostante la presenza della lista dei sezionali e la possibilitù di includerli/scluderli dalla stampa del Libro Giornale, essi non vengono presi in considerazione

Comportamento attuale prima di questa PR:

Contabilità -> Rendiconti -> Libro Giornale. A prescindere da ciò che è presente nella lista dei sezionali, la stampa è sempre la stessa.

Comportamento desiderato dopo questa PR:

Contabilità -> Rendiconti -> Libro Giornale. In base ai valori presenti nella lista dei sezionali vengono filtrati i movimenti presenti nella stampa

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
