### PR TITLE
[12.0] FIX l10n_it_ddt: in DDT report, partner addresses are not printed

### DIFF
--- a/l10n_it_ddt/__manifest__.py
+++ b/l10n_it_ddt/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Italian Localization - DDT: documento di trasporto',
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.1.1',
     'category': 'Localization/Italy',
     'summary': 'Documento di Trasporto',
     'author': 'Davide Corio, Odoo Community Association (OCA),'

--- a/l10n_it_ddt/views/report_ddt.xml
+++ b/l10n_it_ddt/views/report_ddt.xml
@@ -95,13 +95,13 @@
                         <div class="col-6">
                             <h2>Consignee</h2>
                             <div t-field="o.partner_shipping_id"
-                                t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}' />
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}' />
                             <div t-if="o.partner_shipping_id">VAT number: <span t-field="o.partner_shipping_id.vat"/></div>
                         </div>
                         <div class="col-6">
                             <h2>Assignee</h2>
                             <div t-field="o.partner_id"
-                                t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}' />
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}' />
                             <div t-if="o.partner_id">VAT number: <span t-field="o.partner_id.vat"/></div>
                         </div>
                     </div>


### PR DESCRIPTION
Comportamento attuale prima di questa PR:

Nella stampa del DDT, gli indirizzi del destinatario e cessionario non vengono stampanti: viene stampato solo il nome

Comportamento desiderato dopo questa PR:

Gli indirizzi vengono stampati



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
