### PR TITLE
[12.0] IMP account_vat_period_end_statement preventing to manually add lines to debit and credit VAT

### DIFF
--- a/account_vat_period_end_statement/__manifest__.py
+++ b/account_vat_period_end_statement/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "ITA - Liquidazione IVA",
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.1.1",
     'category': 'Localization/Italy',
     'summary': "Allow to create the 'VAT Statement'.",
     'license': 'AGPL-3',

--- a/account_vat_period_end_statement/models/account.py
+++ b/account_vat_period_end_statement/models/account.py
@@ -102,20 +102,12 @@ class AccountVatPeriodEndStatement(models.Model):
     debit_vat_account_line_ids = fields.One2many(
         'statement.debit.account.line', 'statement_id', 'Debit VAT',
         help='The accounts containing the debit VAT amount to write-off',
-        states={
-            'confirmed': [('readonly', True)],
-            'paid': [('readonly', True)],
-            'draft': [('readonly', False)]
-        }
+        readonly=True
     )
     credit_vat_account_line_ids = fields.One2many(
         'statement.credit.account.line', 'statement_id', 'Credit VAT',
         help='The accounts containing the credit VAT amount to write-off',
-        states={
-            'confirmed': [('readonly', True)],
-            'paid': [('readonly', True)],
-            'draft': [('readonly', False)]
-        })
+        readonly=True)
     previous_credit_vat_account_id = fields.Many2one(
         'account.account', 'Previous Credits VAT',
         help='Credit VAT from previous periods',


### PR DESCRIPTION
because no use case is expected to allow it and they are removed when user clicks on "recompute"

Comportamento attuale prima di questa PR:

In liquidazione IVA, l'utente può aggiungere righe nelle liste "Righe conti di debito" e "Righe conti di credito"

Comportamento desiderato dopo questa PR:

L'utente non può


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
