### PR TITLE
[12.0] IMP l10n_it_ddt interfaccia e stampa

### DIFF
--- a/l10n_it_ddt/__manifest__.py
+++ b/l10n_it_ddt/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Italian Localization - DDT: documento di trasporto',
-    'version': '12.0.1.1.1',
+    'version': '12.0.1.2.0',
     'category': 'Localization/Italy',
     'summary': 'Documento di Trasporto',
     'author': 'Davide Corio, Odoo Community Association (OCA),'

--- a/l10n_it_ddt/models/stock_picking_package_preparation.py
+++ b/l10n_it_ddt/models/stock_picking_package_preparation.py
@@ -90,7 +90,11 @@ class StockPickingPackagePreparation(models.Model):
         return self.env['stock.ddt.type'].search([], limit=1)
 
     ddt_type_id = fields.Many2one(
-        'stock.ddt.type', string='TD Type', default=_default_ddt_type)
+        'stock.ddt.type', string='TD Type', default=_default_ddt_type,
+        states={
+            'done': [('readonly', True)],
+            'cancel': [('readonly', True)]
+        })
     ddt_number = fields.Char(string='TD Number', copy=False)
     partner_shipping_id = fields.Many2one(
         'res.partner', string="Shipping Address")
@@ -111,6 +115,10 @@ class StockPickingPackagePreparation(models.Model):
     display_name = fields.Char(
         string='Name', compute='_compute_clean_display_name')
     volume = fields.Float('Volume')
+    volume_uom_id = fields.Many2one(
+        'uom.uom', 'Volume UoM',
+        default=lambda self: self.env.ref(
+            'uom.product_uom_litre', raise_if_not_found=False))
     invoice_id = fields.Many2one(
         'account.invoice', string='Invoice', readonly=True, copy=False)
     to_be_invoiced = fields.Boolean(
@@ -122,7 +130,15 @@ class StockPickingPackagePreparation(models.Model):
         string="Force Net Weight",
         help="Fill this field with the value you want to be used as weight. "
              "Leave empty to let the system to compute it")
+    weight_manual_uom_id = fields.Many2one(
+        'uom.uom', 'Net Weight UoM',
+        default=lambda self: self.env.ref(
+            'uom.product_uom_kgm', raise_if_not_found=False))
     gross_weight = fields.Float(string="Gross Weight")
+    gross_weight_uom_id = fields.Many2one(
+        'uom.uom', 'Gross Weight UoM',
+        default=lambda self: self.env.ref(
+            'uom.product_uom_kgm', raise_if_not_found=False))
     check_if_picking_done = fields.Boolean(
         compute='_compute_check_if_picking_done',
         )

--- a/l10n_it_ddt/views/report_ddt.xml
+++ b/l10n_it_ddt/views/report_ddt.xml
@@ -34,11 +34,11 @@
                     </td>
                     <td>
                         <h6>Net Weight</h6>
-                        <div class="signature" t-field="ddt.weight"></div>
+                        <div class="signature"><span t-field="ddt.weight"/> <span t-field="ddt.weight_manual_uom_id"/></div>
                     </td>
                     <td>
                         <h6>Gross Weight</h6>
-                        <div class="signature" t-field="ddt.gross_weight"></div>
+                        <div class="signature"><span t-field="ddt.gross_weight"/> <span t-field="ddt.gross_weight_uom_id"/></div>
                     </td>
                 </tr>
                 <tr>
@@ -47,8 +47,8 @@
                         <div class="signature" t-field="ddt.carrier_id.name"></div>
                     </td>
                     <td>
-                        <h6>Date</h6>
-                        <div class="signature" t-field="ddt.date" t-field-options='{"widget": "date"}'></div>
+                        <h6>Shipping date</h6>
+                        <div class="signature" t-field="ddt.date_done" t-options='{"widget": "date"}'></div>
                     </td>
                     <td>
                         <h6>Pick up time</h6>
@@ -60,7 +60,7 @@
                     </td>
                     <td>
                         <h6>Size</h6>
-                        <div class="signature" t-field="ddt.volume"></div>
+                        <div class="signature"><span t-field="ddt.volume"/> <span t-field="ddt.volume_uom_id"/></div>
                     </td>
                 </tr>
             </table>
@@ -106,7 +106,7 @@
                         </div>
                     </div>
                     <br/>
-                    <h1>TD number: <span t-field="o.ddt_number"></span></h1>
+                    <h2>TD number: <span t-field="o.ddt_number"></span> - <span t-field="o.date" t-options='{"widget": "date"}'></span></h2>
                     <table class="table table-condensed">
                         <t t-set="has_serial_number"
                            t-value="o.line_ids.filtered('lot_ids')"
@@ -115,6 +115,7 @@
                             <tr>
                                 <th><strong>Description</strong></th>
                                 <th class="text-right"><strong>Quantity</strong></th>
+                                <th class="text-left" groups="uom.group_uom"><strong>UoM</strong></th>
                                 <th name="lot_serial" t-if="has_serial_number" class="text-right">
                                     <strong>Lots/Serial Numbers</strong>
                                 </th>
@@ -128,6 +129,7 @@
                             <tr t-foreach="o.line_ids" t-as="line">
                                 <td><span t-field="line.name"></span></td>
                                 <td class="text-right"><span t-field="line.product_uom_qty"></span></td>
+                                <td class="text-left" groups="uom.group_uom"><span t-field="line.product_uom_id"></span></td>
                                 <t t-if="has_serial_number">
                                     <t t-set="lot_dict" t-value="line.quantity_by_lot()"/>
                                     <td class="text-right">

--- a/l10n_it_ddt/views/stock_picking_package_preparation.xml
+++ b/l10n_it_ddt/views/stock_picking_package_preparation.xml
@@ -30,6 +30,10 @@
                            domain="[('type_tax_use','=','sale'),('company_id','=',parent.company_id)]"/>
                 </xpath>
 
+                <field name="date_done" position="attributes">
+                    <attribute name="readonly">0</attribute>
+                </field>
+
             </field>
         </record>
 
@@ -140,22 +144,38 @@
                     <page string="Shipping Informations"
                           attrs="{'invisible':[('ddt_type_id', '=', False)]}">
                         <group>
-                            <field name="carriage_condition_id"
-                                   attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
-                            <field name="goods_description_id"
-                                   attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
-                            <field name="transportation_reason_id"
-                                   attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
-                            <field name="transportation_method_id"
-                                   attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
-                            <field name="carrier_id"/>
-                            <field name="parcels"
-                                   attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
-                            <field name="volume"/>
-                            <field name="weight"/>
-                            <field name="weight_manual"/>
-                            <field name="gross_weight"/>
-                            <field name="show_price"/>
+                            <group>
+                                <field name="parcels"
+                                       attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
+                                <label for="volume"/>
+                                <div class="o_row">
+                                    <field name="volume"/>
+                                    <field name="volume_uom_id" groups="uom.group_uom" widget="selection"/>
+                                </div>
+                                <field name="weight"/>
+                                <label for="weight_manual"/>
+                                <div class="o_row">
+                                    <field name="weight_manual"/>
+                                    <field name="weight_manual_uom_id" groups="uom.group_uom" widget="selection"/>
+                                </div>
+                                <label for="gross_weight"/>
+                                <div class="o_row">
+                                    <field name="gross_weight"/>
+                                    <field name="gross_weight_uom_id" groups="uom.group_uom" widget="selection"/>
+                                </div>
+                                <field name="show_price"/>
+                            </group>
+                            <group>
+                                <field name="carriage_condition_id"
+                                       attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
+                                <field name="goods_description_id"
+                                       attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
+                                <field name="transportation_reason_id"
+                                       attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
+                                <field name="transportation_method_id"
+                                       attrs="{'required':[('ddt_type_id', '!=', False)]}"/>
+                                <field name="carrier_id"/>
+                            </group>
                         </group>
                     </page>
                 </notebook>


### PR DESCRIPTION
Sulla stampa riportare il campo data di spedizione, non stampare l'ora
Permettere di modificare la data di spedizione anche nello stato confermato
Indicare le unità di misura anche nei campi Peso lordo, Peso netto, volume
Nella stampa, nelle righe, visualizzare l'unità di misura
Impedire di modificare il tipo DDT se completato o annullato





--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
