### PR TITLE
[8.0]  l10n_it_fatturapa_in: Correct _get_tax_amount() function

### DIFF
--- a/l10n_it_fatturapa_in/__openerp__.py
+++ b/l10n_it_fatturapa_in/__openerp__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '8.0.1.1.6',
+    'version': '8.0.1.1.7',
     'category': 'Localization/Italy',
     'summary': 'Electronic invoices reception',
     'author': 'Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -374,7 +374,7 @@ class WizardImportFatturapa(models.TransientModel):
             )
             line_tax = self.env['account.tax'].browse(line_tax_id)
             if new_tax.id != line_tax_id:
-                if new_tax._get_tax_amount() != line_tax._get_tax_amount():
+                if new_tax.amount != line_tax.amount:
                     self.log_inconsistency(_(
                         "XML contains tax %s. Product %s has tax %s. Using "
                         "the XML one"


### PR DESCRIPTION
Removed the _get_tax_amount () function because the calculation on "Tax on Children" occurs differently from odoo10

Descrizione del problema o della funzionalità:

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
