### PR TITLE
10.0 ddt invoice down payments

### DIFF
--- a/l10n_it_ddt/__manifest__.py
+++ b/l10n_it_ddt/__manifest__.py
@@ -11,7 +11,7 @@
 
 {
     'name': 'DDT',
-    'version': '10.0.1.7.3',
+    'version': '10.0.1.7.4',
     'category': 'Localization/Italy',
     'summary': 'Documento di Trasporto',
     'author': 'Davide Corio, Odoo Community Association (OCA),'

--- a/l10n_it_ddt/models/sale.py
+++ b/l10n_it_ddt/models/sale.py
@@ -126,8 +126,8 @@ class SaleOrder(models.Model):
         result = mod_obj.get_object_reference(
             'stock_picking_package_preparation',
             'action_stock_picking_package_preparation')
-        id = result and result[1] or False
-        result = act_obj.browse(id).read()[0]
+        act_id = result and result[1] or False
+        result = act_obj.browse(act_id).read()[0]
 
         ddt_ids = []
         for so in self:

--- a/l10n_it_ddt/models/stock.py
+++ b/l10n_it_ddt/models/stock.py
@@ -19,6 +19,9 @@ class StockPicking(models.Model):
         column2='stock_picking_package_preparation_id',
         string='DdT',
         copy=False, )
+    ddt_type = fields.Many2one(
+        'stock.ddt.type',
+        related='picking_type_id.default_location_src_id.type_ddt_id')
 
     @api.multi
     def write(self, values):

--- a/l10n_it_ddt/models/stock_picking_package_preparation.py
+++ b/l10n_it_ddt/models/stock_picking_package_preparation.py
@@ -181,7 +181,7 @@ class StockPickingPackagePreparation(models.Model):
         # ----- Check if exist a stock picking whose state is 'done'
         for record_picking in self.picking_ids:
             if record_picking.state == 'done':
-                raise UserError((
+                raise UserError(_(
                     "Impossible to put in pack a picking whose state "
                     "is 'done'"))
         for package in self:

--- a/l10n_it_ddt/models/stock_picking_package_preparation.py
+++ b/l10n_it_ddt/models/stock_picking_package_preparation.py
@@ -414,8 +414,8 @@ class StockPickingPackagePreparation(models.Model):
                         invoices[group_key].id, line.product_uom_qty)
 
             # Create invoice lines for down payments
-            if self._context.get('subtract_down_payment_invoice',
-                                 False) and order:
+            if self.env.context.get(
+                    'subtract_down_payment_invoice', False) and order:
                 for order_line in order.order_line.filtered(
                         lambda l: l.invoice_status == 'to invoice'):
                     if order_line.product_id and \
@@ -423,7 +423,9 @@ class StockPickingPackagePreparation(models.Model):
                             down_payment_product_id:
                         line_data = order_line._prepare_invoice_line(
                             order_line.qty_to_invoice)
-                        line_data['sale_line_ids'] = [(6, 0, [order_line.id])]
+                        sale_line_ids_data = line_data.get('sale_line_ids', [])
+                        sale_line_ids_data.append((6, 0, [order_line.id]))
+                        line_data['sale_line_ids'] = sale_line_ids_data
                         invoices[group_key].invoice_line_ids = [
                             (0, 0, line_data)]
 

--- a/l10n_it_ddt/wizard/ddt_create_invoice.py
+++ b/l10n_it_ddt/wizard/ddt_create_invoice.py
@@ -13,13 +13,18 @@ class DdtCreateInvoice(models.TransientModel):
         return self.env['stock.picking.package.preparation'].browse(
             self.env.context['active_ids'])
 
+    subtract_down_payment_invoice = fields.Boolean(
+        'Subtract Down Payment Invoice')
     ddt_ids = fields.Many2many(
         'stock.picking.package.preparation', default=_get_ddt_ids)
 
     @api.multi
     def create_invoice(self):
         if self.ddt_ids:
-            invoice_ids = self.ddt_ids.action_invoice_create()
+            subtract_down_payment_invoice = self.subtract_down_payment_invoice
+            invoice_ids = self.ddt_ids.with_context(
+                subtract_down_payment_invoice=subtract_down_payment_invoice
+                ).action_invoice_create()
             # ----- Show new invoices
             if invoice_ids:
                 ir_model_data = self.env['ir.model.data']

--- a/l10n_it_ddt/wizard/ddt_create_invoice.xml
+++ b/l10n_it_ddt/wizard/ddt_create_invoice.xml
@@ -6,6 +6,11 @@
             <field name="model">ddt.create.invoice</field>
             <field name="arch" type="xml">
               <form string="DDT Create Invoice">
+                <group>
+                  <group>
+                    <field name="subtract_down_payment_invoice"/>
+                  </group>
+                </group>
                 <separator string="DDT" />
                     <field string="DDT" name="ddt_ids" readonly="0">
                         <tree create="false">
@@ -23,7 +28,7 @@
                         or
                         <button string="Cancel" class="oe_link" special="cancel" />
                     </footer>
-            </form>
+              </form>
             </field>
         </record>
 

--- a/l10n_it_ddt/wizard/ddt_from_picking.py
+++ b/l10n_it_ddt/wizard/ddt_from_picking.py
@@ -213,11 +213,3 @@ class DdTFromPickings(models.TransientModel):
             'views': [(form_id, 'form'), (tree_id, 'tree')],
             'type': 'ir.actions.act_window',
         }
-
-
-class StockPicking(models.Model):
-    _inherit = "stock.picking"
-
-    ddt_type = fields.Many2one(
-        'stock.ddt.type',
-        related='picking_type_id.default_location_src_id.type_ddt_id')


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Quando da un ordine si genera un DDT e da quel DDT una fattura, quest'ultima non tiene conto delle fatture di anticipo già presenti sull'ordine

Comportamento attuale prima di questa PR:

Creare un ordine e da questo generare un DDT.
Creare una fattura di anticipo dall'ordine.
Creare una fattura dal DDT.
La fattura del DDT copre completamente l'ordine e non considera gli anticipi.

Comportamento desiderato dopo questa PR:

Creare un ordine e da questo generare un DDT.
Creare una fattura di anticipo dall'ordine.
Creare una fattura dal DDT.
La fattura del DDT riporta gli anticipi presenti sull'ordine nella nuova fattura.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
