### PR TITLE
[12.0] IMP l10n_it_vat_statement_communication nuovi paramentri di esclusione

### DIFF
--- a/l10n_it_vat_statement_communication/README.rst
+++ b/l10n_it_vat_statement_communication/README.rst
@@ -34,6 +34,15 @@ I dati possono essere caricati da liquidazioni IVA effettuate in odoo tramite `a
 .. contents::
    :local:
 
+Configuration
+=============
+
+Nella scheda dell'imposta è possibile configurare "escludere dalle operazioni attive / passive" e/o "escludere dall'IVA esigibile / detratta".
+
+La prima opzione va utilizzata ad esempio nel caso di operazioni in reverse charge, per escludere l'imponibile di `22% intra UE (debito)` (usata nelle autofatture attive) dal calcolo di `VP2 Totale operazioni attive`
+
+Tramite la seconda opzione è invece possibile, in casi particolari, escludere il valore dell'imposta.
+
 Usage
 =====
 

--- a/l10n_it_vat_statement_communication/__manifest__.py
+++ b/l10n_it_vat_statement_communication/__manifest__.py
@@ -19,6 +19,7 @@
         'security/ir.model.access.csv',
         'views/comunicazione_liquidazione.xml',
         'views/config.xml',
+        'views/account.xml',
         'wizard/export_file_view.xml',
         'security/security.xml',
     ],

--- a/l10n_it_vat_statement_communication/models/__init__.py
+++ b/l10n_it_vat_statement_communication/models/__init__.py
@@ -1,3 +1,4 @@
 
 from . import comunicazione_liquidazione
 from . import config
+from . import account

--- a/l10n_it_vat_statement_communication/models/account.py
+++ b/l10n_it_vat_statement_communication/models/account.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class AccountTaxCode(models.Model):
+    _inherit = "account.tax"
+
+    vsc_exclude_operation = fields.Boolean(
+        string='Exclude from active / passive operations')
+
+    vsc_exclude_vat = fields.Boolean(
+        string='Exclude from VAT payable / deducted')

--- a/l10n_it_vat_statement_communication/models/account.py
+++ b/l10n_it_vat_statement_communication/models/account.py
@@ -1,7 +1,7 @@
 from odoo import fields, models
 
 
-class AccountTaxCode(models.Model):
+class AccountTax(models.Model):
     _inherit = "account.tax"
 
     vsc_exclude_operation = fields.Boolean(

--- a/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
+++ b/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
@@ -549,6 +549,8 @@ class ComunicazioneLiquidazioneVp(models.Model):
         for debit in liq.debit_vat_account_line_ids:
             debit_taxes |= debit.tax_id
         for debit_tax in debit_taxes:
+            if debit_tax.vsc_exclude_operation:
+                continue
             tax = debit_taxes.with_context(
                 self._get_tax_context(period)).browse(debit_tax.id)
             self.imponibile_operazioni_attive += (
@@ -560,6 +562,8 @@ class ComunicazioneLiquidazioneVp(models.Model):
         for credit in liq.credit_vat_account_line_ids:
             credit_taxes |= credit.tax_id
         for credit_tax in credit_taxes:
+            if credit_tax.vsc_exclude_operation:
+                continue
             tax = credit_taxes.with_context(
                 self._get_tax_context(period)).browse(credit_tax.id)
             self.imponibile_operazioni_passive -= (
@@ -584,9 +588,13 @@ class ComunicazioneLiquidazioneVp(models.Model):
 
                 # Iva esigibile
                 for vat_amount in liq.debit_vat_account_line_ids:
+                    if vat_amount.tax_id.vsc_exclude_vat:
+                        continue
                     quadro.iva_esigibile += vat_amount.amount
                 # Iva detratta
                 for vat_amount in liq.credit_vat_account_line_ids:
+                    if vat_amount.tax_id.vsc_exclude_vat:
+                        continue
                     quadro.iva_detratta += vat_amount.amount
                 # credito/debito periodo precedente
                 quadro.debito_periodo_precedente =\

--- a/l10n_it_vat_statement_communication/readme/CONFIGURE.rst
+++ b/l10n_it_vat_statement_communication/readme/CONFIGURE.rst
@@ -1,0 +1,5 @@
+Nella scheda dell'imposta è possibile configurare "Escludere dalle operazioni attive / passive" e/o "Escludere dall'IVA esigibile / detratta".
+
+La prima opzione va utilizzata ad esempio nel caso di operazioni in inversione contabile (reverse charge), per escludere l'imponibile di `22% intra UE (debito)` (usata nelle autofatture attive) dal calcolo di `VP2 Totale operazioni attive`
+
+Tramite la seconda opzione è invece possibile, in casi particolari, escludere il valore dell'imposta.

--- a/l10n_it_vat_statement_communication/static/description/index.html
+++ b/l10n_it_vat_statement_communication/static/description/index.html
@@ -373,25 +373,32 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#id1">Configuration</a></h1>
+<p>Nella scheda dell’imposta è possibile configurare “escludere dalle operazioni attive / passive” e/o “escludere dall’IVA esigibile / detratta”.</p>
+<p>La prima opzione va utilizzata ad esempio nel caso di operazioni in reverse charge, per escludere l’imponibile di <cite>22% intra UE (debito)</cite> (usata nelle autofatture attive) dal calcolo di <cite>VP2 Totale operazioni attive</cite></p>
+<p>Tramite la seconda opzione è invece possibile, in casi particolari, escludere il valore dell’imposta.</p>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id1">Usage</a></h1>
+<h1><a class="toc-backref" href="#id2">Usage</a></h1>
 <ul class="simple">
 <li>Creare una nuova comunicazione.</li>
 <li>Nel “Quadro VP” aggiungere una voce selezionando in alto la liquidazione, precedentemente creata, da inserire.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-italy/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -399,15 +406,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Openforce di Camilli Alessandro</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li>Alessandro Camilli</li>
 <li>Lorenzo Battistini</li>
@@ -415,7 +422,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/l10n_it_vat_statement_communication/views/account.xml
+++ b/l10n_it_vat_statement_communication/views/account.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_tax_vsc_form" model="ir.ui.view">
+        <field name="name">vsc.account.tax.form</field>
+        <field name="model">account.tax</field>
+        <field name="inherit_id"
+               ref="account_vat_period_end_statement.view_tax_form_vat"/>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='vat_statement_account_id']"
+                   position="after">
+                <field name="vsc_exclude_operation"/>
+                <field name="vsc_exclude_vat"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Aggiunti 3 paramentri:
1 nella configigurazione dell'azienda, per indicare il codice per l'invio della dichiarazione 
2 flag nell'imposta:  
* Escludi da operazioni attive/passive ​
* Escludi da iva esigibile/detratta







--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
