### PR TITLE
[11.0] l10n_it_account: constrain upon accounts and account groups + account_balance_sign for account.account.type

### DIFF
--- a/l10n_it_account/__init__.py
+++ b/l10n_it_account/__init__.py
@@ -1,3 +1,9 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from odoo import api, SUPERUSER_ID
+
+
+def _l10n_it_account_post_init(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['account.account.type'].set_account_types_negative_sign()

--- a/l10n_it_account/__manifest__.py
+++ b/l10n_it_account/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Account',
-    'version': '11.0.1.2.2',
+    'version': '11.0.1.2.3',
     'category': 'Hidden',
     'author': "Agile Business Group, Abstract, "
               "Odoo Community Association (OCA)",

--- a/l10n_it_account/__manifest__.py
+++ b/l10n_it_account/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Italian Localization - Account',
-    'version': '11.0.1.2.3',
+    'version': '11.0.1.3.0',
     'category': 'Hidden',
     'author': "Agile Business Group, Abstract, "
               "Odoo Community Association (OCA)",
@@ -21,10 +21,12 @@
     "data": [
         'views/account_setting.xml',
         'views/account_menuitem.xml',
+        'views/account_view.xml',
         'views/partner_view.xml',
         'views/product_view.xml',
         'views/res_config_settings_views.xml',
         'reports/account_reports_view.xml',
     ],
     'installable': True,
+    'post_init_hook': '_l10n_it_account_post_init',
 }

--- a/l10n_it_account/migrations/12.0.1.3.0/post-migration.py
+++ b/l10n_it_account/migrations/12.0.1.3.0/post-migration.py
@@ -1,0 +1,11 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        env['account.account.type'].set_account_types_negative_sign()

--- a/l10n_it_account/models/__init__.py
+++ b/l10n_it_account/models/__init__.py
@@ -3,3 +3,4 @@
 from . import account_account
 from . import account_group
 from . import account_tax
+from . import account_type

--- a/l10n_it_account/models/__init__.py
+++ b/l10n_it_account/models/__init__.py
@@ -1,3 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import account_account
+from . import account_group
 from . import account_tax

--- a/l10n_it_account/models/account_account.py
+++ b/l10n_it_account/models/account_account.py
@@ -1,0 +1,11 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class Account(models.Model):
+    _inherit = 'account.account'
+
+    @api.constrains('group_id')
+    def check_group_constrain_account_types(self):
+        self.mapped('group_id').check_constrain_account_types()

--- a/l10n_it_account/models/account_group.py
+++ b/l10n_it_account/models/account_group.py
@@ -1,11 +1,21 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
 class AccountGroup(models.Model):
     _inherit = 'account.group'
+
+    account_ids = fields.One2many(
+        comodel_name='account.account',
+        inverse_name='group_id',
+        string="Accounts",
+    )
+    account_balance_sign = fields.Integer(
+        compute="_compute_account_balance_sign",
+        string="Balance sign",
+    )
 
     @api.constrains('account_ids')
     def check_constrain_account_types(self):
@@ -17,3 +27,19 @@ class AccountGroup(models.Model):
         ])
         if error_msg:
             raise ValidationError(error_msg)
+
+    @api.multi
+    def _compute_account_balance_sign(self):
+        for group in self:
+            acc_type = group.get_first_account_type()
+            if acc_type:
+                group.account_balance_sign = acc_type.account_balance_sign
+            else:
+                group.account_balance_sign = 1
+
+    def get_first_account_type(self):
+        if self.account_ids:
+            return self.account_ids[0].user_type_id
+        children = self.search([('parent_id', '=', self.id)])
+        for child in children:
+            return child.get_first_account_type()

--- a/l10n_it_account/models/account_group.py
+++ b/l10n_it_account/models/account_group.py
@@ -1,0 +1,19 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class AccountGroup(models.Model):
+    _inherit = 'account.group'
+
+    @api.constrains('account_ids')
+    def check_constrain_account_types(self):
+        error_msg = '\n'.join([
+            _("Cannot link accounts of different types to group '{}'."
+              .format(group.name))
+            for group in self
+            if len(group.account_ids.mapped('user_type_id').ids) > 1
+        ])
+        if error_msg:
+            raise ValidationError(error_msg)

--- a/l10n_it_account/models/account_type.py
+++ b/l10n_it_account/models/account_type.py
@@ -1,0 +1,27 @@
+from odoo import models, fields, api
+
+ACCOUNT_TYPES_NEGATIVE_SIGN = [
+    'account.data_unaffected_earnings',
+    'account.data_account_type_revenue',
+    'account.data_account_type_other_income',
+    'account.data_account_type_payable',
+    'account.data_account_type_credit_card',
+    'account.data_account_type_prepayments',
+    'account.data_account_type_current_liabilities',
+    'account.data_account_type_non_current_liabilities',
+]
+
+
+class AccountType(models.Model):
+    _inherit = 'account.account.type'
+    account_balance_sign = fields.Integer(
+        default=1,
+        string="Balance sign",
+    )
+
+    @api.model
+    def set_account_types_negative_sign(self):
+        for xml_id in ACCOUNT_TYPES_NEGATIVE_SIGN:
+            acc_type = self.env.ref(xml_id, raise_if_not_found=False)
+            if acc_type:
+                acc_type.account_balance_sign = -1

--- a/l10n_it_account/tests/__init__.py
+++ b/l10n_it_account/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_l10n_it_account

--- a/l10n_it_account/tests/test_l10n_it_account.py
+++ b/l10n_it_account/tests/test_l10n_it_account.py
@@ -1,0 +1,32 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+from odoo.exceptions import ValidationError
+
+
+class TestAccount(TransactionCase):
+
+    def setUp(self):
+        super(TestAccount, self).setUp()
+        self.data_account_type_current_assets = self.env.ref(
+            'account.data_account_type_current_assets')
+        self.data_account_type_current_liabilities = self.env.ref(
+            'account.data_account_type_current_liabilities')
+        self.group_1 = self.env['account.group'].create({
+            'name': '1'
+        })
+
+    def test_group_constraint(self):
+        self.env['account.account'].create({
+            'name': 'it_account_1',
+            'code': 'it_account_1',
+            'group_id': self.group_1.id,
+            'user_type_id': self.data_account_type_current_assets.id
+        })
+        with self.assertRaises(ValidationError):
+            self.env['account.account'].create({
+                'name': 'it_account_2',
+                'code': 'it_account_2',
+                'group_id': self.group_1.id,
+                'user_type_id': self.data_account_type_current_liabilities.id
+            })

--- a/l10n_it_account/views/account_view.xml
+++ b/l10n_it_account/views/account_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_type_form_sign" model="ir.ui.view">
+        <field name="name">account.account.type.form.sign</field>
+        <field name="model">account.account.type</field>
+        <field name="inherit_id" ref="account.view_account_type_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group/group/field[@name='type']" position="after">
+                <field name="account_balance_sign"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_account_group_form_sign" model="ir.ui.view">
+        <field name="name">account.group.form.sign</field>
+        <field name="model">account.group</field>
+        <field name="inherit_id" ref="account.view_account_group_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group/field[@name='code_prefix']" position="after">
+                <field name="account_balance_sign"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Descrizione del problema o della funzionalità: aggiunta constrain che impedisce ad un gruppo di conti di avere differenti tipologie di conto.

Comportamento attuale prima di questa PR: nessun controllo in merito.

Comportamento desiderato dopo questa PR: viene lanciato errore se l'utente prova ad associare un conto di tipo X ad un gruppo composto da conti di tipo Y. Nessun gruppo di conti può avere conti di tipi diversi (se impostati).


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
