### PR TITLE
[12.0] FIX l10n_it_sdi_channel: allow to set first_invoice_sent.

### DIFF
--- a/l10n_it_sdi_channel/models/sdi.py
+++ b/l10n_it_sdi_channel/models/sdi.py
@@ -46,7 +46,9 @@ class SdiChannelPEC(models.Model):
         default=lambda self: self.env['ir.config_parameter'].get_param(
             'sdi.pec.first.address')
     )
-    first_invoice_sent = fields.Boolean("First invoice sent", readonly=True)
+    first_invoice_sent = fields.Boolean(
+        "First e-invoice sent",
+        help="This is set after having sent the first e-invoice to SDI")
 
     @api.constrains('pec_server_id')
     def check_pec_server_id(self):

--- a/l10n_it_sdi_channel/views/sdi_view.xml
+++ b/l10n_it_sdi_channel/views/sdi_view.xml
@@ -31,7 +31,7 @@
                     </group>
                     <newline/>
                     <group attrs="{'invisible': [('channel_type', '!=', 'pec')]}">
-                        <field name="first_invoice_sent" invisible="1"/>
+                        <field name="first_invoice_sent"/>
                         <field name="pec_server_id" context="{'default_is_fatturapa_pec': True}"
                                attrs="{'required': [('channel_type', '=', 'pec')]}"/>
                         <field name="email_exchange_system"


### PR DESCRIPTION
This is useful when starting using odoo after having already sent e-invoices via PEC


Comportamento attuale prima di questa PR:

L'utente che inizia a usare odoo viene obbligato a inviare la prima e-fattura a sdi01@pec.fatturapa.it

Comportamento desiderato dopo questa PR:

L'utente  indicare che la prima fattura all'SDI è già stata inviata in precedenza


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
