### PR TITLE
FIX l10n_it_fatturapa_in_purchase: allow to set PO line in invoice line

### DIFF
--- a/l10n_it_fatturapa_in_purchase/views/invoice_view.xml
+++ b/l10n_it_fatturapa_in_purchase/views/invoice_view.xml
@@ -12,10 +12,25 @@
                     <field name="purchase_line_id"
                            attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"
                            domain="[('partner_id', '=', partner_id), ('to_invoice', '=', True)]"
-                           readonly="0"
+                           readonly="0" options="{'no_create': True}"
                     />
                 </group>
             </xpath>
         </field>
     </record>
+    <record id="invoice_supplier_form_po_line" model="ir.ui.view">
+        <field name="name">invoice_supplier_form_po_line</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_supplier_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='analytic_tag_ids']" position="after">
+                <field name="partner_id" invisible="1"/>
+                <field name="purchase_line_id"
+                       domain="[('partner_id', '=', partner_id), ('to_invoice', '=', True)]"
+                       readonly="0" string="PO line" options="{'no_create': True}"
+                />
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Permettere all'utente di impostare il riferimento alla riga d'ordine d'acquisto nelle fatture passive

Comportamento attuale prima di questa PR:

L'utente non può inserire il riferimento alla riga d'ordine

Comportamento desiderato dopo questa PR:

L'utente può


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
