### PR TITLE
[11.0][FIX] l10n_it_withholding_tax: Added condition upon 'date_end' column in where clause for _get_rate method

### DIFF
--- a/l10n_it_withholding_tax/__manifest__.py
+++ b/l10n_it_withholding_tax/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Italian Withholding Tax',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Account',
     'author': 'Openforce, Odoo Italia Network, '
               'Odoo Community Association (OCA)',

--- a/l10n_it_withholding_tax/models/withholding_tax.py
+++ b/l10n_it_withholding_tax/models/withholding_tax.py
@@ -18,6 +18,7 @@ class WithholdingTax(models.Model):
             SELECT tax, base FROM withholding_tax_rate
                 WHERE withholding_tax_id = %s
                  and (date_start <= current_date or date_start is null)
+                 and (date_stop >= current_date or date_stop is null)
                 ORDER by date_start LIMIT 1''',
                             (self.id,))
         rate = self.env.cr.fetchone()


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Il metodo `_get_rate` attualmente ritorna il più vecchio record di `withholding.tax.rate` senza però tener conto se questo record sia "scaduto" o meno

Comportamento attuale prima di questa PR:
Vengono selezionati record errati

Comportamento desiderato dopo questa PR:
I record con `date_end` superato non verranno selezionati dalla query



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
