### PR TITLE
[12.0] FIX l10n_it_ddt: quantity_by_lot to correctly compute quantities

### DIFF
--- a/l10n_it_ddt/models/stock_picking_package_preparation.py
+++ b/l10n_it_ddt/models/stock_picking_package_preparation.py
@@ -719,12 +719,12 @@ class StockPickingPackagePreparationLine(models.Model):
         to its quantity (if the product is tracked with lots)"""
         self.ensure_one()
         res = {}
-        for quant in self.lot_ids.mapped('quant_ids'):
-            if quant.location_id == self.move_id.location_dest_id:
-                if quant.lot_id not in res:
-                    res[quant.lot_id] = quant.quantity
+        for move_line in self.move_id.move_line_ids:
+            if move_line.lot_id:
+                if move_line.lot_id not in res:
+                    res[move_line.lot_id] = move_line.qty_done
                 else:
-                    res[quant.lot_id] += quant.quantity
+                    res[move_line.lot_id] += move_line.qty_done
         for lot in res:
             if lot.product_id.tracking == 'lot':
                 res[lot] = formatLang(self.env, res[lot])

--- a/l10n_it_fatturapa_out_ddt/tests/test_fatturapa_ddt.py
+++ b/l10n_it_fatturapa_out_ddt/tests/test_fatturapa_ddt.py
@@ -69,6 +69,9 @@ class TestInvoiceDDT(FatturaPACommon):
         self.so2.ddt_ids[0].ddt_number = 'DDT/0101'
         self.so1.ddt_ids[0].set_done()
         self.so2.ddt_ids[0].set_done()
+        # Set sequence to have the expected order in XML
+        self.so1.ddt_ids.line_ids[0].sequence = 1
+        self.so2.ddt_ids.line_ids[0].sequence = 2
         invoice_wizard = self.env['ddt.create.invoice'].with_context(
             {'active_ids': (self.so1.ddt_ids | self.so2.ddt_ids).ids}
         ).create({})


### PR DESCRIPTION
See https://github.com/OCA/l10n-italy/issues/1326

Case fixed (see test case):

 - create product tracked by lot
 - set its inventory with qty 10 for lot1 and 10 for lot2
 - create a picking with quantity 6
 - deliver 3 products of lot1 and 3 of lot2
 - create another picking, with quantity 6
 - deliver 4 products of lot1 and 2 of lot2
 - create DDT from the last picking

Print PDF DDT and see wrong quantities: 7 and 5 instead of 4 and 2





--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
