### PR TITLE
[12.0] FIX l10n_it_fatturapa_out MIME type

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -100,6 +100,7 @@ class WizardExportFatturapa(models.TransientModel):
             'name': '%s_%s.xml' % (vat, number),
             'datas_fname': '%s_%s.xml' % (vat, number),
             'datas': base64.encodestring(fatturapa.toxml("UTF-8")),
+            'mimetype': 'text/xml',
         }
         return attach_obj.create(attach_vals)
 


### PR DESCRIPTION
After https://github.com/odoo/odoo/commit/5eb15c01b556620c77c0f7327494d4bf3117d115 setting correct mimetype for XML

Otherwise, odoo tries to guess MIME type autonomously






--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
