### PR TITLE
11.0-fix number page in footer when print report with more page

### DIFF
--- a/l10n_it_account/reports/account_reports_view.xml
+++ b/l10n_it_account/reports/account_reports_view.xml
@@ -108,7 +108,7 @@
                             fromPage[j].textContent = parseInt(eval(vars['sitepage']) + fiscal_page_base);
                         var toPage = document.getElementsByClassName('topage');
                         for(var j = 0; j&lt;toPage.length; j++)
-                            toPage[j].textContent = parseInt(eval(vars['sitepage']) + fiscal_page_base);
+                            toPage[j].textContent = parseInt(eval(vars['sitepages']) + fiscal_page_base);
 
                         var index = vars['webpage'].split('.', 4)[3]
                         var header = document.getElementById('minimal_layout_report_headers');


### PR DESCRIPTION
Before this PR, number page in footer is wrong - if there are 2 page: page 1 of 1; in second page: page 2 of 2
After this PR, Number page in footer is right

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing