### PR TITLE
[12.0]  l10n_it_fatturapa_in: Handle VAT number accepted by SDI but not accepted by odoo

### DIFF
--- a/l10n_it_fatturapa_in/tests/data/IT01234567890_FPR03.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT01234567890_FPR03.xml
@@ -65,7 +65,7 @@
         <DatiAnagraficiVettore>				
           <IdFiscaleIVA>
             <IdPaese>IT</IdPaese>
-            <IdCodice>04507990150</IdCodice>
+            <IdCodice>0233599054</IdCodice>
           </IdFiscaleIVA>
           <Anagrafica>
             <Denominazione>Trasporto spa</Denominazione>


### PR DESCRIPTION
Vedi test automatico: l'XML modificato viene accettato da SDI ma non da odoo

TODO
https://github.com/OCA/l10n-italy/pull/1345


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
