### PR TITLE
[8.0] Fix VAT check in import fatturapa

### DIFF
--- a/l10n_it_fatturapa_in/__openerp__.py
+++ b/l10n_it_fatturapa_in/__openerp__.py
@@ -8,7 +8,7 @@
 
 {
     'name': 'Italian Localization - Fattura elettronica - Ricezione',
-    'version': '8.0.1.1.8',
+    'version': '8.0.1.1.9',
     'category': 'Localization/Italy',
     'summary': 'Electronic invoices reception',
     'author': 'Agile Business Group, Innoviu, '

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import vatnumber
 from openerp import models, api, fields, _
 from openerp.tools import float_is_zero
 from openerp.exceptions import Warning as UserError
@@ -124,6 +125,22 @@ class WizardImportFatturapa(models.TransientModel):
                 )
         partners = partner_model
         if vat:
+            is_vat = vatnumber.check_vat(vat)
+            if is_vat:
+                partners = partner_model.search([
+                    ('vat', '=', vat),
+                ])
+            else:
+                self.log_inconsistency(
+                        _(
+                            'The VAT number %s of the carrier/transporter %s is not valid'
+                        )
+                        % (
+                            vat,
+                            DatiAnagrafici.Anagrafica.Denominazione
+                        )
+                    )
+                return False
             partners = partner_model.search([
                 ('vat', '=', vat),
             ])


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Verifica se la partita iva del fornitore è valida prima dell'inserimento della fattura

Comportamento attuale prima di questa PR:
Se la partita iva non è valida, per un qualche errore di inserimento del fornitore odoo da errore e si blocca e non si riesce ad importare la fattura.

Comportamento desiderato dopo questa PR:
Controlla la P.IVA se è valida continua normalmente se invece non esiste importa comunque ma senza indicare il partner. Questa soluzione è valida quando si tratta del Vettore Trasportatore, Intermediario



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
