### PR TITLE
[11.0][FIX][l10n_it_vat_registries]

### DIFF
--- a/l10n_it_vat_registries/models/vat_registry.py
+++ b/l10n_it_vat_registries/models/vat_registry.py
@@ -113,7 +113,7 @@ class ReportRegistroIva(models.AbstractModel):
 
             if (
                 'receivable' in move.move_type or
-                ('payable_refund' == move.move_type and tax_amount > 0)
+                'payable_refund' == move.move_type
             ):
                 # otherwise refund would be positive and invoices
                 # negative.


### PR DESCRIPTION
Negative tax line in supplier invoice, must be negative in vat register line

Descrizione del problema o della funzionalità:
https://github.com/OCA/l10n-italy/issues/1355

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
