### PR TITLE
[10.0][IMP][l10n_it_fatturapa_in] Set the supplier invoice bill regis…

### DIFF
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -41,6 +41,9 @@ class AccountInvoice(models.Model):
     e_invoice_force_validation = fields.Boolean(
         string='Force E-Invoice Validation')
 
+    e_invoice_received_date = fields.Date(
+        string='E-Bill Received Date')
+
     @api.multi
     def invoice_validate(self):
         for invoice in self:

--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -30,6 +30,8 @@ class FatturaPAAttachmentIn(models.Model):
     registered = fields.Boolean(
         "Registered", compute="_compute_registered", store=True)
 
+    e_invoice_received_date = fields.Datetime(string='E-Bill Received Date')
+
     e_invoice_validation_error = fields.Boolean(
         compute='_compute_e_invoice_validation_error')
 

--- a/l10n_it_fatturapa_in/views/account_view.xml
+++ b/l10n_it_fatturapa_in/views/account_view.xml
@@ -20,6 +20,7 @@
                         <group>
                             <field name="xml_supplier_id"/>
                             <field name="invoices_number"/>
+                            <field name="e_invoice_received_date"/>
                             <field name="registered"/>
                             <field name="invoices_total"/>
                         </group>
@@ -123,6 +124,7 @@
             <field name="date_invoice" position="before">
                 <field name="sender" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
                 <field name="protocol_number" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
+                <field name="e_invoice_received_date" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
             </field>
             <field name="price_unit" position="before">
                 <field name="fatturapa_attachment_in_id" invisible="1"/>

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -866,6 +866,9 @@ class WizardImportFatturapa(models.TransientModel):
                 comment += rel_doc + '\n'
 
         invoice_data = {
+            'e_invoice_received_date':
+                fatturapa_attachment.e_invoice_received_date or
+                fatturapa_attachment.create_date,
             'fiscal_document_type_id': docType_id,
             'sender': fatt.FatturaElettronicaHeader.SoggettoEmittente or False,
             'account_id': pay_acc_id,

--- a/l10n_it_fatturapa_pec/models/mail_thread.py
+++ b/l10n_it_fatturapa_pec/models/mail_thread.py
@@ -124,7 +124,7 @@ class MailThread(models.AbstractModel):
         for attachment in self.env['ir.attachment'].browse(
                 [att_id for m, att_id in attachment_ids]):
             if fatturapa_regex.match(attachment.name):
-                self.create_fatturapa_attachment_in(attachment)
+                self.create_fatturapa_attachment_in(attachment, message_dict)
         message_dict['attachment_ids'] = attachment_ids
         self.clean_message_dict(message_dict)
         # model and res_id are only needed by
@@ -155,10 +155,13 @@ class MailThread(models.AbstractModel):
                 return fatturapa_attachment_out
         return attachment_out_model.browse()
 
-    def create_fatturapa_attachment_in(self, attachment):
+    def create_fatturapa_attachment_in(self, attachment, message_dict=None):
         decoded = base64.b64decode(attachment.datas)
         fatturapa_attachment_in = self.env['fatturapa.attachment.in']
         fetchmail_server_id = self.env.context.get('fetchmail_server_id')
+        received_date = False
+        if message_dict is not None and 'date' in message_dict:
+            received_date = message_dict['date']
         company_id = False
         e_invoice_user_id = False
         if fetchmail_server_id:
@@ -189,6 +192,7 @@ class MailThread(models.AbstractModel):
                                 'datas_fname': file_name,
                                 'datas': base64.encodestring(inv_file.read()),
                                 'company_id': company_id,
+                                'e_invoice_received_date': received_date,
                             })
         else:
             fatturapa_atts = fatturapa_attachment_in.search(
@@ -201,4 +205,5 @@ class MailThread(models.AbstractModel):
                 fatturapa_attachment_in.create({
                     'ir_attachment_id': attachment.id,
                     'company_id': company_id,
+                    'e_invoice_received_date': received_date,
                 })

--- a/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
+++ b/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
@@ -4,6 +4,8 @@
 
 from .e_invoice_common import EInvoiceCommon
 from odoo.modules import get_module_resource
+from odoo.fields import Datetime
+
 import mock
 
 
@@ -91,6 +93,9 @@ class TestEInvoiceResponse(EInvoiceCommon):
 
         e_invoices = self.attach_in_model.search([])
 
+        msg_dict = self.env['mail.thread'] \
+            .message_parse(message=incoming_mail)
+
         self.env['mail.thread'] \
             .with_context(fetchmail_server_id=self.PEC_server.id) \
             .message_process(False, incoming_mail)
@@ -98,6 +103,9 @@ class TestEInvoiceResponse(EInvoiceCommon):
         e_invoices = self.attach_in_model.search([]) - e_invoices
 
         self.assertTrue(e_invoices)
+        self.assertEqual(
+            Datetime.from_string(e_invoices.e_invoice_received_date),
+            Datetime.from_string(msg_dict['date']))
         self.assertEqual(e_invoices.xml_supplier_id.vat,
                          'IT02652600210')
 


### PR DESCRIPTION
…tration date as indicated in the incoming PEC from SDI

Descrizione del problema o della funzionalità:

La data competenza di una fattura di acquisto elettronica dovrebbe essere quella al momento del prelievo dalla PEC

Comportamento attuale prima di questa PR:

Attualmente non viene gestita

Comportamento desiderato dopo questa PR:

Setta la data competenza della registrazione delle fattura di acquisto prendendo l'informazione dalla PEC inviata dallo SDI

Vedi https://github.com/OCA/l10n-italy/issues/1364

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
