### PR TITLE
[12.0][IMP][l10n_it_fatturapa_in] Set the supplier invoice bill regis…

### DIFF
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -40,6 +40,9 @@ class AccountInvoice(models.Model):
     e_invoice_force_validation = fields.Boolean(
         string='Force E-Invoice Validation')
 
+    e_invoice_received_date = fields.Date(
+        string='E-Bill Received Date')
+
     @api.multi
     def invoice_validate(self):
         for invoice in self:

--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -32,6 +32,8 @@ class FatturaPAAttachmentIn(models.Model):
     registered = fields.Boolean(
         "Registered", compute="_compute_registered", store=True)
 
+    e_invoice_received_date = fields.Datetime(string='E-Bill Received Date')
+
     e_invoice_validation_error = fields.Boolean(
         compute='_compute_e_invoice_validation_error')
 

--- a/l10n_it_fatturapa_in/views/account_view.xml
+++ b/l10n_it_fatturapa_in/views/account_view.xml
@@ -26,6 +26,7 @@
                         <group>
                             <field name="xml_supplier_id"/>
                             <field name="invoices_number"/>
+                            <field name="e_invoice_received_date"/>
                             <field name="registered"/>
                             <field name="invoices_total"/>
                         </group>
@@ -129,6 +130,7 @@
             <field name="date_invoice" position="before">
                 <field name="sender" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
                 <field name="protocol_number" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
+                <field name="e_invoice_received_date" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
             </field>
             <field name="price_unit" position="before">
                 <field name="fatturapa_attachment_in_id" invisible="1"/>

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -870,7 +870,14 @@ class WizardImportFatturapa(models.TransientModel):
             for rel_doc in causLst:
                 comment += rel_doc + '\n'
 
+        if fatturapa_attachment.e_invoice_received_date:
+            e_invoice_received_date = fatturapa_attachment.\
+                e_invoice_received_date.date()
+        else:
+            e_invoice_received_date = fatturapa_attachment.create_date.date()
+
         invoice_data = {
+            'e_invoice_received_date': e_invoice_received_date,
             'fiscal_document_type_id': docType_id,
             'sender': fatt.FatturaElettronicaHeader.SoggettoEmittente or False,
             'account_id': pay_acc_id,

--- a/l10n_it_fatturapa_pec/models/mail_thread.py
+++ b/l10n_it_fatturapa_pec/models/mail_thread.py
@@ -65,7 +65,8 @@ class MailThread(models.AbstractModel):
                 for attachment in self.env['ir.attachment'].browse(
                         [att_id for m, att_id in attachment_ids]):
                     if fatturapa_regex.match(attachment.name):
-                        self.create_fatturapa_attachment_in(attachment)
+                        self.create_fatturapa_attachment_in(attachment,
+                                                            message_dict)
 
                 message_dict['attachment_ids'] = attachment_ids
                 self.clean_message_dict(message_dict)
@@ -177,10 +178,13 @@ class MailThread(models.AbstractModel):
                 return fatturapa_attachment_out
         return False
 
-    def create_fatturapa_attachment_in(self, attachment):
+    def create_fatturapa_attachment_in(self, attachment, message_dict=None):
         decoded = base64.b64decode(attachment.datas)
         fatturapa_attachment_in = self.env['fatturapa.attachment.in']
         fetchmail_server_id = self.env.context.get('fetchmail_server_id')
+        received_date = False
+        if message_dict is not None and 'date' in message_dict:
+            received_date = message_dict['date']
         company_id = False
         e_invoice_user_id = False
         # The incoming supplier e-bill doesn't carry which company
@@ -217,6 +221,7 @@ class MailThread(models.AbstractModel):
                                 'datas_fname': file_name,
                                 'datas': base64.encodestring(inv_file.read()),
                                 'company_id': company_id,
+                                'e_invoice_received_date': received_date,
                             })
         else:
             fatturapa_atts = fatturapa_attachment_in.search(
@@ -229,4 +234,5 @@ class MailThread(models.AbstractModel):
                 fatturapa_attachment_in.create({
                     'ir_attachment_id': attachment.id,
                     'company_id': company_id,
+                    'e_invoice_received_date': received_date,
                 })

--- a/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
+++ b/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
@@ -4,6 +4,7 @@
 
 from .e_invoice_common import EInvoiceCommon
 from odoo.modules import get_module_resource
+from odoo.fields import Datetime
 
 
 class TestEInvoiceResponse(EInvoiceCommon):
@@ -90,6 +91,9 @@ class TestEInvoiceResponse(EInvoiceCommon):
 
         e_invoices = self.attach_in_model.search([])
 
+        msg_dict = self.env['mail.thread'] \
+            .message_parse(message=incoming_mail)
+
         self.env['mail.thread'] \
             .with_context(fetchmail_server_id=self.PEC_server.id) \
             .message_process(False, incoming_mail)
@@ -97,6 +101,9 @@ class TestEInvoiceResponse(EInvoiceCommon):
         e_invoices = self.attach_in_model.search([]) - e_invoices
 
         self.assertTrue(e_invoices)
+        self.assertEqual(
+            Datetime.from_string(e_invoices.e_invoice_received_date),
+            Datetime.from_string(msg_dict['date']))
         self.assertEqual(e_invoices.xml_supplier_id.vat,
                          'IT02652600210')
 


### PR DESCRIPTION
…tration date as indicated in the incoming PEC from SDI

Descrizione del problema o della funzionalità:

La data competenza di una fattura di acquisto elettronica dovrebbe essere quella al momento del prelievo dalla PEC

Comportamento attuale prima di questa PR:

Attualmente non viene gestita

Comportamento desiderato dopo questa PR:

Setta la data competenza della registrazione delle fattura di acquisto prendendo l'informazione dalla PEC inviata dallo SDI

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
