### PR TITLE
[10.0][IMP][l10n_it_fatturapa_in] Add the possibility to optionally e…

### DIFF
--- a/l10n_it_fatturapa/models/partner.py
+++ b/l10n_it_fatturapa/models/partner.py
@@ -47,6 +47,9 @@ class ResPartner(models.Model):
     electronic_invoice_subjected = fields.Boolean(
         "Subjected to Electronic Invoice")
 
+    electronic_invoice_no_contact_update = fields.Boolean(
+        "Do not update the contact from Electronic Invoice Details")
+
     @api.multi
     @api.constrains(
         'is_pa', 'ipa_code', 'codice_destinatario', 'company_type',

--- a/l10n_it_fatturapa/views/partner_view.xml
+++ b/l10n_it_fatturapa/views/partner_view.xml
@@ -9,6 +9,7 @@
             <notebook position="inside">
             <page name="fatturapa" string="Electronic Invoice" groups="account.group_account_invoice">
                 <group name="fatturapa_group">
+                    <field name="electronic_invoice_no_contact_update" attrs="{'invisible': [('supplier', '=', False)]}"/>
                     <field name="electronic_invoice_subjected"/>
                     <group attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}">
                         <field name="ipa_code" placeholder="IPA123" attrs="{'invisible': [('is_pa','=', False)]}"/>

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -530,3 +530,20 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.assertTrue(orig_invoice.e_invoice_validation_error)
         self.assertTrue(orig_invoice.reference)
         self.assertTrue(orig_invoice.date_invoice)
+
+    def test_30_xml_import(self):
+        self.env.user.company_id.cassa_previdenziale_product_id = (
+            self.service.id)
+        res = self.run_wizard('test30', 'IT05979361218_001.xml')
+        invoice_id = res.get('domain')[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        partner_id = invoice.partner_id
+        partner_id.write({
+            'street': 'Viale Repubblica, 34',
+            'electronic_invoice_no_contact_update': True,
+        })
+        res = self.run_wizard('test30', 'IT05979361218_002.xml')
+        invoice_id = res.get('domain')[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertEqual(invoice.partner_id.id, partner_id.id)
+        self.assertEqual(invoice.partner_id.street, 'Viale Repubblica, 34')

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -177,8 +177,12 @@ class WizardImportFatturapa(models.TransientModel):
     def getCedPrest(self, cedPrest):
         partner_model = self.env['res.partner']
         partner_id = self.getPartnerBase(cedPrest.DatiAnagrafici)
-        fiscalPosModel = self.env['fatturapa.fiscal_position']
+        no_contact_update = False
         if partner_id:
+            no_contact_update = partner_model.browse(partner_id).\
+                electronic_invoice_no_contact_update
+        fiscalPosModel = self.env['fatturapa.fiscal_position']
+        if partner_id and not no_contact_update:
             partner_company_id = partner_model.browse(partner_id).company_id.id
             vals = {
                 'street': cedPrest.Sede.Indirizzo,
@@ -278,7 +282,11 @@ class WizardImportFatturapa(models.TransientModel):
     def getCarrirerPartner(self, Carrier):
         partner_model = self.env['res.partner']
         partner_id = self.getPartnerBase(Carrier.DatiAnagraficiVettore)
+        no_contact_update = False
         if partner_id:
+            no_contact_update = partner_model.browse(partner_id).\
+                electronic_invoice_no_contact_update
+        if partner_id and not no_contact_update:
             vals = {
                 'license_number':
                 Carrier.DatiAnagraficiVettore.NumeroLicenzaGuida or '',


### PR DESCRIPTION
…xclude partner from being updated from e-bill data

Descrizione del problema o della funzionalità:

Attualmente i dettagli del partner/fornitore vengono sempre e comunque aggiornati al momento dell'importazione di una fattura elettronica sovrascrivendo eventuali modifiche da parte dell'utente

Comportamento attuale prima di questa PR:

I dettagli del partner/fornitore vengono aggiornati sempre dalla fattura importata

Comportamento desiderato dopo questa PR:

Rendere opzionale l'aggiornamento di specifici partner/fornitori al momento dell'importazione delle fatture di acquisto


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
