### PR TITLE
[12.0][FIX] Fix l10n_it_fatturapa_pec to set correctly company_id as …

### DIFF
--- a/l10n_it_fatturapa_pec/__manifest__.py
+++ b/l10n_it_fatturapa_pec/__manifest__.py
@@ -23,6 +23,7 @@
     'data': [
         'security/groups.xml',
         'views/account.xml',
+        'views/company_view.xml',
         'views/fatturapa_attachment_out.xml',
         'wizard/send_pec_view.xml',
         'views/fetchmail_view.xml',

--- a/l10n_it_fatturapa_pec/models/__init__.py
+++ b/l10n_it_fatturapa_pec/models/__init__.py
@@ -4,3 +4,4 @@ from . import account
 from . import fatturapa_attachment_out
 from . import mail_thread
 from . import fetchmail
+from . import company

--- a/l10n_it_fatturapa_pec/models/company.py
+++ b/l10n_it_fatturapa_pec/models/company.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    e_invoice_user_id = fields.Many2one(
+        "res.users", "E-invoice creator",
+        help="This user will be used at supplier e-invoice creation.",
+        default=lambda self: self.env.user.id
+    )
+
+
+class AccountConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    e_invoice_user_id = fields.Many2one(
+        related='company_id.e_invoice_user_id',
+        string="Supplier e-invoice creator",
+        help="This user will be used at supplier e-invoice creation. "
+             "This setting is relevant in multi-company environments",
+        readonly=False
+    )
+
+    @api.onchange('company_id')
+    def onchange_company_id(self):
+        res = super(AccountConfigSettings, self).onchange_company_id()
+        if self.company_id:
+            company = self.company_id
+            self.e_invoice_user_id = (
+                company.e_invoice_user_id and
+                company.e_invoice_user_id.id or False
+            )
+        else:
+            self.e_invoice_user_id = False
+        return res

--- a/l10n_it_fatturapa_pec/views/company_view.xml
+++ b/l10n_it_fatturapa_pec/views/company_view.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_config_settings_ftpa_pec" model="ir.ui.view">
+        <field name="name">view_account_config_settings_ftpa_pec</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="l10n_it_fatturapa.view_account_config_settings"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='fatturapa_settings']" position="after">
+                <div class="row mt16 o_settings_container" id="supplier_fatturapa_settings">
+                    <div class="col-12 col-lg-12 o_setting_box">
+                        <div class="o_setting_left_pane"/>
+                        <div class="o_setting_right_pane">
+                            <span class="o_form_label">Supplier Invoices</span>
+                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."
+                                  aria-label="Values set here are company-specific."
+                                  groups="base.group_multi_company" role="img"/>
+                            <div class="text-muted">
+                                Default user used in electronic supplier invoices
+                            </div>
+                            <div class="content-group">
+                                <div class="row">
+                                    <label for="e_invoice_user_id" class="col-lg-6 o_light_label"/>
+                                    <field name="e_invoice_user_id" class="col-lg-6"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
…we do for v10.0

Descrizione del problema o della funzionalità:

Le fatture di acquisto elettroniche non hanno il supporto del multi company come è implementato sulla v10

Comportamento attuale prima di questa PR:

La multi company non è supportata per le fatture elettroniche d'acquisto

Comportamento desiderato dopo questa PR:

Supportare il multi company sulle fatture elettroniche d'acquisto come per la v10


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
