### PR TITLE
[10.0][IMP][l10n_it_fatturapa_in] Add active and passive rounding sup…

### DIFF
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -161,7 +161,8 @@ class AccountInvoice(models.Model):
     def compute_xml_amount_untaxed(self, DatiRiepilogo):
         amount_untaxed = 0.0
         for Riepilogo in DatiRiepilogo:
-            amount_untaxed += float(Riepilogo.ImponibileImporto)
+            rounding = float(Riepilogo.Arrotondamento or 0.0)
+            amount_untaxed += float(Riepilogo.ImponibileImporto) + rounding
         return amount_untaxed
 
     @api.model

--- a/l10n_it_fatturapa_in/models/company.py
+++ b/l10n_it_fatturapa_in/models/company.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
-from odoo import fields, models, api
+from odoo import fields, models
 
 
 class ResCompany(models.Model):
     _inherit = 'res.company'
+
     cassa_previdenziale_product_id = fields.Many2one(
         'product.product', 'Welfare Fund Data Product',
         help="Product used to model DatiCassaPrevidenziale XML element "
@@ -33,17 +34,13 @@ class ResCompany(models.Model):
 
 class AccountConfigSettings(models.TransientModel):
     _inherit = 'account.config.settings'
+
     cassa_previdenziale_product_id = fields.Many2one(
         related='company_id.cassa_previdenziale_product_id',
-        string="Welfare Fund Data Product",
-        help="Product used to model DatiCassaPrevidenziale XML element "
-             "on bills."
     )
     sconto_maggiorazione_product_id = fields.Many2one(
         related='company_id.sconto_maggiorazione_product_id',
-        string="Discount Supplement Product",
-        help="Product used to model ScontoMaggiorazione XML element on bills."
-        )
+    )
     arrotondamenti_attivi_account_id = fields.Many2one(
         related='company_id.arrotondamenti_attivi_account_id',
     )
@@ -53,21 +50,3 @@ class AccountConfigSettings(models.TransientModel):
     arrotondamenti_tax_id = fields.Many2one(
         related='company_id.arrotondamenti_tax_id',
     )
-
-    @api.onchange('company_id')
-    def onchange_company_id(self):
-        res = super(AccountConfigSettings, self).onchange_company_id()
-        if self.company_id:
-            company = self.company_id
-            self.cassa_previdenziale_product_id = (
-                company.cassa_previdenziale_product_id and
-                company.cassa_previdenziale_product_id.id or False
-            )
-            self.sconto_maggiorazione_product_id = (
-                company.sconto_maggiorazione_product_id and
-                company.sconto_maggiorazione_product_id.id or False
-                )
-        else:
-            self.cassa_previdenziale_product_id = False
-            self.sconto_maggiorazione_product_id = False
-        return res

--- a/l10n_it_fatturapa_in/models/company.py
+++ b/l10n_it_fatturapa_in/models/company.py
@@ -14,6 +14,21 @@ class ResCompany(models.Model):
         'product.product', 'Discount Supplement Product',
         help="Product used to model ScontoMaggiorazione XML element on bills."
         )
+    arrotondamenti_attivi_account_id = fields.Many2one(
+        'account.account', 'Active Rounding Account',
+        domain=[('deprecated', '=', False)],
+        help="Account used for active rounding amount on bills."
+        )
+    arrotondamenti_passivi_account_id = fields.Many2one(
+        'account.account', 'Passive Rounding Account',
+        domain=[('deprecated', '=', False)],
+        help="Account used for passive rounding amount on bills."
+        )
+    arrotondamenti_tax_id = fields.Many2one(
+        'account.tax', 'Rounding Tax',
+        domain=[('type_tax_use', '=', 'purchase'), ('amount', '=', 0.0)],
+        help="Tax used for rounding amount on bills."
+        )
 
 
 class AccountConfigSettings(models.TransientModel):
@@ -29,6 +44,15 @@ class AccountConfigSettings(models.TransientModel):
         string="Discount Supplement Product",
         help="Product used to model ScontoMaggiorazione XML element on bills."
         )
+    arrotondamenti_attivi_account_id = fields.Many2one(
+        related='company_id.arrotondamenti_attivi_account_id',
+    )
+    arrotondamenti_passivi_account_id = fields.Many2one(
+        related='company_id.arrotondamenti_passivi_account_id',
+    )
+    arrotondamenti_tax_id = fields.Many2one(
+        related='company_id.arrotondamenti_tax_id',
+    )
 
     @api.onchange('company_id')
     def onchange_company_id(self):

--- a/l10n_it_fatturapa_in/tests/data/IT05979361218_011.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT05979361218_011.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:FatturaElettronica versione="FPA12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+       <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>05979361218</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>006</ProgressivoInvio>
+            <FormatoTrasmissione>FPA12</FormatoTrasmissione>
+            <CodiceDestinatario>UFPQ1O</CodiceDestinatario>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>05979361218</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>SOCIETA' ALPHA BETA SRL</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF02</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIALE ROMA 543B</Indirizzo>
+                <CAP>07100</CAP>
+                <Comune>SASSARI</Comune>
+                <Provincia>SS</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <CodiceFiscale>80213330584</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>AMMINISTRAZIONE BETA</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIA TORINO 38-B</Indirizzo>
+                <CAP>00145</CAP>
+                <Comune>ROMA</Comune>
+                <Provincia>RM</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody xmlns="">
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2019-05-11</Data>
+                <Numero>852S1</Numero>
+                <ImportoTotaleDocumento>34.32</ImportoTotaleDocumento>
+                <Causale>Rif ordine 908</Causale>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>USB4</Descrizione>
+                <Quantita>1.00</Quantita>
+                <UnitaMisura>Pz.</UnitaMisura>
+                <PrezzoUnitario>18.07</PrezzoUnitario>
+                <PrezzoTotale>18.07</PrezzoTotale>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N4</Natura>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>2</NumeroLinea>
+                <Descrizione>USB</Descrizione>
+                <Quantita>1.00</Quantita>
+                <UnitaMisura>Pz.</UnitaMisura>
+                <PrezzoUnitario>16.60</PrezzoUnitario>
+                <PrezzoTotale>16.60</PrezzoTotale>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N4</Natura>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N4</Natura>
+                <Arrotondamento>-0.35</Arrotondamento>
+                <ImponibileImporto>34.67</ImponibileImporto>
+                <Imposta>0.00</Imposta>
+                <EsigibilitaIVA>I</EsigibilitaIVA>
+                <RiferimentoNormativo>Esenzione Art.8 comma 1 DPR 633/72</RiferimentoNormativo>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -518,6 +518,29 @@ class TestFatturaPAXMLValidation(SingleTransactionCase):
         invoices = self.invoice_model.browse(invoice_ids)
         self.assertEqual(len(invoices), 2)
 
+    def test_24_xml_import(self):
+        arrotondamenti_attivi_account_id = self.env['account.account'].\
+            search([('user_type_id', '=', self.env.ref(
+                'account.data_account_type_other_income').id)], limit=1).id
+        arrotondamenti_passivi_account_id = self.env['account.account'].\
+            search([('user_type_id', '=', self.env.ref(
+                'account.data_account_type_direct_costs').id)], limit=1).id
+        arrotondamenti_tax_id = self.env['account.tax'].search(
+            [('type_tax_use', '=', 'purchase'),
+             ('amount', '=', 0.0)], order='sequence', limit=1)
+        self.env.user.company_id.arrotondamenti_attivi_account_id = (
+            arrotondamenti_attivi_account_id)
+        self.env.user.company_id.arrotondamenti_passivi_account_id = (
+            arrotondamenti_passivi_account_id)
+        self.env.user.company_id.arrotondamenti_tax_id = (
+            arrotondamenti_tax_id)
+        res = self.run_wizard('test24', 'IT05979361218_011.xml')
+        invoice_id = res.get('domain')[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertAlmostEqual(invoice.e_invoice_amount_untaxed, 34.32)
+        self.assertEqual(invoice.e_invoice_amount_tax, 0.0)
+        self.assertEqual(invoice.e_invoice_amount_total, 34.32)
+
     def test_01_xml_link(self):
         """
         E-invoice lines are created.

--- a/l10n_it_fatturapa_in/views/company_view.xml
+++ b/l10n_it_fatturapa_in/views/company_view.xml
@@ -15,6 +15,18 @@
                     <label for="sconto_maggiorazione_product_id"/>
                     <field name="sconto_maggiorazione_product_id" class="oe_inline"/>
                 </div>
+                <div>
+                    <label for="arrotondamenti_attivi_account_id"/>
+                    <field name="arrotondamenti_attivi_account_id" class="oe_inline"/>
+                </div>
+                <div>
+                    <label for="arrotondamenti_passivi_account_id"/>
+                    <field name="arrotondamenti_passivi_account_id" class="oe_inline"/>
+                </div>
+                <div>
+                    <label for="arrotondamenti_tax_id"/>
+                    <field name="arrotondamenti_tax_id" class="oe_inline"/>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
…port when importing e-bill

Descrizione del problema o della funzionalità:

La procedura di importazione delle fatture elettroniche di acquisto non supporta la gestione degli arrotondamenti, pertanto la fattura che viene generata risulta errata e quindi da "sistemare" a mano

Comportamento attuale prima di questa PR:

Non c'è supporto degli arrotondamenti in fatture elettroniche d'acquisto

Comportamento desiderato dopo questa PR:

Supporto completo per la rilevazione degli arrotondamenti attivi e passivi


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
