### PR TITLE
[12.0] FIX l10n_it_website_portal_fiscalcode check after invoice issuing

### DIFF
--- a/l10n_it_website_portal_fiscalcode/controllers/main.py
+++ b/l10n_it_website_portal_fiscalcode/controllers/main.py
@@ -14,9 +14,22 @@ class WebsitePortalFiscalCode(CustomerPortal):
         error, error_message = \
             super(WebsitePortalFiscalCode, self).details_form_validate(data)
         # Check fiscalcode
+        partner = request.env.user.partner_id
+        # company_type does not come from page form
+        company_type = partner.company_type
+        company_name = False
+        if 'company_name' in data:
+            company_name = data.get('company_name')
+        else:
+            # when company_name is not posted (readonly)
+            if partner.company_name:
+                company_name = partner.company_name
+            elif partner.company_type == 'company':
+                company_name = partner.name
         dummy_partner = request.env['res.partner'].new({
             'fiscalcode': data.get('fiscalcode'),
-            'company_name': data.get('company_name'),
+            'company_name': company_name,
+            'company_type': company_type,
         })
         if not dummy_partner.check_fiscalcode():
             error['fiscalcode'] = 'error'


### PR DESCRIPTION
Steps:

 - Create a partner (type company) and give them portal access
 - With the new user, access to portal
 - Edit partner details setting fiscal code with 11 digits
 - Using admin, create an invoice for that partner and validate
 - Using the new user, access to portal, open partner details and save



Comportamento attuale prima di questa PR:

Get "The fiscal code doesn't seem to be correct"

Comportamento desiderato dopo questa PR:

Partner is saved


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
