### PR TITLE
[12.0] FIX l10n_it_fiscal_document_type: when "Fiscal Document Type" is set on partner, that type should not be used for refunds

### DIFF
--- a/l10n_it_fiscal_document_type/models/account_invoice.py
+++ b/l10n_it_fiscal_document_type/models/account_invoice.py
@@ -32,9 +32,9 @@ class AccountInvoice(models.Model):
 
         # Partner
         if partner:
-            if type in ('out_invoice', 'out_refund'):
+            if type in ('out_invoice'):
                 doc_id = partner.out_fiscal_document_type.id or False
-            elif type in ('in_invoice', 'in_refund'):
+            elif type in ('in_invoice'):
                 doc_id = partner.in_fiscal_document_type.id or False
         # Fiscal Position
         if not doc_id and fiscal_position:


### PR DESCRIPTION
Vedi https://github.com/OCA/l10n-italy/issues/1014




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
