### PR TITLE
[12.0][FIX] l10n_it_website_portal_fatturapa_sale: Prevent the form to be submitted

### DIFF
--- a/l10n_it_website_portal_fatturapa_sale/__manifest__.py
+++ b/l10n_it_website_portal_fatturapa_sale/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "ITA - Fattura elettronica - Portale clienti",
     "summary": "Controlli per la fattura elettronica nel portale vendite",
-    "version": "12.0.1.0.1",
+    "version": "12.0.1.0.2",
     "author": "Odoo Community Association (OCA)",
     "category": "Localization/Italy",
     "website": "https://github.com/OCA/l10n-italy/tree/"

--- a/l10n_it_website_portal_fatturapa_sale/static/src/js/payment_form.js
+++ b/l10n_it_website_portal_fatturapa_sale/static/src/js/payment_form.js
@@ -6,6 +6,7 @@ odoo.define('l10n_it_website_portal_fatturapa_sale.payment_form', function (requ
 
     PaymentForm.include({
         payEvent: function (ev) {
+            ev.preventDefault();
             var partner_id = this.options.partnerId;
             var super_pay_event = this._super;
             var self = this;


### PR DESCRIPTION
The form should not be submitted immediately, that is the same behavior of parent method https://github.com/odoo/odoo/blob/df58958631c7583c2f39c1e8b7cfda47e663ab20/addons/payment/static/src/js/payment_form.js#L52

**Descrizione del problema o della funzionalità**
0. Abilitare il pagamento paypal.
1. Creare un ordine nel backend che abbia il flag 'pagamento online'.
2. Click su 'invia per email'.
3. Click su 'anteprima' per accedere al frontend.
4. Click su 'accetta e paga'
5. Nel popup, selezionare paypal e click su 'Conferma'

**Comportamento attuale prima di questa PR**
La pagina viene ricaricata

**Comportamento desiderato dopo questa PR**
Redirezionamento a paypal

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
