### PR TITLE
[8.0] fix search view welfare fund type

### DIFF
--- a/l10n_it_fatturapa/models/account.py
+++ b/l10n_it_fatturapa/models/account.py
@@ -98,19 +98,24 @@ class FatturapaFiscalPosition(models.Model):
 class WelfareFundType(models.Model):
     # _position = ['2.1.1.7.1']
     _name = "welfare.fund.type"
-    _description = 'welfare fund type'
+    _description = 'Welfare Fund Type'
     _rec_name = 'display_name'
 
-    name = fields.Char('name')
-    description = fields.Char('description')
-    display_name = fields.Char(string='Name', compute='_compute_display_name')
+    name = fields.Char('Name')
+    description = fields.Char('Description')
+    display_name = fields.Char(string='Name',
+                               compute='_compute_clean_display_name')
 
-    @api.depends('description', 'name')
     @api.multi
-    def _compute_display_name(self):
+    @api.depends(
+        'description', 'name'
+    )
+    def _compute_clean_display_name(self):
         for record in self:
-            record.display_name = u'[%s] %s' % (
-                record.name, record.description)
+            name = record.name
+            if record.name and record.description:
+                name = u'[%s] %s' % (record.name, record.description)
+            record.display_name = name
 
 
 class WelfareFundDataLine(models.Model):

--- a/l10n_it_fatturapa/views/account_view.xml
+++ b/l10n_it_fatturapa/views/account_view.xml
@@ -33,5 +33,14 @@
                 </field>
             </field>
         </record>
+        <record id="welfare_fund_type_tree" model="ir.ui.view">
+            <field name="name">welfare.fund.type.tree</field>
+            <field name="model">welfare.fund.type</field>
+            <field name="arch" type="xml">
+                <tree string="">
+                    <field name="display_name" />
+                </tree>
+            </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
Descrizione del problema o della funzionalità: nella ricerca del tipo di cassa previdenza dall'interno della ritenuta non si vede il nome

Comportamento attuale prima di questa PR: non si vede il nome, ma solo il campo 'creato da'

Comportamento desiderato dopo questa PR: si vede il nome della cassa previdenza




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
