### PR TITLE
FIX l10n_it_fiscal_document_type: when "Fiscal Document Type" is set …

### DIFF
--- a/l10n_it_fiscal_document_type/models/account_invoice.py
+++ b/l10n_it_fiscal_document_type/models/account_invoice.py
@@ -34,9 +34,9 @@ class AccountInvoice(models.Model):
 
         # Partner
         if partner:
-            if type in ('out_invoice', 'out_refund'):
+            if type in ('out_invoice'):
                 doc_id = partner.out_fiscal_document_type.id or False
-            elif type in ('in_invoice', 'in_refund'):
+            elif type in ('in_invoice'):
                 doc_id = partner.in_fiscal_document_type.id or False
         # Fiscal Position
         if not doc_id and fiscal_position:


### PR DESCRIPTION
…on partner, that type should not be used for refunds
issue https://github.com/OCA/l10n-italy/issues/1014

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
