### PR TITLE
[12.0]FIX l10n_it_withholding_tax: modificata posizione voce di menu del modulo

### DIFF
--- a/l10n_it_withholding_tax/views/withholding_tax.xml
+++ b/l10n_it_withholding_tax/views/withholding_tax.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-        <menuitem id="wt_main" name="Withholding tax" parent="account.menu_finance" sequence="5" groups="account.group_account_manager"/>
+        <menuitem id="wt_main" name="Withholding tax"
+                  parent="account.menu_finance_entries" groups="account.group_account_manager"/>
 
-        <!--
+       <!--
         WITHHOLDING TAX
          -->
         <record id="view_withholding_tax_tree" model="ir.ui.view">


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Comportamento attuale prima di questa PR:
Premessa: Il problema si presenta solo con l'installazione del  account_accountant (modulo della versione Enterprise), il quale sposta tutti i sotto menù del menù Invoicing (Fatturazione) in un nuovo menù Accounting (Contabilità) 
Questo modulo crea una nuova voce di menù sotto Invoicing (Fatturazione). 
Il risultato finale era che il menù "Withholding tax" e i suoi sotto menu erano presenti (da soli) sotto Invoicing.

Comportamento desiderato dopo questa PR:
Spostato la voce di menù "Withholding tax" nel sotto menù Accounting (uno dei sottomenù nativamente spostato da account_accountant)

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
