### PR TITLE
[12.0] FIX l10n_it_central_journal: msgmerge error

### DIFF
--- a/l10n_it_central_journal/i18n/it.po
+++ b/l10n_it_central_journal/i18n/it.po
@@ -242,12 +242,8 @@ msgid "Progressive Credit"
 msgstr ""
 
 #. module: l10n_it_central_journal
-#: model:ir.model.fields,field_description:l10n_it_central_journal.field_date_range_progressive_debit
-msgid "Progressive Debit"
-msgstr ""
-
-#. module: l10n_it_central_journal
-#: model:ir.model.fields,field_description:l10n_it_central_journal.field_wizard_giornale_progressive_debit2
+#: model:ir.model.fields,field_description:l10n_it_central_journal.field_date_range__progressive_debit
+#: model:ir.model.fields,field_description:l10n_it_central_journal.field_wizard_giornale__progressive_debit2
 msgid "Progressive Debit"
 msgstr "Progressivo dare"
 


### PR DESCRIPTION
./l10n_it_central_journal/i18n/it.po:251: duplicate message definition...
./l10n_it_central_journal/i18n/it.po:247: ...this is the location of the first definition

See https://github.com/OCA/l10n-italy/commit/a12f91abb675b23ad4e3231c43ae6690df2e688d#commitcomment-34945948




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
