### PR TITLE
[12.0] [FIX] l10n_it_fiscal_document_type: Fiscal document type should be always synced to values of other fields not only if changed in the views (onchange)

### DIFF
--- a/l10n_it_fiscal_document_type/models/account_invoice.py
+++ b/l10n_it_fiscal_document_type/models/account_invoice.py
@@ -4,24 +4,17 @@ from odoo import models, fields, api
 class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
 
-    @api.onchange('partner_id', 'journal_id', 'type', 'fiscal_position_id')
+    @api.multi
+    @api.depends('partner_id', 'journal_id', 'type', 'fiscal_position_id')
     def _set_document_fiscal_type(self):
-        dt = self._get_document_fiscal_type(
-            self.type, self.partner_id, self.fiscal_position_id,
-            self.journal_id)
-        if dt:
-            self.fiscal_document_type_id = dt[0]
-
-    @api.model
-    def create(self, vals):
-        invoice = super(AccountInvoice, self).create(vals)
-        if not invoice.fiscal_document_type_id:
-            dt = self._get_document_fiscal_type(
+        for invoice in self:
+            if invoice.state != 'draft':
+                continue
+            dt = invoice._get_document_fiscal_type(
                 invoice.type, invoice.partner_id, invoice.fiscal_position_id,
                 invoice.journal_id)
             if dt:
                 invoice.fiscal_document_type_id = dt[0]
-        return invoice
 
     def _get_document_fiscal_type(self, type=None, partner=None,
                                   fiscal_position=None, journal=None):
@@ -53,4 +46,6 @@ class AccountInvoice(models.Model):
     fiscal_document_type_id = fields.Many2one(
         'fiscal.document.type',
         string="Fiscal Document Type",
+        compute='_set_document_fiscal_type',
+        store=True,
         readonly=False)

--- a/l10n_it_fiscal_document_type/tests/test_doc_type.py
+++ b/l10n_it_fiscal_document_type/tests/test_doc_type.py
@@ -10,7 +10,11 @@ class TestDocType(TransactionCase):
         super(TestDocType, self).setUp()
         self.journalrec = self.env['account.journal'].search(
             [('type', '=', 'sale')])[0]
-        self.TD01 = self.env.ref('l10n_it_fiscal_document_type.1')
+        self.doc_type_model = self.env['fiscal.document.type']
+        self.TD01 = self.doc_type_model.search(
+            [('code', '=', 'TD01')], limit=1)
+        self.TD04 = self.doc_type_model.search(
+            [('code', '=', 'TD04')], limit=1)
         self.inv_model = self.env['account.invoice']
         self.partner3 = self.env.ref('base.res_partner_3')
 
@@ -26,3 +30,23 @@ class TestDocType(TransactionCase):
             'partner_id': self.partner3.id
         })
         self.assertEqual(invoice2.fiscal_document_type_id.id, self.TD01.id)
+
+    def test_doc_type_update(self):
+        """Check that document type is updated when updating invoice type."""
+        revenue_account_type = \
+            self.env.ref('account.data_account_type_revenue')
+        revenue_account = self.env['account.account'].search(
+            [('user_type_id', '=', revenue_account_type.id)], limit=1)
+        invoice = self.inv_model.create({
+            'partner_id': self.partner3.id,
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.env.ref('product.product_product_5').id,
+                'quantity': 10.0,
+                'account_id': revenue_account.id,
+                'name': 'product test 5',
+                'price_unit': 100.00,
+            })]})
+        self.assertEqual(invoice.fiscal_document_type_id, self.TD01)
+
+        invoice.type = 'out_refund'
+        self.assertEqual(invoice.fiscal_document_type_id, self.TD04)


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

https://github.com/OCA/l10n-italy/issues/1452




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
