### PR TITLE
[12.0] FIX liquidazione IVA: calcolo credito anno precedente e impostazione del campo corretto in comunicazione

### DIFF
--- a/account_vat_period_end_statement/views/account_view.xml
+++ b/account_vat_period_end_statement/views/account_view.xml
@@ -84,6 +84,7 @@
                                 <separator colspan="3" string="Previous Credits VAT"/>
                                 <field name="previous_credit_vat_account_id" attrs="{'required':[('previous_credit_vat_amount','!=',0)]}"/>
                                 <field name="previous_credit_vat_amount" nolabel="1"/>
+                                <field name="previous_year_credit" />
                                 <separator colspan="3" string="Previous Debits VAT"/>
                                 <field name="previous_debit_vat_account_id" attrs="{'required':[('previous_debit_vat_amount','!=',0)]}"/>
                                 <field name="previous_debit_vat_amount" nolabel="1"/>

--- a/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
+++ b/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
@@ -599,8 +599,12 @@ class ComunicazioneLiquidazioneVp(models.Model):
                 # credito/debito periodo precedente
                 quadro.debito_periodo_precedente =\
                     liq.previous_debit_vat_amount
-                quadro.credito_periodo_precedente =\
-                    liq.previous_credit_vat_amount
+                if liq.previous_year_credit:
+                    quadro.credito_anno_precedente =\
+                        liq.previous_credit_vat_amount
+                else:
+                    quadro.credito_periodo_precedente =\
+                        liq.previous_credit_vat_amount
                 # Credito anno precedente (NON GESTITO)
                 # Versamenti auto UE (NON GESTITO)
                 # Crediti d’imposta (NON GESTITO)


### PR DESCRIPTION
Vedi https://github.com/OCA/l10n-italy/issues/1527

In più: Il campo VP9 in comunicazione va valorizzato, a posto del VP8.
Il modulo per la comunicazione XML risulta disponibile solo per la 12

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
