### PR TITLE
[12.0] FIX travis: Unable to install module "l10n_it_fatturapa" because an external dependency is not met: No module named asn1crypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - pip install codicefiscale
   - pip install unidecode==0.04.17
   - pip install PyXB==1.2.6
+  - pip install asn1crypto==0.24.0
 
 script:
   - travis_run_tests


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/1495




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
