### PR TITLE
[12.0] FIX l10n_it_fiscalcode_crm tests

### DIFF
--- a/l10n_it_fiscalcode_crm/models/crm_lead.py
+++ b/l10n_it_fiscalcode_crm/models/crm_lead.py
@@ -10,12 +10,12 @@ class Lead(models.Model):
 
     @api.multi
     def _create_lead_partner(self):
-        """Add VAT to partner."""
+        """Add fiscal code to partner."""
         return (super(Lead, self.with_context(
             default_fiscalcode=self.fiscalcode))._create_lead_partner())
 
     def _onchange_partner_id_values(self, partner_id):
-        """Recover fiscalcode from partner if available."""
+        """Recover fiscal code from partner if available."""
         result = super(Lead, self)._onchange_partner_id_values(partner_id)
         if not partner_id:
             return result

--- a/l10n_it_fiscalcode_crm/tests/test_lead.py
+++ b/l10n_it_fiscalcode_crm/tests/test_lead.py
@@ -14,7 +14,9 @@ class LeadCase(TransactionCase):
     def test_transfered_values(self):
         """Field gets transfered when creating partner."""
         self.lead.fiscalcode = self.test_field
-        self.lead.handle_partner_assignation()
+        partner_ids = self.lead.handle_partner_assignation()
+        for lead_id in partner_ids:
+            self.env["crm.lead"].browse(lead_id).partner_id = partner_ids[lead_id]
         self.assertEqual(self.lead.partner_id.fiscalcode, self.test_field)
 
     def test_onchange_partner_id(self):


### PR DESCRIPTION
after https://github.com/odoo/odoo/commit/e1833936255839cd34eba5758ca4c3124fd2522c

we get
```
FAIL
FAIL: test_transfered_values (odoo.addons.l10n_it_fiscalcode_crm.tests.test_lead.LeadCase)
` Field gets transfered when creating partner.
Traceback (most recent call last):
`   File "/home/travis/build/OCA/l10n-italy/l10n_it_fiscalcode_crm/tests/test_lead.py", line 18, in test_transfered_values
`     self.assertEqual(self.lead.partner_id.fiscalcode, self.test_field)
` AssertionError: False != 'AAABBB99A11A999A'
FAILED
```
See https://travis-ci.org/OCA/l10n-italy/builds/610975336

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
