### PR TITLE
l10n_it_fatturapa_in_rc: fix auto_install key

### DIFF
--- a/l10n_it_fatturapa_in_rc/__manifest__.py
+++ b/l10n_it_fatturapa_in_rc/__manifest__.py
@@ -14,7 +14,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "autoinstall": True,
+    "auto_install": True,
     "depends": [
         "l10n_it_reverse_charge",
         "l10n_it_fatturapa_in",


### PR DESCRIPTION
Descrizione del problema o della funzionalità: in the manifest file replace `autoinstall` by `auto_install`

10.0: https://github.com/OCA/l10n-italy/pull/1532

Si noti che il modulo `l10n_it_fatturapa_in_rc` non è presente in altre versioni.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
