### PR TITLE
[10.0][l10n_it_fatturapa_pec] Permettere di rigenerare il file xml pe…

### DIFF
--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -7,8 +7,9 @@
         <field name="inherit_id" ref="account.invoice_form"/>
         <field name="arch" type="xml">
             <button name="action_invoice_proforma2" position="before">
-                <button name="%(action_wizard_export_fatturapa)d" type="action" states="open,paid"
-                        string="Export E-invoice" class="oe_highlight"/>
+                <button name="%(action_wizard_export_fatturapa)d" type="action"
+                        string="Export E-invoice" class="oe_highlight"
+                        attrs="{'invisible': ['|', ('fatturapa_attachment_out_id', '!=', False), ('state', 'not in', ['open', 'paid'])]}"/>
             </button>
             <field name="partner_id" position="after">
                 <field name="electronic_invoice_subjected" invisible="1"/>

--- a/l10n_it_fatturapa_pec/__manifest__.py
+++ b/l10n_it_fatturapa_pec/__manifest__.py
@@ -4,6 +4,7 @@
 # Copyright 2018-2019 Sergio Corato (https://efatto.it)
 # Copyright 2018-2019 Lorenzo Battistini <https://github.com/eLBati>
 # Copyright 2018 Sergio Zanchetta (Associazione PNLUG - Gruppo Odoo)
+# Copyright 2019 Roberto Fichera (https://levelprime.com)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     'name': 'Italian Localization - Fattura elettronica - Supporto PEC',
@@ -22,9 +23,10 @@
     ],
     'data': [
         'security/groups.xml',
-        'views/account.xml',
         'views/fatturapa_attachment_out.xml',
         'wizard/send_pec_view.xml',
+        'wizard/wizard_export_fatturapa_view.xml',
+        'views/account.xml',
         'views/fetchmail_view.xml',
         'security/ir.model.access.csv',
         'views/company_view.xml',

--- a/l10n_it_fatturapa_pec/views/account.xml
+++ b/l10n_it_fatturapa_pec/views/account.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
     <record id="view_invoice_fatturapa_out_pec_tree" model="ir.ui.view">
         <field name="name">view.invoice.fatturapa.out.pec.tree</field>
         <field name="model">account.invoice</field>
-        <field name="inherit_id" ref="account.invoice_tree"></field>
+        <field name="inherit_id" ref="account.invoice_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='state']" position="before">
                 <field name="fatturapa_state"/>
@@ -14,18 +15,23 @@
     <record id="view_invoice_fatturapa_out_pec_form" model="ir.ui.view">
         <field name="name">view.invoice.fatturapa.out.pec.form</field>
         <field name="model">account.invoice</field>
-        <field name="inherit_id" ref="account.invoice_form"></field>
+        <field name="inherit_id" ref="account.invoice_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='date_invoice']" position="after">
                 <field name="fatturapa_state"/>
             </xpath>
+            <button name="action_invoice_proforma2" position="before">
+                <button name="%(action_wizard_export_fatturapa_regenerate)d" type="action"
+                        string="Re-Export E-invoice" class="oe_highlight"
+                        attrs="{'invisible': ['|', '|', ('fatturapa_attachment_out_id', '=', False), ('fatturapa_state', 'not in', ['error']), ('state', 'not in', ['open', 'paid'])]}"/>
+            </button>
         </field>
     </record>
 
     <record id="view_account_invoice_fatturapa_out_pec_filter" model="ir.ui.view">
         <field name="name">view.account.invoice.fatturapa.out.pec.filter</field>
         <field name="model">account.invoice</field>
-        <field name="inherit_id" ref="account.view_account_invoice_filter"></field>
+        <field name="inherit_id" ref="account.view_account_invoice_filter"/>
         <field name="arch" type="xml">
             <xpath expr="//filter[@name='late']" position="after">
                 <separator/>

--- a/l10n_it_fatturapa_pec/wizard/__init__.py
+++ b/l10n_it_fatturapa_pec/wizard/__init__.py
@@ -2,3 +2,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from . import send_pec
+from . import wizard_export_fatturapa

--- a/l10n_it_fatturapa_pec/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_pec/wizard/wizard_export_fatturapa.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Roberto Fichera - Level Prime Srl
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import base64
+import logging
+
+from odoo import models, _
+from odoo.exceptions import UserError
+
+from odoo.addons.l10n_it_fatturapa_out.wizard.wizard_export_fatturapa import (
+    fatturapaBDS
+)
+
+from odoo.addons.l10n_it_fatturapa.bindings.fatturapa import (
+    FatturaElettronica,
+    FatturaElettronicaBodyType
+)
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from pyxb.exceptions_ import SimpleFacetValueError, SimpleTypeValueError
+except ImportError as err:
+    _logger.debug(err)
+
+
+class WizardExportFatturapa(models.TransientModel):
+    _inherit = "wizard.export.fatturapa"
+
+    def updateAttachment(self, attach, fatturapa):
+        attach_str = fatturapa.toxml(
+            encoding="UTF-8",
+            bds=fatturapaBDS,
+        )
+        fatturapaBDS.reset()
+        attach.write({
+            'datas': base64.encodestring(attach_str),
+        })
+
+    def reSetProgressivoInvio(self, attach, fatturapa):
+        # Xml file name uses the format VAT_XXXXX.xml and we are interested
+        # to get XXXXX
+        file_id = attach.name.split('_')[1].split('.')[0]
+        try:
+            fatturapa.FatturaElettronicaHeader.DatiTrasmissione.\
+                ProgressivoInvio = file_id
+        except (SimpleFacetValueError, SimpleTypeValueError) as e:
+            msg = _(
+                'FatturaElettronicaHeader.DatiTrasmissione.'
+                'ProgressivoInvio:\n%s'
+            ) % unicode(e)
+            raise UserError(msg)
+        return file_id
+
+    def exportFatturaPARegenerate(self):
+        invoice_obj = self.env['account.invoice']
+        attachments = self.env['fatturapa.attachment.out']
+        # Browse active invoice
+        active_id = invoice_obj.browse(self._context.get('active_id'))
+        # Search all the invoices belonging the same xml file
+        invoice_ids = invoice_obj.search(
+            [('fatturapa_attachment_out_id', '=',
+             active_id.fatturapa_attachment_out_id.id)])
+
+        partner = active_id.partner_id
+        if partner.is_pa:
+            fatturapa = FatturaElettronica(versione='FPA12')
+        else:
+            fatturapa = FatturaElettronica(versione='FPR12')
+
+        company = self.env.user.company_id
+        context_partner = self.env.context.copy()
+        context_partner.update({'lang': partner.lang})
+
+        try:
+            self.with_context(context_partner).setFatturaElettronicaHeader(
+                company, partner, fatturapa)
+            for invoice_id in invoice_obj.with_context(context_partner).browse(
+                    invoice_ids.ids):
+
+                if self.report_print_menu:
+                    self.generate_attach_report(invoice_id)
+                invoice_body = FatturaElettronicaBodyType()
+                invoice_id.preventive_checks()
+                self.with_context(
+                    context_partner
+                ).setFatturaElettronicaBody(
+                    invoice_id, invoice_body)
+                fatturapa.FatturaElettronicaBody.append(invoice_body)
+                # TODO DatiVeicoli
+
+            self.reSetProgressivoInvio(
+                active_id.fatturapa_attachment_out_id, fatturapa)
+        except (SimpleFacetValueError, SimpleTypeValueError) as e:
+            raise UserError(unicode(e))
+
+        self.updateAttachment(
+            active_id.fatturapa_attachment_out_id, fatturapa)
+
+        attachments += active_id.fatturapa_attachment_out_id
+
+        action = {
+            'view_type': 'form',
+            'name': "Re-Export Electronic Invoice",
+            'res_model': 'fatturapa.attachment.out',
+            'type': 'ir.actions.act_window',
+            }
+
+        if len(attachments) == 1:
+            action['view_mode'] = 'form'
+            action['res_id'] = attachments[0].id
+        else:
+            action['view_mode'] = 'tree,form'
+            action['domain'] = [('id', 'in', attachments.ids)]
+
+        return action

--- a/l10n_it_fatturapa_pec/wizard/wizard_export_fatturapa_view.xml
+++ b/l10n_it_fatturapa_pec/wizard/wizard_export_fatturapa_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="wizard_export_fatturapa_form_view_regenerate" model="ir.ui.view">
+        <field name="name">Export Electronic Invoice Regenerate</field>
+        <field name="model">wizard.export.fatturapa</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="l10n_it_fatturapa_out.wizard_export_fatturapa_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='exportFatturaPA']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//button[@name='exportFatturaPA']" position="after">
+                <button name="exportFatturaPARegenerate" string="Re-Export"
+                        type="object" class="oe_highlight"/>
+            </xpath>
+        </field>
+    </record>
+
+    <act_window id="action_wizard_export_fatturapa_regenerate"
+                key2="client_action_multi"
+                name="Re-Export Electronic Invoice"
+                res_model="wizard.export.fatturapa"
+                src_model="account.invoice"
+                target="new"
+                view_id="wizard_export_fatturapa_form_view_regenerate"
+                view_mode="form"/>
+
+</odoo>


### PR DESCRIPTION
…r le fatture elettroniche in stato di errore

Descrizione del problema o della funzionalità:

Quando una fattura elettronica non viene accettata dallo SDI si è obbligati a rimettere in stato di bozza l'account invoice per poi procedere alla correzione e rigenerazione del file xml da inviare perdendo allo stesso tempo lo storico delle operazioni con lo SDI. Spesso l'errore è dovuto a questioni di codice fiscale, partita iva, codici univoci etc etc non corretti

Comportamento attuale prima di questa PR:

Non c'è possibilità di rigenerare solo il file xml in caso di errore 

Comportamento desiderato dopo questa PR:

Dare la possibilità all'utente di poter rigenerare solo il file xml in caso di errore senza dover rimettere la fattura in bozza

Vedi https://github.com/OCA/l10n-italy/issues/1540

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
