### PR TITLE
[12.0] [IMP] set e-invoicing modules incompatibility

### DIFF
--- a/l10n_it_fatturapa/README.rst
+++ b/l10n_it_fatturapa/README.rst
@@ -82,6 +82,17 @@ Configuration
 * Configure Electronic Invoice data in Accounting Configuration, where needed
 * Optionally configure the Electronic Invoice preview format style by selecting 'Preview Format Style' in 'Accounting Configuration'
 
+Usage
+=====
+
+**Italiano**
+
+Il modulo NON È compatibile con il modulo standard l10n_it_edi.
+
+**English**
+
+The module is NOT compatible with the standard l10n_it_edi module.
+
 Bug Tracker
 ===========
 

--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -14,6 +14,7 @@
     'website': 'https://github.com/OCA/l10n-italy/tree/12.0/'
                'l10n_it_fatturapa',
     'license': 'LGPL-3',
+    'excludes': ['l10n_it_edi'],
     "depends": [
         'l10n_it_account',
         'l10n_it_fiscalcode',

--- a/l10n_it_fatturapa/readme/USAGE.rst
+++ b/l10n_it_fatturapa/readme/USAGE.rst
@@ -1,0 +1,7 @@
+**Italiano**
+
+Il modulo NON È compatibile con il modulo standard l10n_it_edi.
+
+**English**
+
+The module is NOT compatible with the standard l10n_it_edi module.

--- a/l10n_it_fatturapa/static/description/index.html
+++ b/l10n_it_fatturapa/static/description/index.html
@@ -381,11 +381,12 @@ ul.auto-toc {
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="id1">Installation</a></li>
 <li><a class="reference internal" href="#configuration" id="id2">Configuration</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+<li><a class="reference internal" href="#usage" id="id3">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -420,8 +421,15 @@ ul.auto-toc {
 <li>Optionally configure the Electronic Invoice preview format style by selecting ‘Preview Format Style’ in ‘Accounting Configuration’</li>
 </ul>
 </div>
+<div class="section" id="usage">
+<h1><a class="toc-backref" href="#id3">Usage</a></h1>
+<p><strong>Italiano</strong></p>
+<p>Il modulo NON È compatibile con il modulo standard l10n_it_edi.</p>
+<p><strong>English</strong></p>
+<p>The module is NOT compatible with the standard l10n_it_edi module.</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-italy/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -429,9 +437,9 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Davide Corio</li>
 <li>Agile Business Group</li>
@@ -440,7 +448,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul class="simple">
 <li>Davide Corio</li>
 <li>Lorenzo Battistini &lt;<a class="reference external" href="https://github.com/eLBati">https://github.com/eLBati</a>&gt;</li>
@@ -452,7 +460,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Attualmente esistono due modi per gestire la fatturazione elettronica:
1) usare il modulo Odoo standard `l10n_it_edi`
2) usare i moduli OCA `l10n_fatturapa_*`

Comportamento attuale prima di questa PR:

Se l'utente installa i moduli di entrambe le soluzioni e non è a conoscenza che si tratta di due soluzioni distinte, si troverà molto disorientato nell'utilizzo delle funzionalità.

Inoltre c'è sempre il rischio latente che vengano fatte delle modifiche nottetempo che rendano incompatibili in modo più grave le due soluzioni.

Comportamento desiderato dopo questa PR:

Se l'utente cerca di installare entrambe le soluzioni per la fatturazione elettronica gli compare un messaggio di avviso di incompatibilità.

La stessa soluzione è stata adottata nel repository `account_financial_tools` relativamente al modulo `account_asset_management`, che risulta incompatibile con lo standard `account_asset`

Vedi https://github.com/OCA/account-financial-tools/tree/11.0/account_asset_management


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
