### PR TITLE
[10.0][l10n_it_fatturapa_out] Limitare il numero di fatture nell'xml

### DIFF
--- a/l10n_it_fatturapa_out/__manifest__.py
+++ b/l10n_it_fatturapa_out/__manifest__.py
@@ -23,6 +23,7 @@
         'wizard/wizard_export_fatturapa_view.xml',
         'views/attachment_view.xml',
         'views/account_view.xml',
+        'views/partner_view.xml',
         'security/ir.model.access.csv',
         'security/rules.xml',
     ],

--- a/l10n_it_fatturapa_out/models/__init__.py
+++ b/l10n_it_fatturapa_out/models/__init__.py
@@ -5,3 +5,4 @@
 
 from . import attachment
 from . import account
+from . import partner

--- a/l10n_it_fatturapa_out/models/partner.py
+++ b/l10n_it_fatturapa_out/models/partner.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Roberto Fichera <roberto.fichera@levelprime.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models, api, _
+from odoo.exceptions import ValidationError
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    max_invoice_in_xml = fields.Integer(
+        string='Max Num. Invoice in XML',
+        default=0,
+        help="Maximum number of invoices to group in a single XML file. "
+             "Default=0 unlimited")
+
+    @api.constrains('max_invoice_in_xml')
+    def _validate_max_invoice_in_xml(self):
+        if self.max_invoice_in_xml < 0:
+            raise ValidationError(
+                _("The max number of invoice to group can't be negative"))

--- a/l10n_it_fatturapa_out/views/partner_view.xml
+++ b/l10n_it_fatturapa_out/views/partner_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_partner_form_fatturapa">
+        <field name="name">partner.form.fatturapa</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="l10n_it_fatturapa.view_partner_form_fatturapa"/>
+        <field name="arch" type="xml">
+            <field name="ipa_code" position="before">
+                <field name="max_invoice_in_xml"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Attualmente non c'è limite al numero di fatture che si posso inserire in un singolo file xml esportato per l'ADE. La PR consente di porre un limite così da genere un numero massimo prefissato per cliente di fatture da esportare come fattura elettronica

Comportamento attuale prima di questa PR:

Nessun limite, tutte le fatture indicate vengono esportare nel singolo file xml per cliente

Comportamento desiderato dopo questa PR:

Possibilità di indicare il numero massimo di fatture che si vogliono inserire in un file xml, se indicato 0 (default) il comportamento è quello attuale senza limiti


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
