### PR TITLE
[12.0] FIX l10n_it_fatturapa_pec website

### DIFF
--- a/l10n_it_fatturapa_pec/__manifest__.py
+++ b/l10n_it_fatturapa_pec/__manifest__.py
@@ -11,7 +11,7 @@
     'category': 'Localization/Italy',
     'summary': 'Invio fatture elettroniche tramite PEC',
     'author': 'Openforce Srls Unipersonale, Odoo Community Association (OCA)',
-    'website': 'https://github.com/OCA/l10n-italy/tree/10.0/'
+    'website': 'https://github.com/OCA/l10n-italy/tree/12.0/'
                'l10n_it_fatturapa_pec',
     'license': 'LGPL-3',
     'depends': [


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Il `website` del modulo `l10n_it_fatturapa_pec` contiene ancora URL con 10.0




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
