### PR TITLE
[12.0] Use float_round from odoo because in python 3 "Exact halfway cases are now rounded to the nearest even result instead of away from zero"

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -15,6 +15,7 @@ from odoo import api, fields, models
 from odoo.tools.translate import _
 from odoo.exceptions import UserError
 from odoo.addons.l10n_it_account.tools.account_tools import encode_for_export
+from odoo.tools.float_utils import float_round
 
 from odoo.addons.l10n_it_fatturapa.bindings.fatturapa import (
     FatturaElettronica,
@@ -307,7 +308,7 @@ class WizardExportFatturapa(models.TransientModel):
                 NumeroREA=company.rea_code,
                 CapitaleSociale=(
                     company.rea_capital and
-                    '%.2f' % company.rea_capital or None),
+                    '%.2f' % float_round(company.rea_capital, 2) or None),
                 SocioUnico=(company.rea_member_type or None),
                 StatoLiquidazione=company.rea_liquidation_state
                 )
@@ -533,7 +534,7 @@ class WizardExportFatturapa(models.TransientModel):
             Divisa=invoice.currency_id.name,
             Data=invoice.date_invoice,
             Numero=invoice.number,
-            ImportoTotaleDocumento='%.2f' % ImportoTotaleDocumento)
+            ImportoTotaleDocumento='%.2f' % float_round(ImportoTotaleDocumento, 2))
 
         # TODO: DatiRitenuta, DatiBollo, DatiCassaPrevidenziale,
         # ScontoMaggiorazione, Arrotondamento,
@@ -643,7 +644,7 @@ class WizardExportFatturapa(models.TransientModel):
             raise UserError(
                 _("Too many taxes for invoice line %s.") % line.name)
         aliquota = line.invoice_line_tax_ids[0].amount
-        AliquotaIVA = '%.2f' % (aliquota)
+        AliquotaIVA = '%.2f' % float_round(aliquota, 2)
         line.ftpa_line_number = line_no
         prezzo_unitario = self._get_prezzo_unitario(line)
         DettaglioLinea = DettaglioLineeType(
@@ -655,7 +656,7 @@ class WizardExportFatturapa(models.TransientModel):
                 qta=line.quantity, precision=uom_precision),
             UnitaMisura=line.uom_id and (
                 unidecode(line.uom_id.name)) or None,
-            PrezzoTotale='%.2f' % line.price_subtotal,
+            PrezzoTotale='%.2f' % float_round(line.price_subtotal, 2),
             AliquotaIVA=AliquotaIVA)
         DettaglioLinea.ScontoMaggiorazione.extend(
             self.setScontoMaggiorazione(line))
@@ -693,7 +694,7 @@ class WizardExportFatturapa(models.TransientModel):
         if line.discount:
             res.append(ScontoMaggiorazioneType(
                 Tipo='SC',
-                Percentuale='%.2f' % line.discount
+                Percentuale='%.2f' % float_round(line.discount, 2)
             ))
         return res
 
@@ -701,9 +702,9 @@ class WizardExportFatturapa(models.TransientModel):
         for tax_line in invoice.tax_line_ids:
             tax = tax_line.tax_id
             riepilogo = DatiRiepilogoType(
-                AliquotaIVA='%.2f' % tax.amount,
-                ImponibileImporto='%.2f' % tax_line.base,
-                Imposta='%.2f' % tax_line.amount
+                AliquotaIVA='%.2f' % float_round(tax.amount, 2),
+                ImponibileImporto='%.2f' % float_round(tax_line.base, 2),
+                Imposta='%.2f' % float_round(tax_line.amount, 2)
                 )
             if tax.amount == 0.0:
                 if not tax.kind_id:
@@ -745,8 +746,8 @@ class WizardExportFatturapa(models.TransientModel):
             move_line_pool = self.env['account.move.line']
             for move_line_id in payment_line_ids:
                 move_line = move_line_pool.browse(move_line_id)
-                ImportoPagamento = '%.2f' % (
-                    move_line.amount_currency or move_line.debit)
+                ImportoPagamento = '%.2f' % float_round(
+                    move_line.amount_currency or move_line.debit, 2)
                 # Create with only mandatory fields
                 DettaglioPagamento = DettaglioPagamentoType(
                     ModalitaPagamento=(

--- a/l10n_it_fatturapa_out_ddt/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out_ddt/wizard/wizard_export_fatturapa.py
@@ -2,6 +2,7 @@
 
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_round
 from odoo.addons.l10n_it_fatturapa.bindings.fatturapa import (
     DatiDDTType,
     DatiTrasportoType,
@@ -69,8 +70,8 @@ class WizardExportFatturapa(models.TransientModel):
                 CausaleTrasporto=invoice.transportation_reason_id.name or None,
                 NumeroColli=invoice.parcels or None,
                 Descrizione=invoice.goods_description_id.name or None,
-                PesoLordo='%.2f' % invoice.gross_weight,
-                PesoNetto='%.2f' % invoice.weight,
+                PesoLordo='%.2f' % float_round(invoice.gross_weight, 2),
+                PesoNetto='%.2f' % float_round(invoice.weight, 2),
                 TipoResa=invoice.incoterms_id.code or None
             )
             if invoice.carrier_id:

--- a/l10n_it_fatturapa_out_stamp/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out_stamp/wizard/wizard_export_fatturapa.py
@@ -4,6 +4,7 @@
 from odoo import models
 from odoo.tools.translate import _
 from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_round
 from odoo.addons.l10n_it_fatturapa.bindings.fatturapa import (
     DatiBolloType
 )
@@ -23,6 +24,6 @@ class WizardExportFatturapa(models.TransientModel):
             stamp_price = invoice.company_id.tax_stamp_product_id.list_price
             body.DatiGenerali.DatiGeneraliDocumento.DatiBollo = DatiBolloType(
                 BolloVirtuale="SI",
-                ImportoBollo='%.2f' % stamp_price,
+                ImportoBollo='%.2f' % float_round(stamp_price, 2),
             )
         return res

--- a/l10n_it_fatturapa_out_triple_discount/wizards/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out_triple_discount/wizards/wizard_export_fatturapa.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models
+from odoo.tools.float_utils import float_round
 from odoo.addons.l10n_it_fatturapa.bindings.fatturapa import (
     ScontoMaggiorazioneType
 )
@@ -20,12 +21,12 @@ class WizardExportFatturapa(models.TransientModel):
                 DettaglioLinea.ScontoMaggiorazione.append(
                     ScontoMaggiorazioneType(
                         Tipo='SC',
-                        Percentuale='%.2f' % line.discount2
+                        Percentuale='%.2f' % float_round(line.discount2, 2)
                     ))
             if line.discount3:
                 DettaglioLinea.ScontoMaggiorazione.append(
                     ScontoMaggiorazioneType(
                         Tipo='SC',
-                        Percentuale='%.2f' % line.discount3
+                        Percentuale='%.2f' % float_round(line.discount3, 2)
                     ))
         return res

--- a/l10n_it_fatturapa_out_wt/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out_wt/wizard/wizard_export_fatturapa.py
@@ -3,6 +3,7 @@
 from odoo import models
 from odoo.tools.translate import _
 from odoo.exceptions import Warning as UserError
+from odoo.tools.float_utils import float_round
 from odoo.addons.l10n_it_fatturapa.bindings.fatturapa import (
     DatiRitenutaType,
     AltriDatiGestionaliType,
@@ -31,8 +32,9 @@ class WizardExportFatturapa(models.TransientModel):
                 = DatiRitenutaType(
                     TipoRitenuta="RT02" if invoice.partner_id.is_company
                     else "RT01",  # RT02 persona giuridica
-                    ImportoRitenuta='%.2f' % wt_line.tax,
-                    AliquotaRitenuta='%.2f' % wt_line.withholding_tax_id.tax,
+                    ImportoRitenuta='%.2f' % float_round(wt_line.tax, 2),
+                    AliquotaRitenuta='%.2f' % float_round(
+                        wt_line.withholding_tax_id.tax, 2),
                     CausalePagamento=wt_line.withholding_tax_id.
                     causale_pagamento_id.code
                 )
@@ -44,8 +46,10 @@ class WizardExportFatturapa(models.TransientModel):
                     DatiCassaPrevidenziale.append(
                         DatiCassaPrevidenzialeType(
                             TipoCassa='TC07',
-                            AlCassa='%.2f' % enas_line.withholding_tax_id.tax,
-                            ImportoContributoCassa='%.2f' % enas_line.tax,
+                            AlCassa='%.2f' % float_round(
+                                enas_line.withholding_tax_id.tax, 2),
+                            ImportoContributoCassa='%.2f' % float_round(
+                                enas_line.tax, 2),
                             AliquotaIVA='0.00',
                             Natura='N2'
                             )
@@ -70,11 +74,11 @@ class WizardExportFatturapa(models.TransientModel):
             if n2_riepilogo:
                 base_amount = float(n2_riepilogo.ImponibileImporto)
                 base_amount += enasarco_base
-                n2_riepilogo.ImponibileImporto = '%.2f' % base_amount
+                n2_riepilogo.ImponibileImporto = '%.2f' % float_round(base_amount, 2)
             else:
                 riepilogo = DatiRiepilogoType(
                     AliquotaIVA='0.00',
-                    ImponibileImporto='%.2f' % enasarco_base,
+                    ImponibileImporto='%.2f' % float_round(enasarco_base, 2),
                     Imposta='0.00',
                     Natura='N2',
                     RiferimentoNormativo='Escluso Art. 13 5C DPR 633/72',
@@ -95,7 +99,7 @@ class WizardExportFatturapa(models.TransientModel):
                     AltriDatiGestionaliType(
                         TipoDato="CASSA-PREV",
                         RiferimentoTesto=('ENASARCO TC07 (%s%%)' % wt.tax),
-                        RiferimentoNumero='%.2f' % amount,
+                        RiferimentoNumero='%.2f' % float_round(amount, 2),
                     )
                 )
             else:
@@ -113,7 +117,7 @@ class WizardExportFatturapa(models.TransientModel):
             for move_line_id in payment_line_ids:
                 move_line = move_line_pool.browse(move_line_id)
                 body.DatiPagamento[0].DettaglioPagamento[index].\
-                    ImportoPagamento = '%.2f' % (
-                        (move_line.amount_currency or move_line.debit) * rate)
+                    ImportoPagamento = '%.2f' % float_round(
+                        (move_line.amount_currency or move_line.debit) * rate, 2)
                 index += 1
         return res


### PR DESCRIPTION

See https://docs.python.org/3/whatsnew/3.0.html#builtins

Examples:
```
>>> '%.2f' % 75.845
'75.84'
>>> '%.2f' % 75.855
'75.86'
>>> round(2.5)
2
>>> round(3.5)
4
```






--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
