### PR TITLE
[12.0][FIX] l10n_it_fatturapa - Add fatturapa_pub_administration_ref to res_config_settings_view

### DIFF
--- a/l10n_it_fatturapa/views/company_view.xml
+++ b/l10n_it_fatturapa/views/company_view.xml
@@ -47,6 +47,10 @@
                                     <field name="fatturapa_art73"/>
                                 </div>
                                 <div class="row">
+                                    <label for="fatturapa_pub_administration_ref" class="col-lg-3 o_light_label"/>
+                                    <field name="fatturapa_pub_administration_ref"/>
+                                </div>
+                                <div class="row">
                                     <label for="fatturapa_rea_office" class="col-lg-3 o_light_label"/>
                                     <field name="fatturapa_rea_office"/>
                                 </div>

--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00001.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00001.xml
@@ -36,6 +36,7 @@
                 <Telefono>06543534343</Telefono>
                 <Email>info@yourcompany.example.com</Email>
             </Contatti>
+            <RiferimentoAmministrazione>F000000111</RiferimentoAmministrazione>
         </CedentePrestatore>
         <CessionarioCommittente>
             <DatiAnagrafici>

--- a/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
@@ -34,6 +34,7 @@ class TestFatturaPAXMLValidation(FatturaPACommon):
         super(TestFatturaPAXMLValidation, self).setUp()
 
     def test_1_xml_export(self):
+        self.env.user.company_id.fatturapa_pub_administration_ref = 'F000000111'
         self.set_sequences(13, '2016-01-07')
         invoice = self.invoice_model.create({
             'date_invoice': '2016-01-07',


### PR DESCRIPTION
Descrizione del problema o della funzionalità: Add `fatturapa_pub_administration_ref` to `res_config_settings_view`, see https://github.com/OCA/l10n-italy/issues/1601
Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
