### PR TITLE
[12.0] IMP l10n_it_fatturapa_in using received date as accounting date

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -878,6 +878,7 @@ class WizardImportFatturapa(models.TransientModel):
 
         invoice_data = {
             'e_invoice_received_date': e_invoice_received_date,
+            'date': e_invoice_received_date,
             'fiscal_document_type_id': docType_id,
             'sender': fatt.FatturaElettronicaHeader.SoggettoEmittente or False,
             'account_id': pay_acc_id,


### PR DESCRIPTION
In general this is the safest choice

See https://github.com/OCA/l10n-italy/issues/1594



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
