### PR TITLE
[FIX] l10n_it_fatturapa_out: DatiRiepilogo is mandatory but tax_line_ids is not required

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -699,6 +699,10 @@ class WizardExportFatturapa(models.TransientModel):
         return res
 
     def setDatiRiepilogo(self, invoice, body):
+        if not invoice.tax_line_ids:
+            raise UserError(
+                _("Invoice {invoice} has no tax lines")
+                .format(invoice=invoice.display_name))
         for tax_line in invoice.tax_line_ids:
             tax = tax_line.tax_id
             riepilogo = DatiRiepilogoType(


### PR DESCRIPTION
See https://github.com/OCA/l10n-italy/issues/1204

Without this, when generating the e-invoice for an invoice that has no tax lines, the following exception is raised:
IncompleteElementContentError: (<odoo.addons.l10n_it_fatturapa.bindings.fatturapa_v_1_2.DatiBeniServiziType object at 0x7f6fb8653ad0>, <pyxb.utils.fac.Configuration object at 0x7f6fb7d137d0>, [<pyxb.binding.basis.ElementContent object at 0x7f6fb8168410>, <pyxb.binding.basis.ElementContent object at 0x7f6fb8168350>, <pyxb.binding.basis.ElementContent object at 0x7f6fb87d8c90>], {})






--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
