### PR TITLE
11.0 FIX l10n_it_fatturapa_out: evitare blocco SDI per mismatch tra P.Iva e CF

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -364,13 +364,14 @@ class WizardExportFatturapa(models.TransientModel):
                 raise UserError(
                     _('VAT number and fiscal code are not set for %s.') %
                     partner.name)
-        if partner.fiscalcode:
-            fatturapa.FatturaElettronicaHeader.CessionarioCommittente.\
-                DatiAnagrafici.CodiceFiscale = partner.fiscalcode
         if partner.vat:
             fatturapa.FatturaElettronicaHeader.CessionarioCommittente.\
                 DatiAnagrafici.IdFiscaleIVA = IdFiscaleType(
                     IdPaese=partner.vat[0:2], IdCodice=partner.vat[2:])
+        if partner.fiscalcode \
+                and (not partner.vat or partner.vat == partner.fiscalcode):
+            fatturapa.FatturaElettronicaHeader.CessionarioCommittente.\
+                DatiAnagrafici.CodiceFiscale = partner.fiscalcode
         if partner.company_name:
             # This is valorized by e-commerce orders typically
             fatturapa.FatturaElettronicaHeader.CessionarioCommittente.\


### PR DESCRIPTION
**Descrizione del problema o della funzionalità:**
Col nuovo aggiornamento SDI, le fatture inviate restano bloccate se P.Iva e CF del Cessionario sono entrambe valorizzate e non combaciano.
Cfr: #1605 

**Comportamento attuale prima di questa PR:**
Nella generazione del file .xml, i dati di P.Iva e CF venivano riportati sempre (se presenti).

**Comportamento desiderato dopo questa PR:**
Nella generazione del file .xml, la P.Iva viene riportata sempre (se presente); il CF viene riportato se presente quando la P.Iva è assente, oppure la P.Iva è presente e le due stringhe combaciano.



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
