### PR TITLE
[12.0] FIX l10n_it_ddt: accessing to invoice without inventory permissions

### DIFF
--- a/l10n_it_ddt/security/ir.model.access.csv
+++ b/l10n_it_ddt/security/ir.model.access.csv
@@ -9,6 +9,4 @@ access_stock_picking_transportation_method_manager,stock.picking.transportation_
 access_stock_picking_transportation_method_user,stock.picking.transportation_method user,model_stock_picking_transportation_method,base.group_user,1,0,0,
 access_stock_ddt_type_user,access_stock_ddt_type user,model_stock_ddt_type,stock.group_stock_user,1,0,0,0
 access_stock_ddt_type_manager,access_stock_ddt_type manager,model_stock_ddt_type,stock.group_stock_manager,1,1,1,1
-
-
-
+access_account_invoice_group_ddt,account.invoice group ddt,model_stock_picking_package_preparation,account.group_account_invoice,1,0,0,0


### PR DESCRIPTION
Steps:

 - Install l10n_it_ddt
 - Create an invoice
 - Create a new user without inventory permissions
 - Log in with the new user and open the invoice

Get access error

See https://github.com/OCA/l10n-italy/issues/1621



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
