### PR TITLE
12.0 [FIX][l10n_it_account] Lesser fix to account.group 'get_group_parents' method (now correctly checking for parenting recursion)

### DIFF
--- a/l10n_it_account/models/account_group.py
+++ b/l10n_it_account/models/account_group.py
@@ -92,13 +92,14 @@ class AccountGroup(models.Model):
         parent_ids = []
         parent = self.parent_id
         while parent:
-            parent_ids.append(parent.id)
-            parent = parent.parent_id
-            if parent == self:
+            if parent.id in parent_ids:
                 raise ValidationError(
                     _("A recursion in '{}' parents has been found.")
                     .format(self.name_get()[0][-1])
                 )
+            else:
+                parent_ids.append(parent.id)
+                parent = parent.parent_id
         return self.browse(parent_ids)
 
     def get_group_subgroups(self):


### PR DESCRIPTION
Piccolo bugfix riguardo al metodo `get_group_parents` per il corretto controllo della ricorsione del campo `parent_id`



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
