### PR TITLE
[12.0][FIX] l10n_it_corrispettivi_sale - prevent update corrispettivi if fiscal_position doesn't exists

### DIFF
--- a/l10n_it_corrispettivi_sale/models/sale.py
+++ b/l10n_it_corrispettivi_sale/models/sale.py
@@ -14,7 +14,8 @@ class SaleOrder(models.Model):
     @api.onchange('fiscal_position_id')
     def _compute_tax_id(self):
         res = super(SaleOrder, self)._compute_tax_id()
-        self.corrispettivi = self.fiscal_position_id.corrispettivi
+        if self.fiscal_position_id:
+            self.corrispettivi = self.fiscal_position_id.corrispettivi
         return res
 
     corrispettivi = fields.Boolean()

--- a/l10n_it_corrispettivi_sale/readme/CONTRIBUTORS.rst
+++ b/l10n_it_corrispettivi_sale/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Simone Rubino <simone.rubino@agilebg.com>
+* Giovanni Serra <giovanni@gslab.it>


### PR DESCRIPTION
Descrizione del problema o della funzionalità: 
Update corrispettivi in sale order only if `fiscal_position_id` exists. Issue https://github.com/OCA/l10n-italy/issues/1628

Comportamento attuale prima di questa PR:
https://recordit.co/0sN9ABSn95

Comportamento desiderato dopo questa PR:
`use_corrispettivi` is correctly propagated in `sale.order`



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
