### PR TITLE
[12.0][FIX] l10n_it_corrispettivi, fix journal on partner change

### DIFF
--- a/l10n_it_corrispettivi/models/account.py
+++ b/l10n_it_corrispettivi/models/account.py
@@ -41,14 +41,15 @@ class AccountInvoice(models.Model):
 
         self.set_corr_journal()
 
-    @api.onchange('partner_id')
+    @api.onchange('partner_id', 'fiscal_position_id')
     def onchange_partner_id_corrispettivi(self):
-        if not self.partner_id or not self.partner_id.use_corrispettivi:
-            # If partner is not set or its use_corrispettivi flag is disabled,
-            # do nothing
-            return
-
-        self.set_corr_journal()
+        if (
+            self.partner_id.use_corrispettivi or
+            self.fiscal_position_id.corrispettivi
+        ):
+            self.set_corr_journal()
+        else:
+            self.journal_id = self._default_journal()
 
     @api.multi
     def set_corr_journal(self):

--- a/l10n_it_corrispettivi/readme/CONTRIBUTORS.rst
+++ b/l10n_it_corrispettivi/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Simone Rubino <simone.rubino@agilebg.com>
 * Sergio Zanchetta <https://github.com/primes2h>
+* Giovanni Serra <giovanni@gslab.it>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
`journal_id` non viene modificato al cambio del partner se quest'ultimo non ha il flag `use_corrispettivi` abilitato: https://recordit.co/tOYz0J4Rxz

Comportamento attuale prima di questa PR:
journal_id` non viene modificato

Comportamento desiderato dopo questa PR:
journal_id` viene modificato



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
