### PR TITLE
[12.0][ADD] fiscal_epos_print_fiscalcode

### DIFF
--- a/fiscal_epos_print/static/src/js/epson_epos_print.js
+++ b/fiscal_epos_print/static/src/js/epson_epos_print.js
@@ -300,11 +300,12 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
         // but before <beginFiscalReceipt /> otherwise it will not be printed
         // as additional header messageType=1
         printFiscalReceiptHeader: function(receipt){
+            var self = this;
             var msg = '';
             if (receipt.header != '' && receipt.header.length > 0) {
                 var hdr = receipt.header.split(/\r\n|\r|\n/);
                 _.each(hdr, function(m, i) {
-                    msg += '<printRecMessage' + ' messageType="1" message="' + this.encodeXml(m)
+                    msg += '<printRecMessage' + ' messageType="1" message="' + self.encodeXml(m)
                          + '" font="1" index="' + (i+1) + '"'
                          + ' operator="' + (receipt.operator || '1') + '" />'
                     });
@@ -315,11 +316,12 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
         // Remember that the footer goes within <printerFiscalReceipt><beginFiscalReceipt />
         // as PROMO code messageType=3
         printFiscalReceiptFooter: function(receipt){
+            var self = this;
             var msg = '';
             if (receipt.footer != '' && receipt.footer.length > 0) {
                 var hdr = receipt.footer.split(/\r\n|\r|\n/);
                 _.each(hdr, function(m, i) {
-                    msg += '<printRecMessage' + ' messageType="3" message="' + this.encodeXml(m)
+                    msg += '<printRecMessage' + ' messageType="3" message="' + self.encodeXml(m)
                          + '" font="1" index="' + (i+1) + '"'
                          + ' operator="' + (receipt.operator || '1') + '" />'
                     });

--- a/fiscal_epos_print_fiscalcode/__init__.py
+++ b/fiscal_epos_print_fiscalcode/__init__.py
@@ -1,0 +1,3 @@
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/fiscal_epos_print_fiscalcode/__manifest__.py
+++ b/fiscal_epos_print_fiscalcode/__manifest__.py
@@ -1,0 +1,22 @@
+#  Copyright 2020 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'ITA - Codice fiscale negli scontrini',
+    'version': '12.0.1.0.0',
+    'category': 'Point of Sale',
+    'summary': 'Consente di includere il codice fiscale negli scontrini',
+    'author': 'Agile Business Group, '
+              'Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'website': 'https://github.com/OCA/l10n-italy/tree/'
+               '12.0/fiscal_epos_print_fiscalcode',
+    'depends': [
+        'fiscal_epos_print',
+        'l10n_it_pos_fiscalcode',
+    ],
+    'data': [
+        'views/assets.xml',
+        'views/res_partner_views.xml',
+    ],
+}

--- a/fiscal_epos_print_fiscalcode/i18n/it.po
+++ b/fiscal_epos_print_fiscalcode/i18n/it.po
@@ -1,0 +1,40 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* fiscal_epos_print_fiscalcode
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-02-07 09:51+0000\n"
+"PO-Revision-Date: 2020-02-07 09:51+0000\n"
+"Last-Translator: Simone Rubino <simone.rubino@agilebg.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: fiscal_epos_print_fiscalcode
+#: model:ir.model,name:fiscal_epos_print_fiscalcode.model_res_partner
+msgid "Contact"
+msgstr "Contatto"
+
+#. module: fiscal_epos_print_fiscalcode
+#. openerp-web
+#: code:addons/fiscal_epos_print_fiscalcode/static/src/js/fiscal_epos_print_fiscalcode.js:15
+#, python-format
+msgid "F.C.: "
+msgstr "C.F.: "
+
+#. module: fiscal_epos_print_fiscalcode
+#: model:ir.model.fields,field_description:fiscal_epos_print_fiscalcode.field_res_partner__epos_print_fiscalcode_receipt
+#: model:ir.model.fields,field_description:fiscal_epos_print_fiscalcode.field_res_users__epos_print_fiscalcode_receipt
+msgid "Fiscal code in receipts"
+msgstr "Codice fiscale negli scontrini"
+
+#. module: fiscal_epos_print_fiscalcode
+#: model:ir.model.fields,help:fiscal_epos_print_fiscalcode.field_res_partner__epos_print_fiscalcode_receipt
+#: model:ir.model.fields,help:fiscal_epos_print_fiscalcode.field_res_users__epos_print_fiscalcode_receipt
+msgid "Print fiscal code in receipts for this partner."
+msgstr "Stampa il codice fiscale negli scontrini."

--- a/fiscal_epos_print_fiscalcode/models/__init__.py
+++ b/fiscal_epos_print_fiscalcode/models/__init__.py
@@ -1,0 +1,3 @@
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import res_partner

--- a/fiscal_epos_print_fiscalcode/models/res_partner.py
+++ b/fiscal_epos_print_fiscalcode/models/res_partner.py
@@ -1,0 +1,13 @@
+#  Copyright 2020 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResPartner (models.Model):
+    _inherit = 'res.partner'
+
+    epos_print_fiscalcode_receipt = fields.Boolean(
+        string="Fiscal code in receipts",
+        help="Print fiscal code in receipts for this partner."
+    )

--- a/fiscal_epos_print_fiscalcode/readme/CONFIGURE.rst
+++ b/fiscal_epos_print_fiscalcode/readme/CONFIGURE.rst
@@ -1,0 +1,7 @@
+**Italiano**
+
+Nella scheda del partner, abilitare `Codice fiscale negli scontrini`.
+
+**English**
+
+In the partner form, check `Fiscal code in receipts`.

--- a/fiscal_epos_print_fiscalcode/readme/CONTRIBUTORS.rst
+++ b/fiscal_epos_print_fiscalcode/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Simone Rubino

--- a/fiscal_epos_print_fiscalcode/readme/DESCRIPTION.rst
+++ b/fiscal_epos_print_fiscalcode/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+**Italiano**
+
+Questo modulo consente di includere il codice fiscale del cliente negli scontrini.
+
+**English**
+
+This module allows to include the fiscal code of the customer in fiscal receipts.

--- a/fiscal_epos_print_fiscalcode/static/src/js/fiscal_epos_print_fiscalcode.js
+++ b/fiscal_epos_print_fiscalcode/static/src/js/fiscal_epos_print_fiscalcode.js
@@ -1,0 +1,29 @@
+odoo.define("fiscal_epos_print_fiscalcode.models", function (require) {
+    "use strict";
+
+    var core = require('web.core');
+    var _t = core._t;
+    var fiscal_epos_print_models =
+        require("fiscal_epos_print.epson_epos_print");
+
+    fiscal_epos_print_models.eposDriver.include( {
+        printFiscalReceiptHeader: function (receipt) {
+            var fiscalcode_message = "";
+            var current_client = this.sender.pos.get_client();
+            var fiscalcode = current_client && current_client.fiscalcode;
+            if (fiscalcode && current_client.epos_print_fiscalcode_receipt) {
+                fiscalcode = fiscalcode.toUpperCase();
+                fiscalcode_message = "\n" + _t("F.C.: ") + fiscalcode + "\n";
+            }
+
+            if (fiscalcode_message) {
+                if (!receipt.header) {
+                    receipt.header = "";
+                }
+                receipt.header += fiscalcode_message;
+            }
+
+            return this._super(receipt);
+        },
+    });
+});

--- a/fiscal_epos_print_fiscalcode/static/src/js/models.js
+++ b/fiscal_epos_print_fiscalcode/static/src/js/models.js
@@ -1,0 +1,6 @@
+odoo.define('fiscal_epos_print_fiscalcode.epos_print_fiscalcode_receipt_field', function (require) {
+    "use strict";
+
+    var pos_models = require('point_of_sale.models');
+    pos_models.load_fields("res.partner", "epos_print_fiscalcode_receipt");
+});

--- a/fiscal_epos_print_fiscalcode/views/assets.xml
+++ b/fiscal_epos_print_fiscalcode/views/assets.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2020 Simone Rubino - Agile Business Group
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+  -->
+
+<odoo>
+    <template id="assets" inherit_id="fiscal_epos_print.assets">
+        <xpath expr="//script[last()]" position="after">
+            <script type="text/javascript" src="/fiscal_epos_print_fiscalcode/static/src/js/fiscal_epos_print_fiscalcode.js"/>
+            <script type="text/javascript" src="/fiscal_epos_print_fiscalcode/static/src/js/models.js"/>
+        </xpath>
+    </template>
+</odoo>

--- a/fiscal_epos_print_fiscalcode/views/res_partner_views.xml
+++ b/fiscal_epos_print_fiscalcode/views/res_partner_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright 2020 Simone Rubino - Agile Business Group
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+  -->
+
+<odoo>
+    <record id="view_partner_form_fiscalcode_data" model="ir.ui.view">
+        <field name="name">Add fiscalcode in receipt to res.partner form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="l10n_it_fiscalcode.view_partner_form_fiscalcode_data"/>
+        <field name="arch" type="xml">
+            <div name="fiscalcode_info" position="after">
+                <field name="epos_print_fiscalcode_receipt"/>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
**Descrizione della funzionalità**
Stampare il codice fiscale negli scontrini

Durante lo sviluppo del modulo ho trovato un problema nel modulo https://github.com/OCA/l10n-italy/tree/12.0/fiscal_epos_print che ho corretto in un commit separato (sempre in questa PR).


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
