### PR TITLE
[IMP] 10.0 - Aggiornato numero di pagina nel footer in base all'anno indicato nel campo year_footer

### DIFF
--- a/l10n_it_account/reports/account_reports_view.xml
+++ b/l10n_it_account/reports/account_reports_view.xml
@@ -65,7 +65,14 @@
                   <div class="col-xs-4 col-xs-offset-4 text-right">
                     <span style="display: none;" id="l10n_it_count_fiscal_page_base" t-esc="l10n_it_count_fiscal_page_base" />
                     <ul class="list-inline">Pag:
-                        <li><span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y')"/></li>
+                        <li>
+                            <t t-if="l10n_it_count_fiscal_year">
+                                <span t-esc="l10n_it_count_fiscal_year"/>
+                            </t>
+                            <t t-if="not l10n_it_count_fiscal_year">
+                                <span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y')"/>
+                            </t>
+                        </li>
                         <li>/</li>
                         <li><span class="page"/></li>
                     </ul>

--- a/l10n_it_vat_registries/models/vat_registry.py
+++ b/l10n_it_vat_registries/models/vat_registry.py
@@ -40,7 +40,8 @@ class ReportRegistroIva(models.AbstractModel):
             'compute_totals_tax': self._compute_totals_tax,
             'l10n_it_count_fiscal_page_base': data['form']['fiscal_page_base'],
             'only_totals': data['form']['only_totals'],
-            'date_format': date_format
+            'date_format': date_format,
+            'year_footer': data['form']['year_footer']
         }
 
         return self.env['report'].render(

--- a/l10n_it_vat_registries/report/report_registro_iva.xml
+++ b/l10n_it_vat_registries/report/report_registro_iva.xml
@@ -13,6 +13,7 @@
         <t t-if="registry_type == 'corrispettivi'">
             <t t-set="title" t-value="'Registro Corrispettivi'"/>
         </t>
+        <t t-set="l10n_it_count_fiscal_year" t-value="year_footer"/>
         <t t-call="l10n_it_account.internal_layout">
             <div class="page">
                 <t t-set="print_details" t-value="1"/>

--- a/l10n_it_vat_registries/wizard/print_registro_iva.py
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.py
@@ -32,6 +32,9 @@ class WizardRegistroIva(models.TransientModel):
     only_totals = fields.Boolean(
         string='Prints only totals')
     fiscal_page_base = fields.Integer('Last printed page', required=True)
+    year_footer = fields.Char(
+        string='Year for Footer',
+        help="Value printed near number of page in the footer")
 
     @api.multi
     def load_journal_ids(self):
@@ -73,6 +76,7 @@ class WizardRegistroIva(models.TransientModel):
         datas_form['journal_ids'] = [j.id for j in wizard.journal_ids]
         datas_form['fiscal_page_base'] = wizard.fiscal_page_base
         datas_form['registry_type'] = wizard.layout_type
+        datas_form['year_footer'] = wizard.year_footer
 
         lang_code = self.env.user.company_id.partner_id.lang
         lang = self.env['res.lang']

--- a/l10n_it_vat_registries/wizard/print_registro_iva.xml
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.xml
@@ -16,6 +16,9 @@
                         <group>
                             <field name="to_date"/>
                         </group>
+                        <group>
+                            <field name="year_footer"/>
+                        </group>
                         <separator string="Journals" colspan="2"/>
                         <group>
                             <field name="tax_registry_id"></field>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Comportamento attuale prima di questa PR:
Prima di questa PR non avevo la possibilità di scegliere l'anno nella stampa registro iva

Comportamento desiderato dopo questa PR:
Dopo di questa PR ho la possibilità di scegliere l'anno nella stampa registro iva

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
