### PR TITLE
[12.0][FIX] fiscal_epos_print: Formato data del reso

### DIFF
--- a/fiscal_epos_print/__manifest__.py
+++ b/fiscal_epos_print/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'ITA - Driver per stampanti fiscali compatibili ePOS-Print XML',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'category': 'Point Of Sale',
     'summary': 'ePOS-Print XML Fiscal Printer Driver - Stampanti Epson compatibili: '
                'FP81II, FP90III',

--- a/fiscal_epos_print/static/src/js/popups.js
+++ b/fiscal_epos_print/static/src/js/popups.js
@@ -61,17 +61,6 @@ odoo.define("fiscal_epos_print.popups", function (require) {
             if (element && !this.datepicker) {
                 this.datepicker = new Pikaday({
                     field: element,
-                    parse: function(str) {
-                        return new Date(str.slice(4, 8),
-                                        str.slice(2, 4),
-                                        str.slice(0, 2))
-                    },
-                    toString: function(date) {
-                        var str = date.toLocaleDateString().split('/');
-                        return addPadding(str[1], 2) +
-                            addPadding(str[0], 2) +
-                            addPadding(str[2]);
-                    }
                 });
             }
         },


### PR DESCRIPTION
**Descrizione del problema o della funzionalità**
1. Portare a termine un ordine nel POS
2. Selezionare l'ordine dal carrello del POS
3. Fare il reso inserendo i dati richiesti
  Nota: la data viene scritta nel formato 11022020
4. Procedere al _pagamento_ e validare

**Comportamento attuale prima di questa PR**
```
res = self._obj.execute(query, params)
psycopg2.DataError: date/time field value out of range: "11022020"
LINE 1: .../0004', 0, NULL, 'Refund 00001-003-0003', 1, '1', '11022020'...
                                                             ^
HINT:  Perhaps you need a different "datestyle" setting.
```

**Comportamento desiderato dopo questa PR**
Completare il reso

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
