### PR TITLE
12.0 - Fix in query sql

### DIFF
--- a/l10n_it_central_journal/wizard/print_giornale.py
+++ b/l10n_it_central_journal/wizard/print_giornale.py
@@ -99,7 +99,7 @@ class WizardGiornale(models.TransientModel):
             aml.date >= %(date_from)s
             AND aml.date <= %(date_to)s
             AND am.state in %(target_type)s
-            AND journal_id in %(journal_ids)s
+            AND aml.journal_id in %(journal_ids)s
             ORDER BY am.date, am.name
         """
         params = {


### PR DESCRIPTION
Comportamento attuale prima di questa PR:
In esecuzione query nella funzione get_line_ids, c'era questo errore:

psycopg2.errors.AmbiguousColumn: column reference "journal_id" is ambiguous
LINE 8:             AND journal_id in (1)
ERROR: column reference "journal_id" is ambiguous

Comportamento desiderato dopo questa PR:
Fix errore


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
