### PR TITLE
12.0-fix-report-account_vat_period_end_statement

### DIFF
--- a/account_vat_period_end_statement/readme/CONTRIBUTORS.rst
+++ b/account_vat_period_end_statement/readme/CONTRIBUTORS.rst
@@ -8,4 +8,5 @@
 * Simone Rubino <simone.rubino@agilebg.com>
 * Giacomo Grasso <giacomo.grasso.82@gmail.com>
 * Lara Baggio <http://linkgroup.it/>
+* Gianmarco Conte <gconte@dinamicheaziendali.it>
 

--- a/account_vat_period_end_statement/views/report_vatperiodendstatement.xml
+++ b/account_vat_period_end_statement/views/report_vatperiodendstatement.xml
@@ -137,7 +137,7 @@
                     <table class="table table-condensed">
                             <t t-foreach="statement.payment_ids" t-as="payment_line">
                                 <tr>
-                                    <td t-esc="'Importo versato (Estremi del versamento: data '+ time.strftime('%d/%m/%Y', time.strptime(payment_line.date, '%Y-%m-%d')) + ' - ' +payment_line.journal_id.name+')'" />
+                                    <td t-esc="'Importo versato (Estremi del versamento: data '+ payment_line.date.strftime('%d/%m/%Y') + ' - ' +payment_line.journal_id.name+')'" />
                                     <td class="text-right" t-esc="formatLang(env, payment_line.debit)" />
                                </tr>
                                <tr>


### PR DESCRIPTION
Comportamento attuale prima di questa PR:
In fase di stampa Liquidazione Iva c'era un errore in questa riga:
`<td t-esc="'Importo versato (Estremi del versamento: data '+ time.strftime('%d/%m/%Y', time.strptime(payment_line.date, '%Y-%m-%d')) + ' - ' +payment_line.journal_id.name+')'" />`

dove lo strptime di payment_line.date andava in errore perchè payment_line.date è di tipo data, mentre la funzione vuole un campo string
Comportamento desiderato dopo questa PR:
string payment_line.date è già una data, quindi fix dell'errore


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
