### PR TITLE
[12.0][ADD]column invoice_id in riba tree view

### DIFF
--- a/l10n_it_ricevute_bancarie/views/account_view.xml
+++ b/l10n_it_ricevute_bancarie/views/account_view.xml
@@ -45,6 +45,7 @@
         <field name="arch" type="xml">
             <tree string="C/O Issue" create="false" colors="grey:reconciled!=False;red:date_maturity&lt;current_date">
                 <field name="partner_id" readonly="1"/>
+                <field name="invoice_id" readonly="1"/>
                 <field name="iban" readonly="1"/>
                 <!-- TODO: field name="partner_ref" readonly="1"/>
                 <field name="invoice_date" readonly="1"/>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Nella tree dell'emissione RiBa manca una colonna con l'indicazione della fattura

Comportamento attuale prima di questa PR:
Nella tree relativa all'emissione delle RiBA manca una colonna con l'indicazione della fattura 

Comportamento desiderato dopo questa PR: 
Viene aggiunta nella vista 'view_riba_da_emettere_tree' una colonna con l'indicazione della fattura




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
