### PR TITLE
[12.0][fiscal_epos_print] Fix error when scanning barcode after gener…

### DIFF
--- a/fiscal_epos_print/static/src/js/models.js
+++ b/fiscal_epos_print/static/src/js/models.js
@@ -25,6 +25,17 @@ odoo.define('fiscal_epos_print.models', function (require) {
             this.fiscal_z_rep_number = null;
             this.fiscal_printer_serial = this.pos.config.fiscal_printer_serial || null;
         },
+
+        // Manages the case in which after printing an invoice
+        // you pass a barcode in the mask of the registered invoice
+        add_product: function(product, options) {
+            if(this._printed || this.finalized == true) {
+                this.destroy();
+                return this.pos.get_order().add_product(product, options);
+            }
+            OrderSuper.prototype.add_product.apply(this, arguments);
+        },
+
         check_order_has_refund: function() {
             var order = this.pos.get_order();
             if (order) {


### PR DESCRIPTION
…ating the invoice

Descrizione del problema o della funzionalità:

Dopo aver generato la fattura da scontrino, il POS rimane in attesa dell'azione da parte dell'operatore. L'azione può essere premere il pulsante "Ordine Successivo" oppure scannerizzare un barcode per aprire un nuovo scontrino. Se si effettua la scansione del barcode si ottiene l'errore riportato di seguito.

![Peek 2020-02-18 17-36](https://user-images.githubusercontent.com/1663021/74757471-555d0700-5276-11ea-82ba-e995bd2e0ff2.gif)

Comportamento attuale prima di questa PR:

Alla scansione di un barcode dopo aver emesso una fattura, il frontend và in crash

Comportamento desiderato dopo questa PR:

Non far crashare l'applicazione ed aprire un nuovo scontrino



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
