### PR TITLE
[12.0][FIX] Recompute if tax stamp is applicable also if one subtotal changes

### DIFF
--- a/l10n_it_account_stamp/models/company.py
+++ b/l10n_it_account_stamp/models/company.py
@@ -21,15 +21,3 @@ class AccountConfigSettings(models.TransientModel):
         help="Product used as Tax Stamp in customer invoices.",
         readonly=False
         )
-
-    @api.onchange('company_id')
-    def onchange_company_id(self):
-        res = super(AccountConfigSettings, self).onchange_company_id()
-        if self.company_id:
-            company = self.company_id
-            self.tax_stamp_product_id = (
-                company.tax_stamp_product_id and
-                company.tax_stamp_product_id.id or False)
-        else:
-            self.tax_stamp_product_id = False
-        return res

--- a/l10n_it_account_stamp/models/invoice.py
+++ b/l10n_it_account_stamp/models/invoice.py
@@ -29,7 +29,7 @@ class AccountInvoice(models.Model):
         else:
             return False
 
-    @api.onchange('tax_line_ids')
+    @api.onchange('tax_line_ids', 'amount_untaxed')
     def _onchange_tax_line_ids(self):
         if self.auto_compute_stamp:
             self.tax_stamp = self.is_tax_stamp_applicable()


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Non veniva ricalcolata l'applicabilità del bollo dopo aver modificato il prezzo o la qta su una riga esistente.
Comportamento attuale prima di questa PR:
Non veniva ricalcolata l'applicabilità del bollo dopo aver modificato il prezzo o la qta su una riga esistente.
Comportamento desiderato dopo questa PR:
Al superamento del limite di applicabilità, viene correttamente mostrato il pulsante per aggiungere il bollo



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
