### PR TITLE
[12.0][FIX] intrastat_statement: transport code value in purchase section

### DIFF
--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
@@ -135,7 +135,7 @@ class IntrastatStatementPurchaseSection1(models.Model):
             'additional_units': round(inv_intra_line.additional_units) or 0,
             'statistic_amount_euro': statistic_amount,
             'delivery_code_id': delivery_code_id.id,
-            'transport_code_id': transport_code_id,
+            'transport_code_id': transport_code_id.id,
             'country_origin_id': inv_intra_line.country_origin_id.id,
             'country_good_origin_id': inv_intra_line.country_good_origin_id.id,
             'province_destination_id': province_destination_id.id


### PR DESCRIPTION
**Descrizione del problema o della funzionalità**
Facendo il ricalcolo del modello intrastat, viene sollevato l'errore:
```psycopg2.ProgrammingError: can't adapt type 'account.intrastat.transport'```


**Comportamento attuale prima di questa PR**
Errore `psycopg2.ProgrammingError: can't adapt type 'account.intrastat.transport'`

**Comportamento desiderato dopo questa PR**
Nessun errore durante il ricalcolo

Non creo la issue perché il modulo non è presente nella `10.0`.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
