### PR TITLE
[12.0] IMP fiscal_epos_print removing lines with quantity = 0, as not allowed by fiscal printer

### DIFF
--- a/fiscal_epos_print/static/src/js/models.js
+++ b/fiscal_epos_print/static/src/js/models.js
@@ -104,6 +104,13 @@ odoo.define('fiscal_epos_print.models', function (require) {
                 'body': _t('No taxes found'),
             });
         },
+        set_quantity: function(quantity, keep_price) {
+            if (quantity == '0') {
+                // Epson FP doesn't allow lines with quantity 0
+                quantity = 'remove';
+            }
+            return _orderline_super.set_quantity.call(this, quantity, keep_price);
+        },
         compute_all: function(taxes, price_unit, quantity, currency_rounding, no_map_tax) {
             var res = _orderline_super.compute_all.call(this, taxes, price_unit, quantity, currency_rounding, no_map_tax);
             var self = this;


### PR DESCRIPTION
Comportamento osservato:

Provando a stampare uno scontrino con una riga con quantità 0, lo scontrino resta bloccato e viene annullato dall'operazione successiva

Comportamento desiderato:

Nel momento in cui l'utente inserisce 0 come quantità per una riga, la riga viene rimossa


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
