### PR TITLE
12.0 [FIX][l10n_it_fatturapa_in] Fix partner search to be multicompany-com…

### DIFF
--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -74,10 +74,11 @@ class FatturaPAAttachmentIn(models.Model):
     @api.depends('ir_attachment_id.datas')
     def _compute_xml_data(self):
         for att in self:
-            fatt = self.env['wizard.import.fatturapa'].get_invoice_obj(att)
+            wiz_obj = self.env['wizard.import.fatturapa'] \
+                .with_context(from_attachment=att)
+            fatt = wiz_obj.get_invoice_obj(att)
             cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore
-            partner_id = self.env['wizard.import.fatturapa'].getCedPrest(
-                cedentePrestatore)
+            partner_id = wiz_obj.getCedPrest(cedentePrestatore)
             att.xml_supplier_id = partner_id
             att.invoices_number = len(fatt.FatturaElettronicaBody)
             att.invoices_total = 0

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -125,13 +125,25 @@ class WizardImportFatturapa(models.TransientModel):
                 )
         partners = partner_model
         if vat:
-            partners = partner_model.search([
-                ('vat', '=', vat),
-            ])
+            domain = [('vat', '=', vat)]
+            if self.env.context.get('from_attachment'):
+                att = self.env.context.get('from_attachment')
+                domain.extend([
+                    '|',
+                    ('company_id', 'child_of', att.company_id.id),
+                    ('company_id', '=', False)
+                ])
+            partners = partner_model.search(domain)
         if not partners and cf:
-            partners = partner_model.search([
-                ('fiscalcode', '=', cf),
-            ])
+            domain = [('fiscalcode', '=', cf)]
+            if self.env.context.get('from_attachment'):
+                att = self.env.context.get('from_attachment')
+                domain.extend([
+                    '|',
+                    ('company_id', 'child_of', att.company_id.id),
+                    ('company_id', '=', False)
+                ])
+            partners = partner_model.search(domain)
         commercial_partner_id = False
         if len(partners) > 1:
             for partner in partners:


### PR DESCRIPTION
…pliant

Descrizione del problema o della funzionalità:
Se lo stesso partner con stessa P. IVA o CF è presente più volte sotto company diverse in un ambiente multicompany, il metodo `getPartnerBase` fallisce la ricerca.

Comportamento desiderato dopo questa PR:
Il metodo `getPartnerBase` tiene conto della company di rilevanza per l'assegnazione del partner e fa la ricerca aggiungendo la `company` nel dominio della `search` su `res.partner`.



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
