### PR TITLE
[12.0] FIX l10n_it_vat_statement_communication: TypeError: Argument must be bytes or unicode, got 'int'

### DIFF
--- a/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
+++ b/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
@@ -265,7 +265,7 @@ class ComunicazioneLiquidazione(models.Model):
         if self.last_month:
             x1_2_1_5_UltimoMese = etree.SubElement(
                 x1_2_1_Frontespizio, etree.QName(NS_IV, "UltimoMese"))
-            x1_2_1_5_UltimoMese.text = self.last_month
+            x1_2_1_5_UltimoMese.text = str(self.last_month)
         # Liquidazione Gruppo
         x1_2_1_6_LiquidazioneGruppo = etree.SubElement(
             x1_2_1_Frontespizio, etree.QName(NS_IV, "LiquidazioneGruppo"))


### PR DESCRIPTION
 - Creare una comunicazione liquidazione IVA
 - Valorizzare il campo `last month`
 - Esportare XML

Ottenere

```
l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py", line 268, in _export_xml_get_frontespizio
    x1_2_1_5_UltimoMese.text = self.last_month
  File "src/lxml/lxml.etree.pyx", line 1031, in lxml.etree._Element.text.__set__ (src/lxml/lxml.etree.c:53218)
  File "src/lxml/apihelpers.pxi", line 715, in lxml.etree._setNodeText (src/lxml/lxml.etree.c:24413)
  File "src/lxml/apihelpers.pxi", line 703, in lxml.etree._createTextNode (src/lxml/lxml.etree.c:24276)
  File "src/lxml/apihelpers.pxi", line 1441, in lxml.etree._utf8 (src/lxml/lxml.etree.c:31470)
TypeError: Argument must be bytes or unicode, got 'int'
```





--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
