### PR TITLE
[12.0] FIX l10n_it_vat_statement_communication: I contribuenti che hanno optato per la liquidazione trimestrale ai sensi dell’art. 7 del D.P.R. n. 542/99 devono indicare “5” per il quarto trimestre

### DIFF
--- a/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
+++ b/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
@@ -462,10 +462,13 @@ class ComunicazioneLiquidazioneVp(models.Model):
         for quadro in self:
             quadro.iva_da_versare = 0
             quadro.iva_a_credito = 0
-            if quadro.period_type == 'quarter' and quadro.quarter == 4:
+            if quadro.period_type == 'quarter' and quadro.quarter == 5:
                 # VP14 non deve essere compilato dai contribuenti trimestrali di cui
                 # all’art. 7 del d.P.R. 14 ottobre 1999, n.542,
                 # relativamente al 4° trimestre
+                # I contribuenti che hanno optato per la liquidazione trimestrale ai
+                # sensi dell’art. 7 del D.P.R. n. 542/99 devono indicare “5” per il
+                # quarto trimestre
                 continue
             debito = (
                 quadro.iva_dovuta_debito + quadro.debito_periodo_precedente +


### PR DESCRIPTION

Descrizione del problema o della funzionalità:

https://github.com/OCA/l10n-italy/issues/1649





--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
