### PR TITLE
12.0 [FIX][l10n_it_withholding_tax] Fix: correctly set net residual amount in invoice payment wizard

### DIFF
--- a/l10n_it_withholding_tax/tests/test_withholding_tax.py
+++ b/l10n_it_withholding_tax/tests/test_withholding_tax.py
@@ -114,7 +114,7 @@ class TestWithholdingTax(TransactionCase):
             'active_model': 'account.invoice',
             'active_ids': [self.invoice.id],
             }
-        register_payments = self.env['account.register.payments']\
+        invoice_payment = self.env['account.payment']\
             .with_context(ctx).create({
                 'payment_date': time.strftime('%Y') + '-07-15',
                 'amount': 800,
@@ -122,7 +122,7 @@ class TestWithholdingTax(TransactionCase):
                 'payment_method_id': self.env.ref(
                     "account.account_payment_method_manual_out").id,
                 })
-        register_payments.create_payments()
+        invoice_payment.action_validate_invoice_payment()
 
         # WT payment generation
         self.assertEqual(


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Il wizard dei pagamenti che si apre dalle fatture fornitore non prende l'importo corretto, impostando come importo da pagare il totale della fattura senza detrarre la ritenuta d'acconto.


Comportamento desiderato dopo questa PR:
Il wizard dei pagamenti che si apre dalle fatture fornitore prende di default il valore corretto, ovvero l'imponibile residuo.




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
