### PR TITLE
[10.0] libro giornale anno footer

### DIFF
--- a/l10n_it_central_journal/models/central_journal.py
+++ b/l10n_it_central_journal/models/central_journal.py
@@ -32,6 +32,7 @@ class ReportGiornale(models.AbstractModel):
             'formatLang': formatLang,
             'l10n_it_count_fiscal_page_base': data['form']['fiscal_page_base'],
             'start_row': data['form']['start_row'],
+            'year_footer': data['form']['year_footer'],
             'date_move_line_to': data['form']['date_move_line_to'],
             'daterange': data['form']['daterange'],
             'print_state': data['form']['print_state'],

--- a/l10n_it_central_journal/views/report_account_central_journal.xml
+++ b/l10n_it_central_journal/views/report_account_central_journal.xml
@@ -5,6 +5,7 @@
 <template id="report_giornale">
     <t t-call="report.html_container">
         <t t-set="title" t-value="'Stampa libro giornale'"/>
+        <t t-set="l10n_it_count_fiscal_year" t-value="year_footer"/>
         <t t-call="l10n_it_account.internal_layout">
             <div class="page">
                 <t t-set="print_details" t-value="1"/>

--- a/l10n_it_central_journal/wizard/print_giornale.py
+++ b/l10n_it_central_journal/wizard/print_giornale.py
@@ -52,6 +52,9 @@ class WizardGiornale(models.TransientModel):
                                    'Target Move', default='all')
     fiscal_page_base = fields.Integer('Last printed page', required=True)
     start_row = fields.Integer('Start row', required=True)
+    year_footer = fields.Char(
+        string='Year for Footer',
+        help="Value printed near number of page in the footer")
 
     @api.onchange('daterange')
     def on_change_daterange(self):
@@ -79,6 +82,13 @@ class WizardGiornale(models.TransientModel):
 
             if self.last_def_date_print == self.daterange.date_end:
                 self.date_move_line_from_view = self.last_def_date_print
+
+    @api.onchange('date_move_line_from')
+    def on_change_date_start(self):
+        if self.date_move_line_from:
+            self.year_footer = str(datetime.strptime(
+                self.date_move_line_from, "%Y-%m-%d").year
+            )
 
     def get_line_ids(self):
         wizard = self
@@ -116,6 +126,7 @@ class WizardGiornale(models.TransientModel):
         datas_form['progressive_credit'] = wizard.progressive_credit
         datas_form['start_row'] = wizard.start_row
         datas_form['daterange'] = wizard.daterange.id
+        datas_form['year_footer'] = wizard.year_footer
         return datas_form
 
     def print_giornale(self):

--- a/l10n_it_central_journal/wizard/print_giornale.xml
+++ b/l10n_it_central_journal/wizard/print_giornale.xml
@@ -27,6 +27,7 @@
                     <field name="target_move"/>
                     <field name="fiscal_page_base"/>
                     <field name="start_row"/>
+                    <field name="year_footer"/>
                     <field name="progressive_credit" invisible="1"/>
                     <field name="progressive_debit2" invisible="1"/>
                 </group>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
https://github.com/OCA/l10n-italy/issues/1672
Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:
viene aggiungo un campo sul wizard di stampa dove può essere indicato l'anno da riportare nel footer del libro giornale.
Di default prende l'anno della data da cui devono essere stampate le registrazioni contabili



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
