### PR TITLE
12.0 comunicazione dati iva: esterometro

### DIFF
--- a/l10n_it_invoices_data_communication/models/communication.py
+++ b/l10n_it_invoices_data_communication/models/communication.py
@@ -188,6 +188,10 @@ class ComunicazioneDatiIva(models.Model):
         help="To fill along with 2.1.2.2 <Nome> and alternatively to "
              "2.1.2.1 <Denominazione>")
     errors = fields.Text(copy=False)
+    esterometro = fields.Boolean(
+        default=True,
+        string="Esterometro"
+    )
 
     @api.onchange('company_id')
     def onchange_company_id(self):
@@ -460,6 +464,10 @@ class ComunicazioneDatiIva(models.Model):
                   ('fiscal_document_type_id.out_invoice', '=', True),
                   ('fiscal_document_type_id.out_refund', '=', True),
                   ]
+        if self.esterometro:
+            domain.append(
+                ('partner_id.country_id.code', 'not in', (False, 'IT'))
+            )
         return domain
 
     def _get_fatture_emesse(self):
@@ -531,6 +539,10 @@ class ComunicazioneDatiIva(models.Model):
                   '|',
                   ('fiscal_document_type_id.in_invoice', '=', True),
                   ('fiscal_document_type_id.in_refund', '=', True), ]
+        if self.esterometro:
+            domain.append(
+                ('partner_id.country_id.code', 'not in', (False, 'IT'))
+            )
         return domain
 
     def _get_fatture_ricevute(self):

--- a/l10n_it_invoices_data_communication/views/comunicazione.xml
+++ b/l10n_it_invoices_data_communication/views/comunicazione.xml
@@ -72,6 +72,7 @@
                         </group>
                         <group name="Summary">
                             <field name="dati_trasmissione" widget="radio"/>
+                            <field name="esterometro"/>
                         </group>
                         <notebook attrs="{'invisible':[('dati_trasmissione', '!=', 'DTE')]}">
                             <page string="Seller" name="page_cedente">


### PR DESCRIPTION
Aggiunta del flag "esterometro" alla dichiarazione dati IVA per filtrare le fatture estere

https://github.com/OCA/l10n-italy/issues/1685

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
