### PR TITLE
[12.0][FIX][l10n_it_corrispettivi] fix  partner in multi company partner

### DIFF
--- a/l10n_it_corrispettivi/models/account.py
+++ b/l10n_it_corrispettivi/models/account.py
@@ -13,6 +13,11 @@ class AccountInvoice(models.Model):
         if not self._context.get('default_corrispettivi', False):
             # If this is not a receipts (corrispettivi), do nothing
             return False
+        domain = [('use_corrispettivi', '=', True)]
+        partner = self.env['res.partner'].search(
+            domain, order="id desc", limit=1)
+        if partner:
+            return partner.id
         return self.env.ref('base.public_user').partner_id.id
 
     @api.model

--- a/l10n_it_corrispettivi/tests/test_corrispettivi.py
+++ b/l10n_it_corrispettivi/tests/test_corrispettivi.py
@@ -112,7 +112,7 @@ class TestCorrispettivi(AccountingTestCase):
         corr_invoice = self.create_corrispettivi_invoice()
         self.assertEqual(
             corr_invoice.partner_id.id,
-            self.env.ref('base.public_user').partner_id.id)
+            self.corrispettivi_partner.id)
         self.assertEqual(
             corr_invoice.journal_id,
             self.journal_model.get_corr_journal())


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
in ambienti multi company non viene preso il partner corretto  e si ottiene questo errore:
![image](https://user-images.githubusercontent.com/43987335/78119771-3622cf00-7409-11ea-8ea0-8f9b3574bc6d.png)

Comportamento attuale prima di questa PR:
Non viene preso il partner corretto in ambienti multi company

Comportamento desiderato dopo questa PR:
Dopo la pr viene  fatta una ricerca all'interno dei partner per vedere se c'è un partner per quella company che ha il flag sui corrispettivi  e viene preso per la creazione della ricevuta

https://github.com/OCA/l10n-italy/issues/1712

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
