### PR TITLE
[12.0] show e-invoice even when attachment is created

### DIFF
--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -36,7 +36,8 @@
                     </group>
                 </page>
                 <page string="Electronic Invoice"
-                    attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}">
+                    attrs="{'invisible': [('electronic_invoice_subjected', '=', False),
+                                          ('fatturapa_attachment_out_id', '=', False)]}">
                     <group>
                         <group string="Results">
                             <field name="fatturapa_attachment_out_id"/>
@@ -46,7 +47,8 @@
                     </group>
                 </page>
                 <page string="Electronic Invoice Attachments"
-                    attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}">
+                    attrs="{'invisible': [('electronic_invoice_subjected', '=', False),
+                                          ('fatturapa_attachment_out_id', '=', False)]}">
                     <group string="Attachments">
                         <field name="fatturapa_doc_attachments" nolabel="1" >
                             <tree string="Attachments">


### PR DESCRIPTION
Descrizione del problema o della funzionalità: non si vede il tab fattura elettronica anche se creata

Comportamento attuale prima di questa PR: non si vede

Comportamento desiderato dopo questa PR: si vede

https://github.com/OCA/l10n-italy/issues/1721


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing