### PR TITLE
[12.0][IMP] riba order

### DIFF
--- a/l10n_it_ricevute_bancarie/models/riba.py
+++ b/l10n_it_ricevute_bancarie/models/riba.py
@@ -40,6 +40,7 @@ class RibaList(models.Model):
 
     _name = 'riba.distinta'
     _description = 'C/O Slip'
+    _order = 'date_created desc'
 
     name = fields.Char(
         'Reference', required=True, readonly=True,


### PR DESCRIPTION
Descrizione del problema o della funzionalità: l'ordinamento delle distinte emesse mostra per prime quelle più vecchie

Comportamento attuale prima di questa PR: l'ordinamento delle distinte emesse è per default id ascendente

Comportamento desiderato dopo questa PR: l'ordinamento delle distinte emesse è per data di creazione discendente

Rif. #1734



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing