### PR TITLE
[12.0][FIX] fiscal_epos_print: Add mandatory format for credit note

### DIFF
--- a/fiscal_epos_print/static/src/js/epson_epos_print.js
+++ b/fiscal_epos_print/static/src/js/epson_epos_print.js
@@ -351,8 +351,6 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
             if (!has_refund) {
                 xml += '<beginFiscalReceipt/>';
             }
-            // footer can go only as promo code so within a fiscal receipt body
-            xml += this.printFiscalReceiptFooter(receipt);
             if (has_refund)
             {
                 xml += this.printFiscalRefundDetails({
@@ -401,6 +399,8 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
                     });
                 }
             });
+            // footer can go only as promo code so within a fiscal receipt body
+            xml += this.printFiscalReceiptFooter(receipt);
             if (has_refund) {
                 xml += self.printRecTotalRefund({});
             }


### PR DESCRIPTION
**Descrizione del problema o della funzionalità**
Nel POS:

1. Nella configurazione del POS, aggiungere un footer
2. Completare un acquisto
3. Fare il reso dell'acquisto e stampare lo scontrino

video: https://drive.google.com/file/d/1Ft5cfNiE04aN2dPeDX_nC2tYnfMiVtC7/view

**Comportamento attuale prima di questa PR**
Messaggio di errore restituito dalla stampante:
![image](https://user-images.githubusercontent.com/32064796/82450340-dd88bd80-9aac-11ea-9f4c-a4eb19d7a426.png)

**Comportamento desiderato dopo questa PR**
Nessun errore

Altro:
Purtroppo non ho trovato una giustificazione nella documentazione che ho per cui lo spostamento del `printRecMessage` risolva l'errore, semplicemente dov'è ora per la stampante non è corretto.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
