### PR TITLE
[12.0]l10n-italy/l10n_it_ricevute_bancarie: set field 'is_unsolved' t…

### DIFF
--- a/l10n_it_ricevute_bancarie/readme/CONTRIBUTORS.rst
+++ b/l10n_it_ricevute_bancarie/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 * Alex Comba <alex.comba@agilebg.com>
 * Marco Calcagni <mcalcagni@dinamicheaziendali.it>
 * Sergio Zanchetta <https://github.com/primes2h>
+* Simone Vanin <simone.vanin@agilebg.com>

--- a/l10n_it_ricevute_bancarie/views/account_view.xml
+++ b/l10n_it_ricevute_bancarie/views/account_view.xml
@@ -115,6 +115,10 @@
         <field name="model">account.invoice</field>
         <field name="inherit_id" ref="account.invoice_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment_term_id']" position="after">
+                <field name="is_unsolved" string="Past Due"
+                       attrs="{'invisible': [('is_unsolved', '=', False)]}"/>
+            </xpath>
             <field name="tax_line_ids" position="after">
                 <separator string="Past Due C/Os" colspan="4"/>
                 <field name="unsolved_move_line_ids" colspan="4" nolabel="1"/>
@@ -122,6 +126,16 @@
         </field>
     </record>
 
+    <record id="invoice_tree" model="ir.ui.view">
+        <field name="name">account.invoice.tree</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_tree"/>
+        <field name="arch" type="xml">
+            <field name="origin" position="after">
+                <field name="is_unsolved" string="Past Due"/>
+            </field>
+        </field>
+    </record>
 
     <record id="view_account_invoice_filter_unsolved" model="ir.ui.view">
         <field name="name">account.invoice.select.unsolved</field>


### PR DESCRIPTION
…o invoice view and tree

Add column is_unsolved to account.invoice_tree view
Add read-only field 'Unsolved' to account.invoice_form view

Descrizione del problema o della funzionalità:
Quando una Riba va in "insoluto" e' necessario comunicare meglio una tale l'informazione marcando visivamente la vista delle fatture.

Comportamento attuale prima di questa PR:
Per verificare se vi erano riba in insoluto, si doveva ricercare la lista di insoluti nel tab "Altre informazioni" di invoice_form.

Comportamento desiderato dopo questa PR:
L'informazione delle riba in insoluto appare nella lista delle fatture cliente e nell'intestazione di invoice_form



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
