### PR TITLE
[12.0][FIX]  l10n_it_corrispettivi: refund and modify invoice

### DIFF
--- a/l10n_it_corrispettivi/wizards/account_invoice_refund.py
+++ b/l10n_it_corrispettivi/wizards/account_invoice_refund.py
@@ -13,7 +13,10 @@ class AccountInvoiceRefund(models.TransientModel):
     def compute_refund(self, mode='refund'):
         res = super(AccountInvoiceRefund, self).compute_refund(mode=mode)
         if isinstance(res, dict):
-            invoice_ids_domain = res['domain'][-1]
+            if mode == 'modify':
+                invoice_ids_domain = ('id', 'in', [res['res_id']])
+            else:
+                invoice_ids_domain = res['domain'][-1]
             invoices = self.env['account.invoice'].search([invoice_ids_domain])
             if all(not inv.corrispettivo for inv in invoices):
                 return res


### PR DESCRIPTION
Descrizione del problema o della funzionalità: quando si crea una nota di credito di una fattura (o corrispettivo) con l'opzione 'Modifica: crea nota di credito, riconcilia e genera nuova fattura in bozza' viene generato un errore perchè il dominio non contiene il filtro con i numeri delle fatture

Comportamento attuale prima di questa PR: la creazione della n.c. non è possibile

Comportamento desiderato dopo questa PR: la creazione della n.c. è possibile




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing