### PR TITLE
[12.0] FIX account_vat_period_end_statement: do not consider annual statements while computing previous credits in periodic statements

### DIFF
--- a/account_vat_period_end_statement/models/account.py
+++ b/account_vat_period_end_statement/models/account.py
@@ -524,7 +524,8 @@ class AccountVatPeriodEndStatement(models.Model):
         for statement in self:
             statement.previous_debit_vat_amount = 0.0
             prev_statements = self.search(
-                [('date', '<', statement.date)], order='date desc')
+                [('date', '<', statement.date), ('annual', '=', False)],
+                order='date desc')
             if prev_statements and not statement.annual:
                 prev_statement = prev_statements[0]
                 if (

--- a/account_vat_period_end_statement/models/account.py
+++ b/account_vat_period_end_statement/models/account.py
@@ -540,9 +540,15 @@ class AccountVatPeriodEndStatement(models.Model):
                             - prev_statement.authority_vat_amount)})
                     company = statement.company_id or self.env.user.company_id
                     statement_fiscal_year_dates = (
-                        company.compute_fiscalyear_dates(statement.date))
+                        company.compute_fiscalyear_dates(
+                            statement.date_range_ids and
+                            statement.date_range_ids[0].date_start or
+                            statement.date))
                     prev_statement_fiscal_year_dates = (
-                        company.compute_fiscalyear_dates(prev_statement.date))
+                        company.compute_fiscalyear_dates(
+                            prev_statement.date_range_ids and
+                            prev_statement.date_range_ids[0].date_start or
+                            prev_statement.date))
                     if (
                         prev_statement_fiscal_year_dates['date_to'] <
                         statement_fiscal_year_dates['date_from']


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/1653 + https://github.com/OCA/l10n-italy/issues/1527

In particolare, passi per riprodurre:

 - creare una liquidazione periodica (mensile o trimestrale), dove risulta un credito IVA di X
 - dopo un mese creare liquidazione annuale, dove risulta un credito IVA di Y
 - dopo un mese creare una liquidazione periodica

Comportamento osservato:
viene impostato un "credito IVA precedente" di Y

Comportamento atteso:
viene impostato un "credito IVA precedente" di X


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
