### PR TITLE
[10.0][l10n_it_ricevute_bancarie] Add Riba line description

### DIFF
--- a/l10n_it_ricevute_bancarie/models/riba.py
+++ b/l10n_it_ricevute_bancarie/models/riba.py
@@ -282,6 +282,7 @@ class RibaListLine(models.Model):
                 list(set(payment_lines)))
 
     sequence = fields.Integer('Number')
+    description = fields.Char('Description', size=40)
     move_line_ids = fields.One2many(
         'riba.distinta.move.line', 'riba_line_id', string='Credit move lines')
     acceptance_move_id = fields.Many2one(

--- a/l10n_it_ricevute_bancarie/views/riba_view.xml
+++ b/l10n_it_ricevute_bancarie/views/riba_view.xml
@@ -55,6 +55,7 @@
                                 <group>
                                     <field name="state"/>
                                     <field name="type"/>
+                                    <field name="description"/>
                                     <field name="invoice_number"/>
                                     <field name="invoice_date"/>
                                     <field name="partner_id"/>
@@ -135,6 +136,7 @@
                             <field name="line_ids" nolabel="1" colspan="4">
                                 <tree string="Detail">
                                     <field name="sequence"/>
+                                    <field name="description"/>
                                     <field name="invoice_number"/>
                                     <field name="invoice_date"/>
                                     <field name="partner_id"/>

--- a/l10n_it_ricevute_bancarie/views/wizard_riba_file_export.xml
+++ b/l10n_it_ricevute_bancarie/views/wizard_riba_file_export.xml
@@ -10,7 +10,7 @@
                     <group col="4">
                         <group colspan="4">
                             <field name="riba_txt" readonly="1" filename="file_name"/>
-                            <field name="file_name" invisible="1"></field>
+                            <field name="file_name" invisible="1"/>
                         </group>
                         <footer colspan="4" >
                             <button name="act_getfile" string="Export" type="object"/>

--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
@@ -130,10 +130,14 @@ class RibaFileExport(models.TransientModel):
             descrizione_domiciliataria.ljust(50)[0:50] + "\r\n")
 
     def _Record50(
-        self, importo_debito, invoice_ref, data_invoice, partita_iva_creditore
+        self, importo_debito, invoice_ref, data_invoice, partita_iva_creditore,
+        description
     ):
-        self._descrizione = 'PER LA FATTURA N. ' + invoice_ref + \
-            ' DEL ' + data_invoice + ' IMP ' + str(importo_debito)
+        if description:
+            self._descrizione = description
+        else:
+            self._descrizione = 'PER LA FATTURA N. ' + invoice_ref + \
+                ' DEL ' + data_invoice + ' IMP ' + str(importo_debito)
         return (
             " 50" + str(self._progressivo).rjust(7, '0') +
             self._descrizione.ljust(80)[0:80] + " " * 10 +
@@ -178,7 +182,7 @@ class RibaFileExport(models.TransientModel):
                     value[5], value[6], value[7], value[8], value[11])
             accumulatore = accumulatore + \
                 self._Record50(
-                    value[2], value[13], value[14], intestazione[11])
+                    value[2], value[13], value[14], intestazione[11], value[15])
             accumulatore = accumulatore + self._Record51(value[0])
             accumulatore = accumulatore + self._Record70()
         accumulatore = accumulatore + self._RecordEF()
@@ -281,6 +285,7 @@ class RibaFileExport(models.TransientModel):
                 line.partner_id.ref and line.partner_id.ref[:16] or '',
                 line.invoice_number[:40],
                 line.invoice_date,
+                line.description,
             ]
             arrayRiba.append(Riba)
 


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/1775

Descrizione del problema o della funzionalità:

Le Ricevute Bancarie non danno la possibilità di indicare una descrizione personalizzata per l'emissione della stessa, ma utilizza un campo fisso calcolato solo al momento dell'esportazione del formato RIBA dell'ABI (Record 50). La PR aggiunge un campo di descrizione opzionale che permette di indicare la descrizione voluta per la particolare emissione della RIBA.

Comportamento attuale prima di questa PR:

Non è possibile indicare una descrizione personalizzata al momento di esportare il file TXT RIBA ABI

Comportamento desiderato dopo questa PR:

Esportazione sul file TXT delle RIBA del campo di descrizione personalizzato per la RIBA


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
