### PR TITLE
[12.0][l10n_it_ricevute_bancarie] Add Riba line description

### DIFF
--- a/l10n_it_ricevute_bancarie/models/riba.py
+++ b/l10n_it_ricevute_bancarie/models/riba.py
@@ -258,6 +258,7 @@ class RibaListLine(models.Model):
                 list(set(payment_lines)))
 
     sequence = fields.Integer('Number')
+    description = fields.Char('Description', size=40)
     move_line_ids = fields.One2many(
         'riba.distinta.move.line', 'riba_line_id', string='Credit Move Lines')
     acceptance_move_id = fields.Many2one(

--- a/l10n_it_ricevute_bancarie/views/riba_view.xml
+++ b/l10n_it_ricevute_bancarie/views/riba_view.xml
@@ -54,6 +54,7 @@
                             <group>
                                 <field name="state"/>
                                 <field name="type"/>
+                                <field name="description"/>
                                 <field name="invoice_number"/>
                                 <field name="invoice_date"/>
                                 <field name="partner_id"/>
@@ -134,6 +135,7 @@
                         <field name="line_ids" nolabel="1" colspan="4">
                             <tree string="Detail">
                                 <field name="sequence"/>
+                                <field name="description"/>
                                 <field name="invoice_number"/>
                                 <field name="invoice_date"/>
                                 <field name="partner_id"/>

--- a/l10n_it_ricevute_bancarie/views/wizard_riba_file_export.xml
+++ b/l10n_it_ricevute_bancarie/views/wizard_riba_file_export.xml
@@ -9,7 +9,7 @@
                 <group col="4">
                     <group colspan="4">
                         <field name="riba_txt" readonly="1" filename="file_name"/>
-                        <field name="file_name" invisible="1"></field>
+                        <field name="file_name" invisible="1"/>
                     </group>
                     <footer colspan="4" >
                         <button name="act_getfile" string="Export" type="object"/>

--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
@@ -130,10 +130,14 @@ class RibaFileExport(models.TransientModel):
             descrizione_domiciliataria.ljust(50)[0:50] + "\r\n")
 
     def _Record50(
-        self, importo_debito, invoice_ref, data_invoice, partita_iva_creditore
+        self, importo_debito, invoice_ref, data_invoice, partita_iva_creditore,
+        description
     ):
-        self._descrizione = 'PER LA FATTURA N. ' + invoice_ref + \
-            ' DEL ' + data_invoice + ' IMP ' + str(importo_debito)
+        if description:
+            self._descrizione = description
+        else:
+            self._descrizione = 'PER LA FATTURA N. ' + invoice_ref + \
+                ' DEL ' + data_invoice + ' IMP ' + str(importo_debito)
         return (
             " 50" + str(self._progressivo).rjust(7, '0') +
             self._descrizione.ljust(80)[0:80] + " " * 10 +
@@ -176,7 +180,7 @@ class RibaFileExport(models.TransientModel):
                     value[5], value[6], value[7], value[8], value[11])
             accumulatore = accumulatore + \
                 self._Record50(
-                    value[2], value[13], value[14], intestazione[11])
+                    value[2], value[13], value[14], intestazione[11], value[15])
             accumulatore = accumulatore + self._Record51(value[0])
             accumulatore = accumulatore + self._Record70()
         accumulatore = accumulatore + self._RecordEF()
@@ -278,6 +282,7 @@ class RibaFileExport(models.TransientModel):
                 line.partner_id.ref and line.partner_id.ref[:16] or '',
                 line.invoice_number[:40],
                 line.invoice_date,
+                line.description,
             ]
             arrayRiba.append(Riba)
 

--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_issue.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_issue.py
@@ -21,17 +21,27 @@ class RibaIssue(models.TransientModel):
     @api.multi
     def create_list(self):
         def create_rdl(countme, bank_id, rd_id, date_maturity, partner_id,
-                       acceptance_account_id):
+                       acceptance_account_id, description):
             rdl = {
                 'sequence': countme,
                 'bank_id': bank_id,
                 'distinta_id': rd_id,
+                'description': description,
                 'due_date': date_maturity,
                 'partner_id': partner_id,
                 'state': 'draft',
                 'acceptance_account_id': acceptance_account_id,
             }
             return riba_list_line.create(rdl)
+
+        def riba_description(move_line):
+            description = None
+            if move_line:
+                if move_line.invoice_date and move_line.display_name:
+                    description = 'FT ' + \
+                        move_line.ref + ' DEL ' + \
+                        move_line.invoice_date.strftime('%d/%m/%Y')
+            return description
 
         self.ensure_one()
         # Qui creiamo la distinta
@@ -81,7 +91,9 @@ class RibaIssue(models.TransientModel):
                         rdl_id = create_rdl(
                             countme, bank_id.id, rd_id,
                             move_line.date_maturity, move_line.partner_id.id,
-                            self.configuration_id.acceptance_account_id.id).id
+                            self.configuration_id.acceptance_account_id.id,
+                            riba_description(move_line)
+                        ).id
                         # total = 0.0
                         # invoice_date_group = ''
                         for grouped_line in grouped_lines[key]:
@@ -96,7 +108,8 @@ class RibaIssue(models.TransientModel):
                 rdl_id = create_rdl(
                     countme, bank_id.id, rd_id, move_line.date_maturity,
                     move_line.partner_id.id,
-                    self.configuration_id.acceptance_account_id.id).id
+                    self.configuration_id.acceptance_account_id.id,
+                    riba_description(move_line)).id
                 riba_list_move_line.create({
                     'riba_line_id': rdl_id,
                     'amount': move_line.amount_residual,


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/1775

Descrizione del problema o della funzionalità:

Le Ricevute Bancarie non danno la possibilità di indicare una descrizione personalizzata per l'emissione della stessa, ma utilizza un campo fisso calcolato solo al momento dell'esportazione del formato RIBA dell'ABI (Record 50). La PR aggiunge un campo di descrizione opzionale che permette di indicare la descrizione voluta per la particolare emissione della RIBA.

Comportamento attuale prima di questa PR:

Non è possibile indicare una descrizione personalizzata al momento di esportare il file TXT RIBA ABI

Comportamento desiderato dopo questa PR:

Esportazione sul file TXT delle RIBA del campo di descrizione personalizzato per la RIBA

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
