### PR TITLE
[12.0] FIX fiscal_epos_print when adding a line with 100% discount

### DIFF
--- a/fiscal_epos_print/static/src/js/epson_epos_print.js
+++ b/fiscal_epos_print/static/src/js/epson_epos_print.js
@@ -362,21 +362,17 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
             _.each(receipt.orderlines, function(l, i, list) {
                 if (l.price >= 0) {
                     if(l.quantity>=0) {
-                        var full_price = l.price;
-                        if (l.discount) {
-                            full_price = round_pr(l.price / (1 - (l.discount / 100)), self.sender.pos.currency.rounding);
-                        }
                         xml += self.printRecItem({
                             description: l.product_name,
                             quantity: l.quantity,
-                            unitPrice: full_price,
+                            unitPrice: l.full_price,
                             department: l.tax_department.code
                         });
                         if (l.discount) {
                             xml += self.printRecItemAdjustment({
                                 adjustmentType: 0,
                                 description: _t('Discount') + ' ' + l.discount + '%',
-                                amount: round_pr((l.quantity * full_price) - (l.quantity * l.price), self.sender.pos.currency.rounding),
+                                amount: round_pr((l.quantity * l.full_price) - (l.quantity * l.price), self.sender.pos.currency.rounding),
                             });
                         }
                     }

--- a/fiscal_epos_print/static/src/js/models.js
+++ b/fiscal_epos_print/static/src/js/models.js
@@ -100,6 +100,12 @@ odoo.define('fiscal_epos_print.models', function (require) {
         export_for_printing: function(){
             var res = _orderline_super.export_for_printing.call(this, arguments);
             res['tax_department'] = this.get_tax_details_r();
+            if (res['tax_department']['included_in_price'] == true) {
+                res['full_price'] = this.price
+            }
+            else {
+                res['full_price'] = this.price * (1 + (res['tax_department']['tax_amount'] / 100))
+            }
             return res;
         },
         get_tax_details_r: function(){
@@ -108,6 +114,8 @@ odoo.define('fiscal_epos_print.models', function (require) {
                 return {
                     code: this.pos.taxes_by_id[i].fpdeptax,
                     taxname: this.pos.taxes_by_id[i].name,
+                    included_in_price: this.pos.taxes_by_id[i].price_include,
+                    tax_amount: this.pos.taxes_by_id[i].amount,
                 }
             }
             this.pos.gui.show_popup('error', {


### PR DESCRIPTION
Creando un POS order con 2 righe di cui una con sconto 100%, la stampante fiscale dà errore




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
