### PR TITLE
[12.0] FIX l10n_it_fatturapa_in when importing an XML with BIC (present in Odoo DB) but without IstitutoFinanziario

### DIFF
--- a/l10n_it_fatturapa_in/tests/data/IT01234567890_FPR10.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT01234567890_FPR10.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:FatturaElettronica versione="FPR12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+  <FatturaElettronicaHeader>
+    <DatiTrasmissione>
+      <IdTrasmittente>
+        <IdPaese>IT</IdPaese>
+        <IdCodice>05979361218</IdCodice>
+      </IdTrasmittente>
+      <ProgressivoInvio>FPR10</ProgressivoInvio>
+      <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+      <CodiceDestinatario>0000000</CodiceDestinatario>
+      <ContattiTrasmittente/>
+    </DatiTrasmissione>
+    <CedentePrestatore>
+      <DatiAnagrafici>
+        <IdFiscaleIVA>
+          <IdPaese>IT</IdPaese>
+          <IdCodice>02780790107</IdCodice>
+        </IdFiscaleIVA>
+        <Anagrafica>
+          <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
+        </Anagrafica>
+        <RegimeFiscale>RF01</RegimeFiscale>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIALE ROMA 543</Indirizzo>
+        <CAP>07100</CAP>
+        <Comune>SASSARI</Comune>
+        <Provincia>SS</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CedentePrestatore>
+    <CessionarioCommittente>
+      <DatiAnagrafici>
+        <CodiceFiscale>03533590174</CodiceFiscale>
+        <Anagrafica>
+          <Denominazione>BETA GAMMA</Denominazione>
+        </Anagrafica>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIA TORINO 38-B</Indirizzo>
+        <CAP>00145</CAP>
+        <Comune>ROMA</Comune>
+        <Provincia>RM</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CessionarioCommittente>
+  </FatturaElettronicaHeader>
+  <FatturaElettronicaBody>
+    <DatiGenerali>
+      <DatiGeneraliDocumento>
+        <TipoDocumento>TD01</TipoDocumento>
+        <Divisa>EUR</Divisa>
+        <Data>2020-06-16</Data>
+        <Numero>126</Numero>
+        <Causale>LA FATTURA FA RIFERIMENTO AD UNA OPERAZIONE AAAA BBBBBBBBBBBBBBBBBB CCC DDDDDDDDDDDDDDD E FFFFFFFFFFFFFFFFFFFF GGGGGGGGGG HHHHHHH II LLLLLLLLLLLLLLLLL MMM NNNNN OO PPPPPPPPPPP QQQQ RRRR SSSSSSSSSSSSSS</Causale>
+        <Causale>SEGUE DESCRIZIONE CAUSALE NEL CASO IN CUI NON SIANO STATI SUFFICIENTI 200 CARATTERI AAAAAAAAAAA BBBBBBBBBBBBBBBBB</Causale>
+      </DatiGeneraliDocumento>
+    </DatiGenerali>
+    <DatiBeniServizi>
+      <DettaglioLinee>
+        <NumeroLinea>1</NumeroLinea>
+        <CodiceArticolo>
+          <CodiceTipo>INT</CodiceTipo>
+          <CodiceValore>ART123</CodiceValore>
+        </CodiceArticolo>
+        <Descrizione>LA DESCRIZIONE DELLA FORNITURA PUO' SUPERARE I CENTO CARATTERI CHE RAPPRESENTAVANO IL PRECEDENTE LIMITE DIMENSIONALE. TALE LIMITE NELLA NUOVA VERSIONE E' STATO PORTATO A MILLE CARATTERI</Descrizione>
+        <Quantita>5.00</Quantita>
+        <PrezzoUnitario>1.00</PrezzoUnitario>
+        <PrezzoTotale>5.00</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+      </DettaglioLinee>
+      <DettaglioLinee>
+        <NumeroLinea>2</NumeroLinea>
+        <Descrizione>FORNITURE VARIE PER UFFICIO</Descrizione>
+        <Quantita>10.00</Quantita>
+        <PrezzoUnitario>2.00</PrezzoUnitario>
+        <PrezzoTotale>20.00</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+      </DettaglioLinee>
+      <DatiRiepilogo>
+        <AliquotaIVA>22.00</AliquotaIVA>
+        <ImponibileImporto>25.00</ImponibileImporto>
+        <Imposta>5.50</Imposta>
+        <EsigibilitaIVA>I</EsigibilitaIVA>
+      </DatiRiepilogo>
+    </DatiBeniServizi>
+    <DatiPagamento>
+      <CondizioniPagamento>TP01</CondizioniPagamento>
+      <DettaglioPagamento>
+        <ModalitaPagamento>MP01</ModalitaPagamento>
+        <DataScadenzaPagamento>2020-06-30</DataScadenzaPagamento>
+        <ImportoPagamento>32.50</ImportoPagamento>
+        <IBAN>IT59R0100003228000000000621</IBAN>
+        <BIC>BCITITMM</BIC>
+      </DettaglioPagamento>
+    </DatiPagamento>
+  </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/fatturapa_common.py
+++ b/l10n_it_fatturapa_in/tests/fatturapa_common.py
@@ -52,6 +52,12 @@ class FatturapaCommon(SingleTransactionCase):
                 self.env.ref('l10n_it_causali_pagamento.a').id,
         })
 
+    def create_res_bank(self):
+        return self.env['res.bank'].create({
+            'name': 'Banca generica',
+            'bic': 'BCITITMM',
+        })
+
     def run_wizard(self, name, file_name, datas_fname=None,
                    mode='import', wiz_values=None, module_name=None):
         if module_name is None:

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -595,6 +595,19 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
             "75.41\n."
         )
 
+    def test_35_xml_import(self):
+        # creating a res.bank and importing an XML without "IstitutoFinanziario"
+        self.create_res_bank()
+        res = self.run_wizard('test35', 'IT01234567890_FPR10.xml')
+        invoice_id = res.get('domain')[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertEqual(
+            invoice.fatturapa_payments[0].payment_methods[0].payment_bank.bank_id.bic,
+            'BCITITMM')
+        self.assertEqual(
+            invoice.fatturapa_payments[0].payment_methods[0].payment_bank.bank_id.name,
+            'Banca generica')
+
     def test_01_xml_link(self):
         """
         E-invoice lines are created.

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -741,7 +741,6 @@ class WizardImportFatturapa(models.TransientModel):
                                 'acc_number': dline.IBAN.strip(),
                                 'partner_id': partner_id,
                                 'bank_id': bankid,
-                                'bank_name': dline.IstitutoFinanziario,
                                 'bank_bic': dline.BIC
                             }
                         ).id


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/1804

Rimuovo la scrittura di `bank_name` (`related='bank_id.name'`) in quanto, se la banca è già presente in Odoo,  l'utente non vorrà che il nome venga modificato


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
