### PR TITLE
[12.0] IMP fiscal_epos_print allowing to save in pos order debug info returned by fiscal printer

### DIFF
--- a/fiscal_epos_print/models/pos_order.py
+++ b/fiscal_epos_print/models/pos_order.py
@@ -16,6 +16,7 @@ class PosOrder(models.Model):
         "Fiscal receipt date", digits=(4, 0))
     fiscal_z_rep_number = fields.Integer("Fiscal closure number")
     fiscal_printer_serial = fields.Char(string='Fiscal Printer Serial')
+    fiscal_printer_debug_info = fields.Text("Debug info", readonly=True)
 
     @api.model
     def _order_fields(self, ui_order):
@@ -33,6 +34,8 @@ class PosOrder(models.Model):
         res['fiscal_z_rep_number'] = ui_order['fiscal_z_rep_number'] or False
         res['fiscal_printer_serial'] = \
             ui_order['fiscal_printer_serial'] or False
+        res['fiscal_printer_debug_info'] = \
+            ui_order['fiscal_printer_debug_info'] or False
         return res
 
     # This is on pos_order_mgmt to send back the fields of already existing
@@ -49,7 +52,18 @@ class PosOrder(models.Model):
         res['fiscal_receipt_date'] = self.fiscal_receipt_date
         res['fiscal_z_rep_number'] = self.fiscal_z_rep_number
         res['fiscal_printer_serial'] = self.fiscal_printer_serial
+        res['fiscal_printer_debug_info'] = self.fiscal_printer_debug_info
         return res
+
+    @api.model
+    def update_fiscal_receipt_debug_info(self, pos_order):
+        po = self.search([('pos_reference', '=', pos_order.get('name'))])
+        debug_info = pos_order.get('fiscal_printer_debug_info')
+        if po:
+            po.write({
+                'fiscal_printer_debug_info': debug_info,
+            })
+        return True
 
     @api.model
     def update_fiscal_receipt_values(self, pos_order):
@@ -76,4 +90,6 @@ class PosOrder(models.Model):
         for order in orders:
             if order['data'].get('fiscal_receipt_number'):
                 self.update_fiscal_receipt_values(order['data'])
+            if order['data'].get('fiscal_printer_debug_info'):
+                self.update_fiscal_receipt_debug_info(order['data'])
         return res

--- a/fiscal_epos_print/static/src/js/epson_epos_print.js
+++ b/fiscal_epos_print/static/src/js/epson_epos_print.js
@@ -122,12 +122,10 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
             options = options || {};
             this.url = options.url || 'http://192.168.1.1/cgi-bin/fpmate.cgi';
             this.fiscalPrinter = new epson.fiscalPrint();
-            this.fpresponse = false;
             this.sender = sender;
             this.order = options.order || null;
             this.fiscalPrinter.onreceive = function(res, tag_list_names, add_info) {
                 sender.chrome.loading_hide();
-                self.fpresponse = tag_list_names
                 var tagStatus = (tag_list_names ? tag_list_names.filter(getStatusField) : []);
                 var msgPrinter = "";
 
@@ -137,6 +135,9 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
                 }
 
                 if (!res.success) {
+                    var order = self.order;
+                    order.fiscal_printer_debug_info = JSON.stringify(res) + '\n' + JSON.stringify(tag_list_names) + '\n' + JSON.stringify(add_info);
+                    sender.pos.push_order(order);
                     if (tagStatus.length > 0) {
                         var info = add_info[tagStatus[0]];
                         var msgPrinter = decodeFpStatus(info);

--- a/fiscal_epos_print/static/src/js/models.js
+++ b/fiscal_epos_print/static/src/js/models.js
@@ -24,6 +24,7 @@ odoo.define('fiscal_epos_print.models', function (require) {
             this.fiscal_receipt_date = null;
             this.fiscal_z_rep_number = null;
             this.fiscal_printer_serial = this.pos.config.fiscal_printer_serial || null;
+            this.fiscal_printer_debug_info = null;
         },
 
         // Manages the case in which after printing an invoice
@@ -56,6 +57,7 @@ odoo.define('fiscal_epos_print.models', function (require) {
             this.fiscal_receipt_date = json.fiscal_receipt_date;
             this.fiscal_z_rep_number = json.fiscal_z_rep_number;
             this.fiscal_printer_serial = json.fiscal_printer_serial;
+            this.fiscal_printer_debug_info = json.fiscal_printer_debug_info;
         },
 
         export_as_JSON: function() {
@@ -69,6 +71,7 @@ odoo.define('fiscal_epos_print.models', function (require) {
             result.fiscal_receipt_date = this.fiscal_receipt_date; // parsed by backend
             result.fiscal_z_rep_number = this.fiscal_z_rep_number;
             result.fiscal_printer_serial = this.fiscal_printer_serial || null;
+            result.fiscal_printer_debug_info = this.fiscal_printer_debug_info;
             return result;
         },
 
@@ -84,6 +87,7 @@ odoo.define('fiscal_epos_print.models', function (require) {
             receipt.fiscal_receipt_date = this.fiscal_receipt_date;
             receipt.fiscal_z_rep_number = this.fiscal_z_rep_number;
             receipt.fiscal_printer_serial = this.fiscal_printer_serial;
+            receipt.fiscal_printer_debug_info = this.fiscal_printer_debug_info;
 
             return receipt
         },

--- a/fiscal_epos_print/views/point_of_sale.xml
+++ b/fiscal_epos_print/views/point_of_sale.xml
@@ -70,6 +70,7 @@
                                 <field name="fiscal_receipt_date"/>
                                 <field name="fiscal_z_rep_number"/>
                                 <field name="fiscal_printer_serial"/>
+                                <field name="fiscal_printer_debug_info" groups="base.group_no_one"/>
                             </group>
                             <group string="Refund Info">
                                 <field name="refund_date"/>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

In caso di errore della stampante, il messaggio può non essere chiaro e/o il codice di errore può non essere decodificato correttamente

Comportamento desiderato dopo questa PR:

Tutti i dati ritornati dalla stampante vengono salvati in un campo di debug apposito sul pos order



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
