### PR TITLE
Fix/riba remove abicab dep

### DIFF
--- a/l10n_it_ricevute_bancarie/__manifest__.py
+++ b/l10n_it_ricevute_bancarie/__manifest__.py
@@ -18,10 +18,8 @@
     'license': "AGPL-3",
     'depends': [
         'account',
-        'account_group_menu',
         'l10n_it_fiscalcode',
         'base_iban',
-        #'l10n_it_abicab',
         'account_due_list'],
     'data': [
         "data/riba_sequence.xml",

--- a/l10n_it_ricevute_bancarie/__manifest__.py
+++ b/l10n_it_ricevute_bancarie/__manifest__.py
@@ -21,7 +21,7 @@
         'account_group_menu',
         'l10n_it_fiscalcode',
         'base_iban',
-        'l10n_it_abicab',
+        #'l10n_it_abicab',
         'account_due_list'],
     'data': [
         "data/riba_sequence.xml",

--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
@@ -198,7 +198,7 @@ class RibaFileExport(models.TransientModel):
         credit_conto = credit_iban[-12:]
         if not credit_bank.codice_sia:
             raise UserError(
-                _('No SIA Code specified for ') + name_company)
+                _('No SIA Code specified for %s') % name_company)
         credit_sia = credit_bank.codice_sia
         dataemissione = datetime.datetime.now().strftime("%d%m%y")
         nome_supporto = datetime.datetime.now().strftime(
@@ -210,7 +210,7 @@ class RibaFileExport(models.TransientModel):
             order_obj.config_id.company_id.partner_id.fiscalcode
         ):
             raise UserError(
-                _('No VAT or Fiscal Code specified for ') + name_company)
+                _('No VAT or Fiscal Code specified for %s') % name_company)
         array_testata = [
             credit_sia,
             credit_abi,
@@ -244,7 +244,7 @@ class RibaFileExport(models.TransientModel):
                 debit_cab = debit_iban[10:15]
             else:
                 raise UserError(
-                    _('No IBAN or ABI/CAB specified for ') +
+                    _('No IBAN or ABI/CAB specified for %s') %
                     line.partner_id.name)
             debitor_city = debitor_address.city and debitor_address.city.ljust(
                 23)[0:23] or ''
@@ -258,7 +258,7 @@ class RibaFileExport(models.TransientModel):
 
             if not line.partner_id.vat and not line.partner_id.fiscalcode:
                 raise UserError(
-                    _('No VAT or Fiscal Code specified for ') +
+                    _('No VAT or Fiscal Code specified for %s') %
                     line.partner_id.name)
             Riba = [
                 line.sequence,

--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
@@ -234,7 +234,8 @@ class RibaFileExport(models.TransientModel):
             debitor_address = line.partner_id
             debitor_street = debitor_address.street or ''
             debitor_zip = debitor_address.zip or ''
-            if debit_bank.bank_abi and debit_bank.bank_cab:
+            #TODO: for compatibility only remove in the next release
+            if debit_bank.bank_abi and 'bank_cab' in debit_bank:
                 debit_abi = debit_bank.bank_abi
                 debit_cab = debit_bank.bank_cab
             elif debit_bank.acc_number:

--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
@@ -189,10 +189,11 @@ class RibaFileExport(models.TransientModel):
         order_obj = self.env['riba.distinta'].browse(active_ids)[0]
         credit_bank = order_obj.config_id.bank_id
         name_company = order_obj.config_id.company_id.partner_id.name
-        if not credit_bank.acc_number:
+        credit_iban = credit_bank.acc_number.replace(" ", "") \
+            if credit_bank.acc_number else None
+        if not credit_iban or not len(credit_iban) == 27:
             raise UserError(_('No IBAN specified.'))
         # remove spaces automatically added by odoo
-        credit_iban = credit_bank.acc_number.replace(" ", "")
         credit_abi = credit_iban[5:10]
         credit_cab = credit_iban[10:15]
         credit_conto = credit_iban[-12:]
@@ -234,12 +235,13 @@ class RibaFileExport(models.TransientModel):
             debitor_address = line.partner_id
             debitor_street = debitor_address.street or ''
             debitor_zip = debitor_address.zip or ''
+            debit_iban = debit_bank.acc_number.replace(" ", "") \
+                if debit_bank.acc_number else None
             #TODO: for compatibility only remove in the next release
-            if debit_bank.bank_abi and 'bank_cab' in debit_bank:
+            if hasattr(debit_bank, "bank_abi") and debit_bank.bank_cab:
                 debit_abi = debit_bank.bank_abi
                 debit_cab = debit_bank.bank_cab
-            elif debit_bank.acc_number:
-                debit_iban = debit_bank.acc_number.replace(" ", "")
+            elif debit_iban and len(debit_bank) == 27:
                 debit_abi = debit_iban[5:10]
                 debit_cab = debit_iban[10:15]
             else:


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Presenza di dipendenze non usate o non direttamente necessarie al modulo. In alcune parti del codice si faceva uso
della concatenazione di stringhe.

Comportamento attuale prima di questa PR:
Per effetto delle dipendenze venivano installati i moduli l10n_it_abicab e account_group_menu, il primo non strettamente
necessario il secondo inutile.
Comportamento desiderato dopo questa PR:
Nessuno dei moduli citati e' piu' richiesto e installato.




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
