### PR TITLE
[FIX] [12.0] l10n_it_dichiarazione_intento -  gestione assegnazione automatica posizione fiscale in fattura

### DIFF
--- a/l10n_it_dichiarazione_intento/__manifest__.py
+++ b/l10n_it_dichiarazione_intento/__manifest__.py
@@ -9,7 +9,7 @@
     'version': '12.0.0.1.3',
     'license': 'AGPL-3',
     'author': 'Francesco Apruzzese, Odoo Community Association (OCA), '
-              'Sergio Corato, Glauco Prina',
+              'Sergio Corato, Glauco Prina, Lara Baggio',
     'website': 'https://github.com/OCA/l10n-italy/tree/'
                '12.0/l10n_it_dichiarazione_intento',
     'depends': [

--- a/l10n_it_dichiarazione_intento/models/account_invoice.py
+++ b/l10n_it_dichiarazione_intento/models/account_invoice.py
@@ -48,13 +48,11 @@ class AccountInvoice(models.Model):
         self._set_fiscal_position()
         return res
 
-    @api.multi
     def select_manually_declarations(self):
         self.ensure_one()
         action = self.env.ref(
             'l10n_it_dichiarazione_intento.select_manually_declarations_action'
             ).read()[0]
-        action['context'] = self.env.context.copy()
         return action
 
     @api.multi

--- a/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
@@ -215,10 +215,21 @@ class DichiarazioneIntento(models.Model):
     def get_valid(self, type_d=None, partner_id=False, date=False):
         if not partner_id or not type_d or not date:
             return False
-        # ----- return valid documents for partner
-        domain = [('partner_id', '=', partner_id), ('type', '=', type_d),
-                  ('date_start', '<=', date), ('date_end', '>=', date)]
         ignore_state = self.env.context.get('ignore_state', False)
+        all_for_partner = self.get_all_for_partner(type_d, partner_id, ignore_state)
+        # # ----- return valid documents for partner
+        records = all_for_partner.filtered(
+            lambda d: d.date_start <= date <= d.date_end
+        )
+        return records
+
+    def get_all_for_partner(self, type_d=None, partner_id=False,
+                            ignore_state=False):
+        if not partner_id or not type_d:
+            return False
+        # ----- return all documents for partner
+        domain = [('partner_id', '=', partner_id),
+                  ('type', '=', type_d)]
         if not ignore_state:
             domain.append(('state', '!=', 'close'), )
         records = self.search(domain, order='state desc, date')

--- a/l10n_it_dichiarazione_intento/readme/CONTRIBUTORS.rst
+++ b/l10n_it_dichiarazione_intento/readme/CONTRIBUTORS.rst
@@ -1,4 +1,5 @@
 * Francesco Apruzzese <francescoapruzzese@openforce.it>
 * Sergio Corato <info@efatto.it>
-* Glauco Prina <gprina@linkgroup.it>
+* Glauco Prina <gprina@linkeurope.it>
 * Lorenzo Battistini <lb@takobi.online>
+* Lara Baggio <lbaggio@linkeurope.it>

--- a/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
@@ -68,6 +68,7 @@ class TestDichiarazioneIntento(TransactionCase):
             })
 
     def setUp(self):
+
         super(TestDichiarazioneIntento, self).setUp()
         self.tax_model = self.env['account.tax']
         self.account = self.env['account.account'].search([
@@ -81,6 +82,7 @@ class TestDichiarazioneIntento(TransactionCase):
         self.today_date = fields.Date.today()
         self.partner1 = self.env.ref('base.res_partner_2')
         self.partner2 = self.env.ref('base.res_partner_12')
+        self.partner3 = self.env.ref('base.res_partner_10')
         self.tax22 = self.tax_model.create({
             'name': '22%',
             'amount': 22,
@@ -116,6 +118,16 @@ class TestDichiarazioneIntento(TransactionCase):
                     'tax_dest_id': self.tax22.id,
                     })]
                 })
+        self.fiscal_position2 = self.env[
+            'account.fiscal.position'].sudo().create({
+                'name': 'Dichiarazione Test 2',
+                'valid_for_dichiarazione_intento': False,
+                'tax_ids': [(0, 0, {
+                    'tax_src_id': self.tax22.id,
+                    'tax_dest_id': self.tax10.id,
+                    })]
+                })
+
         self.dichiarazione1 = self._create_dichiarazione(self.partner1, 'out')
         self.dichiarazione2 = self._create_dichiarazione(self.partner2, 'out')
         self.dichiarazione3 = self._create_dichiarazione(self.partner2, 'out')
@@ -132,6 +144,8 @@ class TestDichiarazioneIntento(TransactionCase):
                                                    tax=self.tax1)
         self.refund1 = self._create_refund(self.partner1, tax=self.tax1,
                                            invoice=self.invoice2)
+        self.invoice4 = self._create_invoice(self.partner3, tax=self.tax22)
+        self.invoice4.fiscal_position_id = self.fiscal_position2.id
 
     def test_dichiarazione_data(self):
         self.assertTrue(self.dichiarazione1.number)
@@ -220,3 +234,7 @@ class TestDichiarazioneIntento(TransactionCase):
         self.assertEqual(self.dichiarazione1.limit_amount, 1000)
         with self.assertRaises(UserError):
             self.refund1.action_invoice_open()
+
+    def test_fiscal_position_no_dichiarazione(self):
+        self.invoice4._onchange_date_invoice()
+        self.assertEqual(self.invoice4.fiscal_position_id.id, self.fiscal_position2.id)

--- a/l10n_it_dichiarazione_intento/views/account_invoice_view.xml
+++ b/l10n_it_dichiarazione_intento/views/account_invoice_view.xml
@@ -12,13 +12,13 @@
                 <div>
                     <field name="dichiarazione_intento_ids" widget="many2many_tags"
                            readonly="1" class="oe_inline oe_link"/>
-                    <button type="object" name="select_manually_declarations" 
+                    <button type="object" name="select_manually_declarations"
                             states="draft" string="Select Manually"
                             class="oe_inline oe_link"/>
                 </div>
             </field>
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='invoice_line_tax_ids']" position="after">
-                <field name="force_dichiarazione_intento_id" 
+                <field name="force_dichiarazione_intento_id"
                        domain="[('partner_id', '=', parent.partner_id), ('state', '!=', 'close'), ('date_start', '&lt;=', parent.date_invoice), ('date_end', '&gt;=', parent.date_invoice)]"/>
             </xpath>
         </field>
@@ -30,7 +30,7 @@
         <field name="inherit_id" ref="account.view_invoice_line_form"/>
         <field name="arch" type="xml">
             <field name="invoice_line_tax_ids" position="after">
-                <field name="force_dichiarazione_intento_id" 
+                <field name="force_dichiarazione_intento_id"
                        domain="[('partner_id', '=', parent.partner_id), ('state', '!=', 'close'), ('date_start', '&lt;=', parent.date_invoice), ('date_end', '&gt;=', parent.date_invoice)]"/>
             </field>
         </field>
@@ -46,13 +46,13 @@
                 <div>
                     <field name="dichiarazione_intento_ids" widget="many2many_tags"
                            readonly="1" class="oe_inline oe_link"/>
-                    <button type="object" name="select_manually_declarations" 
+                    <button type="object" name="select_manually_declarations"
                             states="draft" string="Select Manually"
                             class="oe_inline oe_link"/>
                 </div>
             </field>
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='invoice_line_tax_ids']" position="after">
-                <field name="force_dichiarazione_intento_id" 
+                <field name="force_dichiarazione_intento_id"
                        domain="[('partner_id', '=', parent.partner_id), ('state', '!=', 'close'), ('date_start', '&lt;=', parent.date_invoice), ('date_end', '&gt;=', parent.date_invoice)]"/>
             </xpath>
         </field>

--- a/l10n_it_dichiarazione_intento/wizard/manually_declarations.py
+++ b/l10n_it_dichiarazione_intento/wizard/manually_declarations.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Francesco Apruzzese <francescoapruzzese@openforce.it>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from lxml import etree
 from odoo import models, fields, api
 
 
@@ -10,37 +9,22 @@ class SelectManuallyDeclarations(models.TransientModel):
     _name = 'select.manually.declarations'
     _description = 'Set declaration of intent manually on invoice'
 
-    def fields_view_get(self, view_id=None, view_type='form', context=None,
-                        toolbar=False, submenu=False):
-        res = super(SelectManuallyDeclarations, self).fields_view_get(
-            view_id=view_id, view_type=view_type,
-            toolbar=toolbar, submenu=False)
-        # Show only valid documents for the invoice
-        invoice_id = self.env.context.get('active_id', False)
+    def _default_declaration(self):
+        invoice_id = self._context.get('active_id', False)
         if not invoice_id:
-            return res
+            return []
         invoice = self.env['account.invoice'].browse(invoice_id)
-        declarations = self.env['dichiarazione.intento'].get_valid(
-            invoice.type.split('_')[0],
-            invoice.partner_id.commercial_partner_id.id,
-            invoice.date_invoice)
-        if declarations:
-            declarations_ids = [d.id for d in declarations]
-        else:
-            declarations_ids = []
-        form_arch = etree.XML(res['arch'])
-        nodes = form_arch.xpath("//field[@name='declaration_ids']")
-        for node in nodes:
-            node.set(
-                'domain',
-                '[("id", "in", {ids})]'.format(ids=declarations_ids)
-                )
-            res['arch'] = etree.tostring(form_arch)
-        return res
+        domain = [('partner_id', '=', invoice.partner_id.commercial_partner_id.id),
+                  ('type', '=', invoice.type.split('_')[0]),
+                  ('date_start', '<=', invoice.date_invoice),
+                  ('date_end', '>=', invoice.date_invoice)
+                  ]
+        return self.env['dichiarazione.intento'].search(domain)
 
     declaration_ids = fields.Many2many(
         'dichiarazione.intento',
         string='Declarations of Intent',
+        default=_default_declaration
     )
 
     @api.multi


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Comportamento attuale prima di questa PR:
installando questo modulo, alla selezione della data in una fattura, se non esistono dichiarazioni d'intento, viene tolta la posizione fiscale.
Questo comportamento era stato introdotto per togliere un eventuale posizione fiscale assegnata da una precedente dichiarazione fiscale, ma non tiene conto del fatto che un cliente possa avere una sua posizione fiscale e non è soggetto a dichiarazione d'intento

Comportamento desiderato dopo questa PR:

La posizione fiscale viene azzerata, solo nel caso in cui, tale posizione fiscale era tra quelle presenti nelle dichiarazioni d'intento del cliente. 
Nel caso in cui non esistano dichiarazioni d'intento non viene toccata la posizione fiscale del cliente.


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
