### PR TITLE
[10.0][FIX] l10n_it_fatturapa_in: Permettere caratteri non ascii in IndirizzoResa

### DIFF
--- a/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT02780790107_11004.xml
@@ -136,7 +136,7 @@ xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.
                 <UnitaMisuraPeso>KGM</UnitaMisuraPeso>
                 <TipoResa>DAP</TipoResa>
                 <IndirizzoResa>
-                    <Indirizzo>strada dei test</Indirizzo>
+                    <Indirizzo>strada dei test tostißimi</Indirizzo>
                     <NumeroCivico>150/B</NumeroCivico>
                     <CAP>12042</CAP>
                     <Comune>Bra</Comune>

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1228,7 +1228,7 @@ class WizardImportFatturapa(models.TransientModel):
 
             if Delivery.IndirizzoResa:
                 delivery_dict['delivery_address'] = (
-                    '{0}, {1}\n{2} - {3}\n{4} {5}'.format(
+                    u'{0}, {1}\n{2} - {3}\n{4} {5}'.format(
                         Delivery.IndirizzoResa.Indirizzo or '',
                         Delivery.IndirizzoResa.NumeroCivico or '',
                         Delivery.IndirizzoResa.CAP or '',


### PR DESCRIPTION
**Descrizione del problema o della funzionalità**

1. Aprire Accounting > Purchases > Electronic Bill > Incoming E-Bill Files
2. Creare una nuova fattura elettronica
3. Selezionare il file IT02780790107_11004.xml (il file modificato in questa PR) e salvare
4. Dal menu Action, selezionare Import Electronic Bill
5. Scegliere E-bills Detail Level = Maximum
6. **Import**

**Comportamento attuale prima di questa PR**
Errore:
```
File "/path/to/odoo/lib/python2.7/site-packages/odoo/addons/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 1044, in invoiceCreate
    Delivery.IndirizzoResa.Nazione or ''
UnicodeEncodeError: 'ascii' codec can't encode character u'\xdf' in position 24: ordinal not in range(128)
```

**Comportamento desiderato dopo questa PR**
Importazione della fattura

**Note**
Non ho aperto la issue d tracciamento perché in v12 il problema non è presente.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
