### PR TITLE
[12.0] IMP l10n_it_sdi_channel when sending normal emails without expliciting SMTP server: the e-invoice PEC server must not be used

### DIFF
--- a/l10n_it_sdi_channel/models/ir_mail_server.py
+++ b/l10n_it_sdi_channel/models/ir_mail_server.py
@@ -21,3 +21,17 @@ class IrMailServer(models.Model):
         # no need to revert to correct email: UserError is always raised and
         # rollback done
         return super(IrMailServer, self).test_smtp_connection()
+
+    @api.model
+    def _search(
+        self, args, offset=0, limit=None, order=None, count=False,
+        access_rights_uid=None
+    ):
+        if args == [] and order == 'sequence' and limit == 1:
+            # This happens in ir.mail_server.connect method when no SMTP server is
+            # explicitly set.
+            # In this case (sending normal emails without expliciting SMTP server)
+            # the e-invoice PEC server must not be used
+            args = [('is_fatturapa_pec', '=', False)]
+        return super(IrMailServer, self)._search(
+            args, offset, limit, order, count, access_rights_uid)


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/1839



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
