### PR TITLE
[12.0] FIX fiscal_epos_print receipt date placeholder

### DIFF
--- a/fiscal_epos_print/static/src/xml/pos.xml
+++ b/fiscal_epos_print/static/src/xml/pos.xml
@@ -58,7 +58,7 @@
                 <div class='client-detail'>
                     <div class='label'>Receipt Date</div>
                     <input id="refund_date" class="detail refund_date" type='text' t-att-value="widget.options.refund_date || ''"
-                           placeholder="DDMMYYYY"/>
+                           placeholder="YYYY-MM-DD"/>
                 </div>
                 <div class='client-detail'>
                     <div class='label'>RT Serial</div>


### PR DESCRIPTION
otherwise user could insert date in wrong format and get "psycopg2.DataError: date/time field value out of range"





--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
