### PR TITLE
FIX l10n_it_vat_statement_communication when setting declarant_fiscalcode_company

### DIFF
--- a/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
+++ b/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
@@ -288,7 +288,7 @@ class ComunicazioneLiquidazione(models.Model):
                 x1_2_1_Frontespizio,
                 etree.QName(NS_IV, "CodiceFiscaleSocieta"))
             x1_2_1_9_CodiceFiscaleSocieta.text =\
-                self.declarant_fiscalcode_company.code
+                self.declarant_fiscalcode_company
         # FirmaDichiarazione
         x1_2_1_10_FirmaDichiarazione = etree.SubElement(
             x1_2_1_Frontespizio, etree.QName(NS_IV, "FirmaDichiarazione"))


### PR DESCRIPTION

```
File "l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py", line 291, in _export_xml_get_frontespizio self.declarant_fiscalcode_company.code AttributeError: 'str' object has no attribute 'code'
```






--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
