### PR TITLE
[12.0][IMP] add invoices date to fatturapa in view

### DIFF
--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -29,6 +29,8 @@ class FatturaPAAttachmentIn(models.Model):
         help="If specified by supplier, total amount of the document net of "
              "any discount and including tax charged to the buyer/ordered"
     )
+    invoices_date = fields.Char(
+        string="Invoices date", compute="_compute_xml_data", store=True)
     registered = fields.Boolean(
         "Registered", compute="_compute_registered", store=True)
 
@@ -82,11 +84,17 @@ class FatturaPAAttachmentIn(models.Model):
             att.xml_supplier_id = partner_id
             att.invoices_number = len(fatt.FatturaElettronicaBody)
             att.invoices_total = 0
+            invoices_date = []
             for invoice_body in fatt.FatturaElettronicaBody:
                 att.invoices_total += float(
                     invoice_body.DatiGenerali.DatiGeneraliDocumento.
                     ImportoTotaleDocumento or 0
                 )
+                invoice_date = fields.Date.to_string(fields.Date.from_string(
+                    invoice_body.DatiGenerali.DatiGeneraliDocumento.Data))
+                if invoice_date not in invoices_date:
+                    invoices_date.append(invoice_date)
+            att.invoices_date = ' '.join(invoices_date)
 
     @api.multi
     @api.depends('in_invoice_ids')

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -40,6 +40,8 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.assertEqual(
             invoice.partner_id.register_fiscalpos.code, 'RF02')
         self.assertEqual(invoice.reference, 'FT/2015/0006')
+        self.assertEqual(invoice.fatturapa_attachment_in_id.invoices_date,
+                         '2015-02-16')
         self.assertEqual(invoice.amount_total, 57.00)
         self.assertEqual(invoice.gross_weight, 0.00)
         self.assertEqual(invoice.net_weight, 0.00)
@@ -78,6 +80,8 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.assertEqual(invoice.reference, '123')
         self.assertEqual(invoice.amount_untaxed, 34.00)
         self.assertEqual(invoice.amount_tax, 7.48)
+        self.assertEqual(invoice.fatturapa_attachment_in_id.invoices_date,
+                         '2014-12-18')
         self.assertEqual(
             len(invoice.invoice_line_ids[0].invoice_line_tax_ids), 1)
         self.assertEqual(
@@ -328,6 +332,8 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         invoice_ids = res.get('domain')[0][2]
         invoices = self.invoice_model.browse(invoice_ids)
         self.assertEqual(len(invoices), 2)
+        self.assertEqual(invoices[0].fatturapa_attachment_in_id.invoices_date,
+                         '2014-12-18 2014-12-20')
         for invoice in invoices:
             self.assertEqual(invoice.inconsistencies, '')
             self.assertEqual(invoice.partner_id.name, "SOCIETA' ALPHA SRL")

--- a/l10n_it_fatturapa_in/views/account_view.xml
+++ b/l10n_it_fatturapa_in/views/account_view.xml
@@ -29,6 +29,7 @@
                             <field name="e_invoice_received_date"/>
                             <field name="registered"/>
                             <field name="invoices_total"/>
+                            <field name="invoices_date"/>
                         </group>
                     </group>
                     <notebook>
@@ -73,6 +74,7 @@
                 <field name="create_date"/>
                 <field name="xml_supplier_id"/>
                 <field name="invoices_number"/>
+                <field name="invoices_date"/>
                 <field name="registered"/>
                 <field name="in_invoice_ids"/>
             </tree>


### PR DESCRIPTION
Descrizione del problema o della funzionalità: le fatture ricevute non sono riconoscibili facilmente senza la data della fattura

Comportamento attuale prima di questa PR: non si vede la data delle fatture prima di importarle

Comportamento desiderato dopo questa PR: si vede la data




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing