### PR TITLE
[12.0] IMP l10n_it_fiscal_payment_term preventing user to create new fatturapa.payment_method or fatturapa.payment_term

### DIFF
--- a/l10n_it_fiscal_payment_term/views/account_view.xml
+++ b/l10n_it_fiscal_payment_term/views/account_view.xml
@@ -8,8 +8,8 @@
             <field name="arch" type="xml">
                 <field name="line_ids" position="after">
                     <group col="2" colspan="2">
-                        <field name="fatturapa_pt_id"/>
-                        <field name="fatturapa_pm_id"/>
+                        <field name="fatturapa_pt_id" options="{'no_create': True, 'no_edit': True}"/>
+                        <field name="fatturapa_pm_id" options="{'no_create': True, 'no_edit': True}"/>
                     </group>
                 </field>
             </field>


### PR DESCRIPTION
Every code is already added by the module and user could ignore the right data to insert

Descrizione del problema o della funzionalità:

https://github.com/OCA/l10n-italy/issues/1851




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
