### PR TITLE
[12.0][FIX] Dichiarazione intento multipla

### DIFF
--- a/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
@@ -221,7 +221,7 @@ class DichiarazioneIntento(models.Model):
         ignore_state = self.env.context.get('ignore_state', False)
         if not ignore_state:
             domain.append(('state', '!=', 'close'), )
-        records = self.search(domain, order='state desc, date desc')
+        records = self.search(domain, order='state desc, date')
         return records
 
 

--- a/l10n_it_dichiarazione_intento/models/sale.py
+++ b/l10n_it_dichiarazione_intento/models/sale.py
@@ -18,7 +18,7 @@ class SaleOrder(models.Model):
                     sale.date_order)
                 if dichiarazioni:
                     sale.fiscal_position_id = \
-                        dichiarazioni.fiscal_position_id.id
+                        dichiarazioni[0].fiscal_position_id.id
 
     @api.onchange('date_order')
     def onchange_date_order(self):


### PR DESCRIPTION
Evitare erroe singleton su SO nel caso in cui ci siano più dichiarazioni
di intento attive.
Nel caso di più dichiarazioni attive, viene presa la più vecchia.

Descrizione del problema o della funzionalità:
Un cliente ha più di una dichiarazione d'intento attiva.
Viene scelto questo cliente nell'SO, si riceve un errore di SINGLETON
Comportamento attuale prima di questa PR:
Quando viene scelto il cliente, si riceve l'errore di SINGLETON
Comportamento desiderato dopo questa PR:
L'errore non appare più




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
