### PR TITLE
[12.0][FIX] create field to exclude recomputation of old invoices

### DIFF
--- a/l10n_it_fatturapa_in/migrations/12.0.1.18.3/pre-migration.py
+++ b/l10n_it_fatturapa_in/migrations/12.0.1.18.3/pre-migration.py
@@ -1,0 +1,14 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+    openupgrade.logged_query(
+        env.cr,
+        """
+    ALTER TABLE fatturapa_attachment_in
+        ADD COLUMN IF NOT EXISTS invoices_date character varying
+    """,
+    )


### PR DESCRIPTION
Descrizione del problema o della funzionalità: il campo `invoices_date` viene calcolato su tutte le vecchie fatture, per cui potrebbe non essere possibile se ci sono fatture non corrette

Comportamento attuale prima di questa PR: viene eseguito il calcolo su tutte le fatture e potrebbe bloccarsi la creazione del campo se non va a buon fine

Comportamento desiderato dopo questa PR: il calcolo del campo non viene eseguito sulle fatture presenti, ma solo su quelle ricevute dopo l'installazione




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing