### PR TITLE
[12.0] add requirements for pip libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyxb==1.2.6
+codicefiscale
+asn1crypto


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

aggiunto file requirements.txt con la lista delle librerie python da installare

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
