### PR TITLE
[12.0] FIX l10n_it_fatturapa_out: when bank account is not an IBAN, don't write in XML; otherwise XML is not valid

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -772,7 +772,7 @@ class WizardExportFatturapa(models.TransientModel):
                 if partner_bank.bank_name:
                     DettaglioPagamento.IstitutoFinanziario = \
                         partner_bank.bank_name
-                if partner_bank.acc_number:
+                if partner_bank.acc_number and partner_bank.acc_type == 'iban':
                     DettaglioPagamento.IBAN = \
                         ''.join(partner_bank.acc_number.split())
                 if partner_bank.bank_bic:


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/1887



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
