### PR TITLE
fixed fpdeptax field in fiscal_epos_print module to accept 2 digits

### DIFF
--- a/fiscal_epos_print/__manifest__.py
+++ b/fiscal_epos_print/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'ITA - Driver per stampanti fiscali compatibili ePOS-Print XML',
-    'version': '12.0.1.1.7',
+    'version': '12.0.1.1.8',
     'category': 'Point Of Sale',
     'summary': 'ePOS-Print XML Fiscal Printer Driver - Stampanti Epson compatibili: '
                'FP81II, FP90III',

--- a/fiscal_epos_print/models/account.py
+++ b/fiscal_epos_print/models/account.py
@@ -1,4 +1,8 @@
-from odoo import fields, models
+from odoo import fields, models, api
+from odoo.exceptions import ValidationError
+import re
+
+regex = r"^[1-9][0-9]?$"  # regular expression to match numbers between [1 - 99]
 
 
 class AccountTax(models.Model):
@@ -6,5 +10,10 @@ class AccountTax(models.Model):
 
     fpdeptax = fields.Char(
         'Department on fiscal printer 1~99',
-        size=1, default="1"
+        size=2, default="1"
     )
+
+    @api.constrains('fpdeptax')
+    def _validate_fpdeptax(self):
+        if not re.search(regex, self.fpdeptax):
+            raise ValidationError("Department ID number range [1 - 99]")


### PR DESCRIPTION
**Descrizione del problema o della funzionalità**:
vedi issue: https://github.com/OCA/l10n-italy/issues/1884

**Comportamento attuale prima di questa PR:**
come descritto nella issue il campo 'fpdeptax' accetta un singolo carattere

**Comportamento desiderato dopo questa PR:**
il campo 'fpdeptax' accetta massimo 2 digits di carattere numerico



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
