### PR TITLE
[12.0][FIX] put higher sequence to expense riba line

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account/account.py
+++ b/l10n_it_ricevute_bancarie/models/account/account.py
@@ -200,6 +200,7 @@ class AccountInvoice(models.Model):
                             year=pay_date[0][:4],
                         ),
                         'account_id': account.id,
+                        'sequence': 9999,
                     }
                     # ---- Update Line Value with tax if is set on product
                     if invoice.company_id.due_cost_service_id.taxes_id:


### PR DESCRIPTION
Descrizione del problema o della funzionalità: inserimento automatico delle righe spese riba

Comportamento attuale prima di questa PR: la/e riga/he spese delle riba viene inserita in mezzo alle altre righe

Comportamento desiderato dopo questa PR: la/e riga/he spese delle riba viene inserita dopo le altre righe




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing