### PR TITLE
[12.0] fetchmail: P3 compatibility

### DIFF
--- a/l10n_it_fatturapa_pec/models/fetchmail.py
+++ b/l10n_it_fatturapa_pec/models/fetchmail.py
@@ -90,7 +90,7 @@ class Fetchmail(models.Model):
                             ):
                                 (header, messages, octets) = pop_server.retr(
                                     num)
-                                message = '\n'.join(messages)
+                                message = (b'\n').join(messages)
                                 try:
                                     MailThread.with_context(
                                         **additional_context


### PR DESCRIPTION

Ho risolto il problema in quanto anche il modulo standard aveva lo stesso errore.
Ecco il link del bug sullo standard

**Descrizione del problema o della funzionalità**
Con Odoo 12 effettuando il controllo delle mail pec in entrata compare questo errore:
General failure when trying to fetch mail from pop server pec.
`Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/odoo/addons/l10n_it_fatturapa_pec/models/fetchmail.py", line 105, in fetch_mail
    message = '\n'.join(messages)
TypeError: sequence item 0: expected str instance, bytes found`


Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:
Modificato il codice come lo standard. Ecco l bug standard
https://github.com/odoo/odoo/issues/20857




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
