### PR TITLE
[12.0] FIX fiscal_epos_print when setting debug info when order is not set

### DIFF
--- a/fiscal_epos_print/static/src/js/epson_epos_print.js
+++ b/fiscal_epos_print/static/src/js/epson_epos_print.js
@@ -135,9 +135,11 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
                 }
 
                 if (!res.success) {
-                    var order = self.order;
-                    order.fiscal_printer_debug_info = JSON.stringify(res) + '\n' + JSON.stringify(tag_list_names) + '\n' + JSON.stringify(add_info);
-                    sender.pos.push_order(order);
+                    if (self.order != null) {
+                        var order = self.order;
+                        order.fiscal_printer_debug_info = JSON.stringify(res) + '\n' + JSON.stringify(tag_list_names) + '\n' + JSON.stringify(add_info);
+                        sender.pos.push_order(order);
+                    }
                     if (tagStatus.length > 0) {
                         var info = add_info[tagStatus[0]];
                         var msgPrinter = decodeFpStatus(info);


### PR DESCRIPTION
E.g. when getting error after sending commands like "aprire cassetto"






--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
