### PR TITLE
[12.0][FIX][l10n_it_fatturapa_in] change name field from wt_found to wt_founds

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1269,13 +1269,13 @@ class WizardImportFatturapa(models.TransientModel):
                     else:
                         raise UserError(msg)
 
-                wt_found = False
+                wt_founds = False
                 for wt in wts:
                     if wt.tax == float(welfareLine.AlCassa):
-                        wt_found = wt
+                        wt_founds = wt
                         break
 
-                if not wt_found:
+                if not wt_founds:
                     msg = _(
                         "The bill contains Welfare Fund tax with "
                         "Type %s and Tax %s "
@@ -1288,7 +1288,7 @@ class WizardImportFatturapa(models.TransientModel):
                         raise UserError(msg)
 
                 for line in invoice.invoice_line_ids:
-                    line.invoice_line_tax_wt_ids = [(4, wt_found.id)]
+                    line.invoice_line_tax_wt_ids = [(4, wt_founds[0].id)]
                 invoice._onchange_invoice_line_wt_ids()
                 invoice.write(invoice._convert_to_write(invoice._cache))
                 continue
@@ -1302,13 +1302,13 @@ class WizardImportFatturapa(models.TransientModel):
                 'account_id': credit_account_id,
             })
             if welfareLine.Ritenuta:
-                if not wt_found:
+                if not wt_founds:
                     raise UserError(_(
                         "Welfare Fund data %s has withholding tax but no "
                         "withholding tax was found in the system."
                     ) % welfareLine.TipoCassa)
                 line_vals['invoice_line_tax_wt_ids'] = [
-                    (6, 0, [wt_found.id])]
+                    (6, 0, [wt_founds[0].id])]
             if self.env.user.company_id.cassa_previdenziale_product_id:
                 cassa_previdenziale_product = self.env.user.company_id \
                     .cassa_previdenziale_product_id


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Comportamento attuale prima di questa PR:
Prima della pr ottengo questo errore importando una fattura con ritenuta di account
    partner_id
  File "/opt/odoo/openforce/l10n-italy/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 949, in invoiceCreate
    FatturaBody, credit_account_id, invoice, wt_founds)
  File "/opt/odoo/openforce/l10n-italy/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 1311, in set_welfares_fund
    if welfareLine.Ritenuta:
AttributeError: 'list' object has no attribute 'id'

Comportamento desiderato dopo questa PR:
non avere l'errore e importare la fatturea e trovare il campo che attualmente viene richiamato erroneamente.


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
