### PR TITLE
[12.0] FIX fiscal_epos_print when adding discount to an order with a non standard VAT

### DIFF
--- a/fiscal_epos_print/static/src/js/epson_epos_print.js
+++ b/fiscal_epos_print/static/src/js/epson_epos_print.js
@@ -391,9 +391,7 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
                 }
                 else {
                     xml += self.printRecItemAdjustment({
-                        adjustmentType: 3,
                         description: l.product_name,
-                        department: l.tax_department.code,
                         amount: -l.price,
                     });
                 }


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

 - Configurare prodotto con IVA 22%
 - Configurare prodotto con IVA 10%
 - Configurare sconto con IVA 22%
 - Abilitare "Sconti globali" impostando il prodotto sconto

Comportamento attuale prima di questa PR:

![pos](https://user-images.githubusercontent.com/1033131/96457719-65bbec00-1220-11eb-9019-f413580e6f0a.gif)


Comportamento desiderato dopo questa PR:

Assumiamo che lo sconto sia sempre di tipo "Discount on last sale" (valore predefinito per il parametro `adjustmentType` di `printRecItemAdjustment`)


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
