### PR TITLE
12.0 nr company extra

### DIFF
--- a/l10n_it_fatturapa/models/company.py
+++ b/l10n_it_fatturapa/models/company.py
@@ -33,6 +33,10 @@ class ResCompany(models.Model):
         string='Preview Format Style', required=True,
         default='fatturaordinaria_v1.2.1.xsl')
 
+    phone_electronic_invoice = fields.Char(
+        string="Phone for Electronic Invoice"
+    )
+
 
 class AccountConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'

--- a/l10n_it_fatturapa/views/company_view.xml
+++ b/l10n_it_fatturapa/views/company_view.xml
@@ -92,6 +92,10 @@
                     </group>
                 </page>
             </notebook>
+
+            <xpath expr="//page/group/group/field[@name='phone']" position="after">
+                <field name="phone_electronic_invoice"/>
+            </xpath>
         </field>
     </record>
 

--- a/l10n_it_fatturapa_out/__manifest__.py
+++ b/l10n_it_fatturapa_out/__manifest__.py
@@ -2,6 +2,7 @@
 # Copyright 2015-2016 Lorenzo Battistini - Agile Business Group
 # Copyright 2018 Sergio Zanchetta (Associazione PNLUG - Gruppo Odoo)
 # Copyright 2018 Sergio Corato
+# Copyright 2020 Matteo Mircoli Openforce srls
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/l10n_it_fatturapa_out/models/__init__.py
+++ b/l10n_it_fatturapa_out/models/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2014 Davide Corio
 # Copyright 2015-2016 Lorenzo Battistini - Agile Business Group
+# Copyright 2020 Matteo Mircoli Openforce srls
 
 from . import attachment
 from . import account

--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -200,11 +200,13 @@ class WizardExportFatturapa(models.TransientModel):
         return True
 
     def _setContattiTrasmittente(self, company, fatturapa):
-        Telefono = company.phone
+        Telefono = company.phone_electronic_invoice or company.phone
         Email = company.email
         fatturapa.FatturaElettronicaHeader.DatiTrasmissione.\
             ContattiTrasmittente = ContattiTrasmittenteType(
-                Telefono=Telefono or None, Email=Email or None)
+                Telefono=Telefono or None,
+                Email=Email or None
+            )
 
         return True
 


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Attualmente se si ha il +39 sulla company si ha l'errore in fase di esportazione, tuttavia mantenere il prefisso internazionale per varie ragioni è importante, con questa pr si aggiunge un nuovo campo per memorizzare il numero senza il prefisso e così da lasciare inalterato il campo standard

Comportamento attuale prima di questa PR:
ci sono problemi con il +39

Comportamento desiderato dopo questa PR:
dopo la pr il numero di telefono se settato viene preso dal nuovo campo



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
