### PR TITLE
[12.0][FIX][l10n_it_fatturapa] URL in Readme doesn't work

### DIFF
--- a/l10n_it_fatturapa/readme/DESCRIPTION.rst
+++ b/l10n_it_fatturapa/readme/DESCRIPTION.rst
@@ -2,7 +2,7 @@
 
 Modulo base per gestire le fatture elettroniche.
 
-http://fatturapa.gov.it
+https://www.fatturapa.gov.it
 
 Consultare anche i file README di l10n_it_fatturapa_out e l10n_it_fatturapa_in.
 
@@ -10,6 +10,6 @@ Consultare anche i file README di l10n_it_fatturapa_out e l10n_it_fatturapa_in.
 
 Base module to handle Electronic Invoices.
 
-http://fatturapa.gov.it
+https://www.fatturapa.gov.it
 
 See also l10n_it_fatturapa_out and l10n_it_fatturapa_in README files.


### PR DESCRIPTION
The readme links to https://fatturapa.gov.it/ wich doesn't work and you get message:

> Siamo spiacenti, la pagina cercata non esiste!

The correct one is https://www.fatturapa.gov.it

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
