### PR TITLE
[12.0][FIX]  l10n_it_fatturapa_sale access groups

### DIFF
--- a/l10n_it_fatturapa_sale/models/sale_order.py
+++ b/l10n_it_fatturapa_sale/models/sale_order.py
@@ -12,6 +12,7 @@ class SaleOrder (models.Model):
         inverse_name='sale_order_id',
         string='Related Documents',
         copy=False,
+        groups="account.group_account_user",
     )
 
     @api.multi

--- a/l10n_it_fatturapa_sale/models/sale_order_line.py
+++ b/l10n_it_fatturapa_sale/models/sale_order_line.py
@@ -12,11 +12,13 @@ class SaleOrderLine (models.Model):
         inverse_name='sale_order_line_id',
         string='Related Documents',
         copy=False,
+        groups="account.group_account_user",
     )
     admin_ref = fields.Char(
         string="Admin. ref.",
         size=20,
         copy=False,
+        groups="account.group_account_user",
     )
 
     @api.multi

--- a/l10n_it_fatturapa_sale/views/sale_order_views.xml
+++ b/l10n_it_fatturapa_sale/views/sale_order_views.xml
@@ -11,7 +11,7 @@
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='order_line']/form/field[@name='name']" position="after">
-                <group name="e_invoice" string="Electronic Invoice">
+                <group name="e_invoice" string="Electronic Invoice" groups="account.group_account_user">
                     <field name="admin_ref"/>
                     <field name="related_documents"/>
                 </group>
@@ -20,7 +20,7 @@
                 <field name="admin_ref"/>
             </xpath>
             <notebook position="inside">
-                <page name="e_invoice" string="Electronic Invoice">
+                <page name="e_invoice" string="Electronic Invoice" groups="account.group_account_user">
                     <group name="related_documents">
                         <field name="related_documents"/>
                     </group>


### PR DESCRIPTION
Descrizione del problema o della funzionalità: in caso di utente con solo permessi al menu Vendite, c'è un divieto di accesso per la presenza di campi legati alla contabilità

Comportamento attuale prima di questa PR: il sistema blocca l'accesso agli ordini di vendita

Comportamento desiderato dopo questa PR: il sistema permette l'accesso agli ordini di vendita nascondendo i campi contabili




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing