### PR TITLE
[12.0] Don't group invoices by partner

### DIFF
--- a/l10n_it_fatturapa_out/__manifest__.py
+++ b/l10n_it_fatturapa_out/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'ITA - Fattura elettronica - Emissione',
-    'version': '12.0.2.0.0',
+    'version': '12.0.3.0.0',
     'development_status': 'Beta',
     'category': 'Localization/Italy',
     'summary': 'Emissione fatture elettroniche',
@@ -19,14 +19,15 @@
         'l10n_it_account',
         'l10n_it_fatturapa',
         'l10n_it_split_payment',
-        ],
+    ],
     'data': [
         'wizard/wizard_export_fatturapa_view.xml',
         'views/attachment_view.xml',
         'views/account_view.xml',
+        'views/company_view.xml',
         'security/ir.model.access.csv',
         'data/l10n_it_fatturapa_out_data.xml',
-        'security/rules.xml',
+        'security/rules.xml'
     ],
     'installable': True,
     'external_dependencies': {

--- a/l10n_it_fatturapa_out/models/__init__.py
+++ b/l10n_it_fatturapa_out/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import attachment
 from . import account
+from . import company

--- a/l10n_it_fatturapa_out/models/company.py
+++ b/l10n_it_fatturapa_out/models/company.py
@@ -1,0 +1,20 @@
+# © 2020 Andrei Levin <andrei.levin@didotech.com>
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    invoices_group_by_partner = fields.Boolean('Multi Invoice XML', help="Permit to pack more invoices in one XML")
+
+
+class AccountConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    invoices_group_by_partner = fields.Boolean(
+        related='company_id.invoices_group_by_partner',
+        string='Multi Invoice XML',
+        help="Permit to pack more invoices in single XML",
+        readonly=False
+    )

--- a/l10n_it_fatturapa_out/views/company_view.xml
+++ b/l10n_it_fatturapa_out/views/company_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_account_config_out_settings" model="ir.ui.view">
+        <field name="name">view_account_config_out_settings</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="l10n_it_fatturapa.view_account_config_settings"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='fatturapa_settings']/div[1]/div[2]/div/div[last()]" position="after">
+                <div class="row">
+                    <label for="invoices_group_by_partner" class="col-lg-3 o_light_label"/>
+                    <field name="invoices_group_by_partner"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Problem:
If invoices are grouped by partner it creates problem for a client who want to bind single XML to different invoices

Before PR:
Invoices are always grouped by partner. 

After PR:
There is an option in settings that permit to choose to group o not to group invoices in a single XML

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
