### PR TITLE
[FIX] l10n_it_ipa: fix REAME file

### DIFF
--- a/l10n_it_ipa/readme/DESCRIPTION.rst
+++ b/l10n_it_ipa/readme/DESCRIPTION.rst
@@ -1,9 +1,11 @@
 **Italiano**
+
 Questo modulo aggiunge il codice IPA sul partner.
 
 http://www.indicepa.gov.it/
 
 **English**
+
 This module adds the IPA code field to the partner.
 
 http://www.indicepa.gov.it/


### PR DESCRIPTION
Dopo il merge di https://github.com/OCA/l10n-italy/pull/1929 il README file si presenta come segue:

![image](https://user-images.githubusercontent.com/3512779/99804030-a9b15200-2b3a-11eb-9c5b-7125558e24e9.png)



