### PR TITLE
[10.0][l10n_it_fatturapa_in] Force to set fiscal_document_type_id bef…

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -973,6 +973,9 @@ class WizardImportFatturapa(models.TransientModel):
 
         # compute the invoice
         invoice.compute_taxes()
+        # We need set fiscal_document_type_id again because it's a calculated
+        # field linked with a @api.depends()
+        invoice.write({'fiscal_document_type_id': docType_id})
         return invoice_id
 
     def set_vendor_bill_data(self, FatturaBody, invoice):


### PR DESCRIPTION
…ore to return the invoice due to calculated field

Descrizione del problema o della funzionalità:

L'import delle fatture elettroniche non setta correttamente il ``fiscal_document_type_id`` in base alla fattura di acquisto perchè il campo è calcolato e per default lo setta a ``TD01``

Comportamento attuale prima di questa PR:

Il campo ``fiscal_document_type_id`` è sempre settato a ``TD01``

Comportamento desiderato dopo questa PR:

Il campo ``fiscal_document_type_id`` è sempre settato correttamente con il tipo documento della fattura elettronica



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
