### PR TITLE
[12.0] [FIX] fiscal_epos_print wrong computation of manual discount

### DIFF
--- a/fiscal_epos_print/static/src/js/epson_epos_print.js
+++ b/fiscal_epos_print/static/src/js/epson_epos_print.js
@@ -375,7 +375,7 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
                             xml += self.printRecItemAdjustment({
                                 adjustmentType: 0,
                                 description: _t('Discount') + ' ' + l.discount + '%',
-                                amount: round_pr((l.quantity * l.full_price) - (l.quantity * l.price), self.sender.pos.currency.rounding),
+                                amount: round_pr((l.quantity * l.full_price) - l.price_display, self.sender.pos.currency.rounding),
                             });
                         }
                     }


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
In alcuni casi il calcolo dello sconto manuale non coincide con quello calcolato dalla epson e lo scontrino non viene emesso.

Comportamento attuale prima di questa PR:

Creare un prodotto con prezzo 4,5 euro ed iva inclusa nel prezzo 10%. Inserire da pos 2 quantità di prodotto con sconto del 5% applicato manualmente da interfaccia. Il file epson xml riporta amount = 0.44 al posto di 0.45

Comportamento desiderato dopo questa PR:

il file xml riporta il corretto amount di 0.45



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
