### PR TITLE
[12.0] [FIX] spazi finali in PECDestinatario

### DIFF
--- a/l10n_it_fatturapa/bindings/fatturapa.py
+++ b/l10n_it_fatturapa/bindings/fatturapa.py
@@ -116,6 +116,10 @@ def CreateFromDocument(xml_string):
                     problems.append(msg)
                     _logger.warn(msg)
 
+    # fix trailing spaces in <PECDestinatario/>
+    for pec in root.xpath("//PECDestinatario"):
+        pec.text = pec.text.rstrip()
+
     fatturapa = _CreateFromDocument(etree.tostring(root))
     setattr(fatturapa, '_xmldoctor', problems)
     return fatturapa

--- a/l10n_it_fatturapa_in/README.rst
+++ b/l10n_it_fatturapa_in/README.rst
@@ -173,6 +173,7 @@ Contributors
 * Alessio Gerace
 * Sergio Zanchetta <https://github.com/primes2h>
 * Giovanni Serra <giovanni@gslab.it>
+* Gianmarco Conte <gconte@dinamicheaziendali.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_it_fatturapa_in/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fatturapa_in/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Alessio Gerace
 * Sergio Zanchetta <https://github.com/primes2h>
 * Giovanni Serra <giovanni@gslab.it>
+* Gianmarco Conte <gconte@dinamicheaziendali.it>

--- a/l10n_it_fatturapa_in/static/description/index.html
+++ b/l10n_it_fatturapa_in/static/description/index.html
@@ -496,6 +496,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Alessio Gerace</li>
 <li>Sergio Zanchetta &lt;<a class="reference external" href="https://github.com/primes2h">https://github.com/primes2h</a>&gt;</li>
 <li>Giovanni Serra &lt;<a class="reference external" href="mailto:giovanni&#64;gslab.it">giovanni&#64;gslab.it</a>&gt;</li>
+<li>Gianmarco Conte &lt;<a class="reference external" href="mailto:gconte&#64;dinamicheaziendali.it">gconte&#64;dinamicheaziendali.it</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_it_fatturapa_in/tests/data/ITBNCMRA80A01D548T_20005.xml
+++ b/l10n_it_fatturapa_in/tests/data/ITBNCMRA80A01D548T_20005.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<q1:FatturaElettronica versione="FPR12" xmlns:q1="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2">
+  <FatturaElettronicaHeader>
+
+       <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01484710387</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>00005</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>0000000</CodiceDestinatario>
+            <ContattiTrasmittente>
+                <Telefono>05543534343</Telefono>
+                <Email>info@yourcompany.example.com</Email>
+            </ContattiTrasmittente>
+            <PECDestinatario>ufficio@pec.bizz.it </PECDestinatario>
+        </DatiTrasmissione>
+
+     <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>01484710387</IdCodice>
+                </IdFiscaleIVA>
+               <Anagrafica>
+				<Nome>Mario</Nome>
+				<Cognome>Bianchi</Cognome>
+				<Titolo>Avvocato</Titolo>
+			</Anagrafica>
+			<RegimeFiscale>RF01</RegimeFiscale>
+		</DatiAnagrafici>
+		<Sede>
+			<Indirizzo>Via Voltapaletto 12</Indirizzo>
+			<CAP>44121</CAP>
+			<Comune>Ferrara</Comune>
+			<Provincia>FE</Provincia>
+			<Nazione>IT</Nazione>
+		</Sede>
+	</CedentePrestatore>
+
+	<CessionarioCommittente>
+		<DatiAnagrafici>
+			<CodiceFiscale>04006460275</CodiceFiscale>
+			<Anagrafica>
+				<Denominazione>BIZZ SRL</Denominazione>
+			</Anagrafica>
+		</DatiAnagrafici>
+		<Sede>
+			<Indirizzo>VIA TORINO 135</Indirizzo>
+			<CAP>30100</CAP>
+			<Comune>Venezia</Comune>
+			<Provincia>VE</Provincia>
+			<Nazione>IT</Nazione>
+		</Sede>
+	</CessionarioCommittente>
+
+  </FatturaElettronicaHeader>
+
+
+<FatturaElettronicaBody>
+
+	       <DatiGenerali>
+		<DatiGeneraliDocumento>
+			<TipoDocumento>TD01</TipoDocumento>
+			<Divisa>EUR</Divisa>
+			<Data>2020-10-25</Data>
+			<Numero>001</Numero>
+
+			<DatiRitenuta>
+				<TipoRitenuta>RT01</TipoRitenuta>
+				<ImportoRitenuta>23.00</ImportoRitenuta>
+				<AliquotaRitenuta>20.00</AliquotaRitenuta>
+				<CausalePagamento>A</CausalePagamento>
+			</DatiRitenuta>
+
+			<DatiCassaPrevidenziale>
+				<TipoCassa>TC01</TipoCassa>
+				<AlCassa>4.00</AlCassa>
+				<ImportoContributoCassa>4.60</ImportoContributoCassa>
+				<ImponibileCassa>115.00</ImponibileCassa>
+				<AliquotaIVA>22.00</AliquotaIVA>
+			</DatiCassaPrevidenziale>
+
+			<ImportoTotaleDocumento>122.91</ImportoTotaleDocumento>
+
+		</DatiGeneraliDocumento>
+	</DatiGenerali>
+
+	<DatiBeniServizi>
+		<DettaglioLinee>
+			<NumeroLinea>1</NumeroLinea>
+			<Descrizione>Competenze</Descrizione>
+			<PrezzoUnitario>100.00</PrezzoUnitario>
+			<PrezzoTotale>100.00</PrezzoTotale>
+			<AliquotaIVA>22.00</AliquotaIVA>
+			<Ritenuta>SI</Ritenuta>
+		</DettaglioLinee>
+
+		<DettaglioLinee>
+			<NumeroLinea>2</NumeroLinea>
+			<Descrizione>Spese generali ( 15% )</Descrizione>
+			<PrezzoUnitario>15.00</PrezzoUnitario>
+			<PrezzoTotale>15.00</PrezzoTotale>
+			<AliquotaIVA>22.00</AliquotaIVA>
+			<Ritenuta>SI</Ritenuta>
+		</DettaglioLinee>
+
+		<DatiRiepilogo>
+			<AliquotaIVA>22.00</AliquotaIVA>
+			<ImponibileImporto>119.60</ImponibileImporto>
+			<Imposta>26.31</Imposta>
+			<EsigibilitaIVA>I</EsigibilitaIVA>
+		</DatiRiepilogo>
+	</DatiBeniServizi>
+
+
+    <DatiPagamento>
+      <CondizioniPagamento>TP02</CondizioniPagamento>
+      <DettaglioPagamento>
+        <ModalitaPagamento>MP05</ModalitaPagamento>
+        <DataScadenzaPagamento>2020-09-30</DataScadenzaPagamento>
+        <ImportoPagamento>122.91</ImportoPagamento>
+        <IstitutoFinanziario>FINECO BANK</IstitutoFinanziario>
+        <IBAN>IT37F0301503200000005796511</IBAN>
+        <BIC>UNCRITMMXXX</BIC>
+      </DettaglioPagamento>
+    </DatiPagamento>
+
+  </FatturaElettronicaBody>
+
+</q1:FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -658,6 +658,12 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.assertTrue(len(invoice.ftpa_withholding_ids), 1)
         self.assertTrue(len(invoice.invoice_line_ids) == 3)
 
+    def test_44_xml_import(self):
+        res = self.run_wizard('test44', 'ITBNCMRA80A01D548T_20005.xml')
+        invoice_id = res.get('domain')[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertTrue(len(invoice.invoice_line_ids) == 3)
+
     def test_01_xml_link(self):
         """
         E-invoice lines are created.


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Se nell'XML sono presenti spazi in coda all'indirizzo nell'element PECDestinatario, la validazione fallisce (non è un dato valido in base all'XMLSchema)
Comportamento attuale prima di questa PR:
Fallisce l'importazione della fattura
Comportamento desiderato dopo questa PR:
La fattura viene importata.



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
