### PR TITLE
[12.0] l10n_it_fatturapa_in: Expected singleton per _compute_amount

### DIFF
--- a/l10n_it_fatturapa_in/README.rst
+++ b/l10n_it_fatturapa_in/README.rst
@@ -173,6 +173,7 @@ Contributors
 * Alessio Gerace
 * Sergio Zanchetta <https://github.com/primes2h>
 * Giovanni Serra <giovanni@gslab.it>
+* Gianmarco Conte <gconte@dinamicheaziendali.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -43,23 +43,26 @@ class AccountInvoice(models.Model):
     e_invoice_received_date = fields.Date(
         string='E-Bill Received Date')
 
+    @api.multi
     @api.depends('invoice_line_ids.price_subtotal', 'tax_line_ids.amount',
                  'tax_line_ids.amount_rounding', 'currency_id', 'company_id',
                  'date_invoice', 'type', 'efatt_rounding')
     def _compute_amount(self):
         super(AccountInvoice, self)._compute_amount()
-        if self.efatt_rounding != 0:
-            self.amount_total += self.efatt_rounding
-            amount_total_company_signed = self.amount_total
-            if self.currency_id and self.company_id and self.currency_id !=\
-                    self.company_id.currency_id:
-                currency_id = self.currency_id
-                amount_total_company_signed = currency_id._convert(
-                    self.amount_total, self.company_id.currency_id,
-                    self.company_id, self.date_invoice or fields.Date.today())
-            sign = self.type in ['in_refund', 'out_refund'] and -1 or 1
-            self.amount_total_company_signed = amount_total_company_signed * sign
-            self.amount_total_signed = self.amount_total * sign
+        for inv in self:
+            if inv.efatt_rounding != 0:
+                inv.amount_total += inv.efatt_rounding
+                amount_total_company_signed = inv.amount_total
+                if inv.currency_id and inv.company_id and \
+                        inv.currency_id != inv.company_id.currency_id:
+                    currency_id = inv.currency_id
+                    amount_total_company_signed = currency_id._convert(
+                        inv.amount_total, inv.company_id.currency_id,
+                        inv.company_id, inv.date_invoice or fields.Date.today())
+                sign = inv.type in ['in_refund', 'out_refund'] and -1 or 1
+                inv.amount_total_company_signed = \
+                    amount_total_company_signed * sign
+                inv.amount_total_signed = inv.amount_total * sign
 
     @api.model
     def invoice_line_move_line_get(self):

--- a/l10n_it_fatturapa_in/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fatturapa_in/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Alessio Gerace
 * Sergio Zanchetta <https://github.com/primes2h>
 * Giovanni Serra <giovanni@gslab.it>
+* Gianmarco Conte <gconte@dinamicheaziendali.it>

--- a/l10n_it_fatturapa_in/static/description/index.html
+++ b/l10n_it_fatturapa_in/static/description/index.html
@@ -496,6 +496,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Alessio Gerace</li>
 <li>Sergio Zanchetta &lt;<a class="reference external" href="https://github.com/primes2h">https://github.com/primes2h</a>&gt;</li>
 <li>Giovanni Serra &lt;<a class="reference external" href="mailto:giovanni&#64;gslab.it">giovanni&#64;gslab.it</a>&gt;</li>
+<li>Gianmarco Conte &lt;<a class="reference external" href="mailto:gconte&#64;dinamicheaziendali.it">gconte&#64;dinamicheaziendali.it</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Da pagamenti -> selezione pagamento con più fatture collegate -> azione -> invia ricevuta per email ho questo errore dovuto dalla funzione _compute_amount in l10n_it_fatturapa_in [12.0]


File "/opt/odoo12/odoo_prd/l10n-italy/l10n_it_fatturapa_in/models/account.py", line 51, in _compute_amount
    if self.efatt_rounding != 0:
  File "/opt/odoo12/odoo_prd/odoo/odoo/fields.py", line 1030, in get
    record.ensure_one()
  File "/opt/odoo12/odoo_prd/odoo/odoo/models.py", line 4768, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.invoice(17145, 17173)

Error to render compiling AST
ValueError: Expected singleton: account.invoice(17145, 17173)
Template: account.report_payment_receipt_document
Path: /templates/t/t/div/table/tbody/tr/td[4]/span
Node: <span t-field="inv.amount_total"/>

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
