### PR TITLE
[12.0 fix] l10n_it_withholding_tax: added consistency check to avoid to call withholding.tax.statement create with empty withholding_tax_id

### DIFF
--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -509,22 +509,23 @@ class AccountInvoice(models.Model):
         """
         wt_statement_obj = self.env['withholding.tax.statement']
         for inv_wt in self.withholding_tax_line_ids:
-            wt_base_amount = inv_wt.base
-            wt_tax_amount = inv_wt.tax
-            if self.type in ['in_refund', 'out_refund']:
-                wt_base_amount = -1 * wt_base_amount
-                wt_tax_amount = -1 * wt_tax_amount
-            val = {
-                'wt_type': '',
-                'date': self.move_id.date,
-                'move_id': self.move_id.id,
-                'invoice_id': self.id,
-                'partner_id': self.partner_id.id,
-                'withholding_tax_id': inv_wt.withholding_tax_id.id,
-                'base': wt_base_amount,
-                'tax': wt_tax_amount,
-            }
-            wt_statement_obj.create(val)
+            if inv_wt.withholding_tax_id.id:
+                wt_base_amount = inv_wt.base
+                wt_tax_amount = inv_wt.tax
+                if self.type in ['in_refund', 'out_refund']:
+                    wt_base_amount = -1 * wt_base_amount
+                    wt_tax_amount = -1 * wt_tax_amount
+                val = {
+                    'wt_type': '',
+                    'date': self.move_id.date,
+                    'move_id': self.move_id.id,
+                    'invoice_id': self.id,
+                    'partner_id': self.partner_id.id,
+                    'withholding_tax_id': inv_wt.withholding_tax_id.id,
+                    'base': wt_base_amount,
+                    'tax': wt_tax_amount,
+                }
+                wt_statement_obj.create(val)
 
     @api.model
     def _get_payments_vals(self):


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
durante la validazione di una fattura con ritenuta di acconto si verifica:
**errore (Tipo documento: Withholding Tax Statement, Operazione: create) - (Record: [18], Utente: 2)**

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:
in fase di debug ho trovato che il motodo **create_wt_statement**, ciclando tra i **self.withholding_tax_line_ids** trova un record vuoto il cui **withholding_tax_id.id** risulta **False** causando il problema descirtto sopra.

la fix evita il tentativo di creazione di un **withholding.tax.statement** con **withholding_tax_id.id** == **False**




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
