### PR TITLE
[12.0][FIX] vat with extra chars

### DIFF
--- a/l10n_it_fatturapa_in/__manifest__.py
+++ b/l10n_it_fatturapa_in/__manifest__.py
@@ -16,6 +16,7 @@
                'l10n_it_fatturapa_in',
     'license': 'AGPL-3',
     "depends": [
+        'base_vat_sanitized',
         'l10n_it_fatturapa',
         'l10n_it_withholding_tax_causali',
         ],

--- a/l10n_it_fatturapa_in/tests/data/IT05979361218_001.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT05979361218_001.xml
@@ -17,7 +17,7 @@ xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.
             <DatiAnagrafici>
                 <IdFiscaleIVA>
                     <IdPaese>IT</IdPaese>
-                    <IdCodice>05979361218</IdCodice>
+                    <IdCodice>05979361218         </IdCodice>
                 </IdFiscaleIVA>
                 <Anagrafica>
                     <Denominazione>SOCIETA' ALPHA BETA SRL</Denominazione>

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -96,6 +96,7 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.assertEqual(invoice.partner_id.street, "VIALE ROMA 543")
         self.assertEqual(invoice.partner_id.state_id.code, "SS")
         self.assertEqual(invoice.partner_id.country_id.code, "IT")
+        self.assertEqual(invoice.partner_id.vat, "IT02780790107")
         self.assertEqual(
             invoice.tax_representative_id.name, "Rappresentante fiscale")
         self.assertEqual(invoice.welfare_fund_ids[0].welfare_rate_tax, 0.04)
@@ -663,6 +664,20 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         invoice_id = res.get('domain')[0][2][0]
         invoice = self.invoice_model.browse(invoice_id)
         self.assertTrue(len(invoice.invoice_line_ids) == 3)
+
+    def test_45_xml_import_no_duplicate_partner(self):
+        partner_id = self.env['res.partner'].search([
+            ('vat', 'ilike', '05979361218')
+        ])
+        partner_id.vat = ' %s  ' % partner_id.vat
+        res = self.run_wizard('test45', 'IT05979361218_001.xml')
+        invoice_id = res.get('domain')[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertEqual(invoice.partner_id.id, partner_id.id)
+        self.assertEqual(
+            len(self.env['res.partner'].search([
+                ('vat', 'ilike', '05979361218')
+            ])), 1)
 
     def test_01_xml_link(self):
         """

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from odoo import models, api, fields
 from odoo.tools import float_is_zero
 from odoo.tools.translate import _
@@ -123,17 +124,17 @@ class WizardImportFatturapa(models.TransientModel):
             # to avoid validation error when creating the given partner
             if DatiAnagrafici.IdFiscaleIVA.IdPaese.upper() == 'IT':
                 vat = "%s%s" % (
-                    DatiAnagrafici.IdFiscaleIVA.IdPaese,
-                    DatiAnagrafici.IdFiscaleIVA.IdCodice.rjust(11, '0')
+                    DatiAnagrafici.IdFiscaleIVA.IdPaese.upper(),
+                    DatiAnagrafici.IdFiscaleIVA.IdCodice.rjust(11, '0')[:11]
                 )
             else:
                 vat = "%s%s" % (
-                    DatiAnagrafici.IdFiscaleIVA.IdPaese,
-                    DatiAnagrafici.IdFiscaleIVA.IdCodice
+                    DatiAnagrafici.IdFiscaleIVA.IdPaese.upper(),
+                    re.sub(r'\W+', '', DatiAnagrafici.IdFiscaleIVA.IdCodice).upper()
                 )
         partners = partner_model
         if vat:
-            domain = [('vat', '=', vat)]
+            domain = [('sanitized_vat', '=', vat)]
             if self.env.context.get('from_attachment'):
                 att = self.env.context.get('from_attachment')
                 domain.extend([


### PR DESCRIPTION
Descrizione del problema o della funzionalità: il sistema crea un partner nuovo anche per un solo spazio di differenza nel codice IVA

Comportamento attuale prima di questa PR: partner duplicati a causa di uno spazio nell'IVA del partner già presente in anagrafica, oppure di uno spazio nell'IVA nell'xml

Comportamento desiderato dopo questa PR: partner non duplicati per i motivi sopra




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing