### PR TITLE
[12.0][FIX] fix code and add test to support issued declaration [l10n_it_dichiarazione_intento]

### DIFF
--- a/l10n_it_dichiarazione_intento/models/account_invoice.py
+++ b/l10n_it_dichiarazione_intento/models/account_invoice.py
@@ -79,7 +79,7 @@ class AccountInvoice(models.Model):
                         'change fiscal position and verify applied tax'))
                 else:
                     continue
-            sign = 1 if invoice.type in ['out_invoice', 'in_refund'] else -1
+            sign = 1 if invoice.type in ['out_invoice', 'in_invoice'] else -1
             dichiarazioni_amounts = {}
             for tax_line in invoice.tax_line_ids:
                 amount = sign * tax_line.base


### PR DESCRIPTION
Descrizione del problema o della funzionalità: le dichiarazione d'intento ricevute restituiscono un errore in fase di validazione della fattura fornitore in quanto il totale utilizzato risulta sempre inferiore al richiesto

Comportamento attuale prima di questa PR: non è possibile validare una fattura fornitore con dichiarazione d'intento emessa

Comportamento desiderato dopo questa PR: è possibile validarla e il controllo sul totale utilizzato è corretto

Rif https://github.com/OCA/l10n-italy/issues/1960


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing