### PR TITLE
[12.0][FIX] l'onchange `to_be_invoiced` non viene attivato in alcune situazioni e quindi il ddt risulta non fatturabile

### DIFF
--- a/l10n_it_ddt/models/stock_picking_package_preparation.py
+++ b/l10n_it_ddt/models/stock_picking_package_preparation.py
@@ -440,7 +440,7 @@ class StockPickingPackagePreparation(models.Model):
         grouped_invoices = {}
         references = {}
         for td in self:
-            if not td.to_be_invoiced or td.invoice_id:
+            if not td.transportation_reason_id.to_be_invoiced or td.invoice_id:
                 continue
 
             group_key = td.get_td_group_key()


### PR DESCRIPTION
Descrizione del problema o della funzionalità: il DDT non risulta fatturabile in quanto l'onchange non viene eseguito in alcuni casi (non è chiaro il motivo scatenante)

Comportamento attuale prima di questa PR: il DDT non risulta fatturabile

Comportamento desiderato dopo questa PR: il DDT risulta fatturabile




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing