### PR TITLE
[12.0][IMP] l10n_it_fiscal_document_type: Hide fields to not italy company

### DIFF
--- a/l10n_it_fiscal_document_type/models/account_fiscal_position.py
+++ b/l10n_it_fiscal_document_type/models/account_fiscal_position.py
@@ -2,9 +2,11 @@ from odoo import models, fields
 
 
 class AccountFiscalPosition(models.Model):
-    _inherit = 'account.fiscal.position'
+    _name = 'account.fiscal.position'
+    _inherit = ['account.fiscal.position', 'l10n_it_account.mixin']
 
     fiscal_document_type_id = fields.Many2one(
         'fiscal.document.type',
         string="Fiscal Document Type",
-        readonly=False)
+        readonly=False
+    )

--- a/l10n_it_fiscal_document_type/models/account_invoice.py
+++ b/l10n_it_fiscal_document_type/models/account_invoice.py
@@ -2,7 +2,8 @@ from odoo import models, fields, api
 
 
 class AccountInvoice(models.Model):
-    _inherit = 'account.invoice'
+    _name = 'account.invoice'
+    _inherit = ['account.invoice', 'l10n_it_account.mixin']
 
     @api.multi
     @api.depends('partner_id', 'journal_id', 'type', 'fiscal_position_id')

--- a/l10n_it_fiscal_document_type/models/res_partner.py
+++ b/l10n_it_fiscal_document_type/models/res_partner.py
@@ -2,7 +2,8 @@ from odoo import models, fields
 
 
 class ResPartner(models.Model):
-    _inherit = 'res.partner'
+    _name = 'res.partner'
+    _inherit = ['res.partner', 'l10n_it_account.mixin']
 
     out_fiscal_document_type = fields.Many2one(
         'fiscal.document.type', string="Out Fiscal Document Type",)

--- a/l10n_it_fiscal_document_type/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fiscal_document_type/readme/CONTRIBUTORS.rst
@@ -2,3 +2,7 @@
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Gianmarco Conte <gconte@dinamicheaziendali.it>
 * Sergio Zanchetta <https://github.com/primes2h>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_fiscal_document_type/views/account_invoice_view.xml
+++ b/l10n_it_fiscal_document_type/views/account_invoice_view.xml
@@ -6,7 +6,12 @@
         <field name="inherit_id" ref="account.invoice_supplier_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='move_id']" position="before">
-                    <field name="fiscal_document_type_id" class="oe_inline" />
+                <field name="is_company_it" invisible="1" />
+                <field
+                    name="fiscal_document_type_id"
+                    attrs="{'invisible': [('is_company_it', '=', False)]}"
+                    class="oe_inline"
+                />
             </xpath>
         </field>
     </record>
@@ -17,7 +22,12 @@
         <field name="inherit_id" ref="account.invoice_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='move_id']" position="before">
-                    <field name="fiscal_document_type_id" class="oe_inline" />
+                <field name="is_company_it" invisible="1" />
+                <field
+                    name="fiscal_document_type_id"
+                    attrs="{'invisible': [('is_company_it', '=', False)]}"
+                    class="oe_inline"
+                />
             </xpath>
         </field>
     </record>

--- a/l10n_it_fiscal_document_type/views/account_view.xml
+++ b/l10n_it_fiscal_document_type/views/account_view.xml
@@ -6,9 +6,12 @@
         <field name="inherit_id" ref="account.view_account_position_form"/>
         <field name="arch" type="xml">
             <field name="company_id" position="after" >
-                <field name="fiscal_document_type_id" />
+                <field name="is_company_it" invisible="1" />
+                <field
+                    name="fiscal_document_type_id"
+                    attrs="{'invisible': [('is_company_it', '=', False)]}"
+                />
             </field>
         </field>
     </record>
-
 </odoo>

--- a/l10n_it_fiscal_document_type/views/res_partner_view.xml
+++ b/l10n_it_fiscal_document_type/views/res_partner_view.xml
@@ -7,10 +7,19 @@
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='property_payment_term_id']" position="before">
-                        <field name="out_fiscal_document_type" class="oe_inline" />
+                    <field name="is_company_it" invisible="1" />
+                    <field
+                        name="out_fiscal_document_type"
+                        attrs="{'invisible': [('is_company_it', '=', False)]}"
+                        class="oe_inline"
+                    />
                 </xpath>
                 <xpath expr="//field[@name='property_supplier_payment_term_id']" position="before">
-                        <field name="in_fiscal_document_type" class="oe_inline" />
+                    <field
+                        name="in_fiscal_document_type"
+                        attrs="{'invisible': [('is_company_it', '=', False)]}"
+                        class="oe_inline"
+                    />
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:
- [ ] `l10n_it_account` https://github.com/OCA/l10n-italy/pull/2011

@Tecnativa TT27569