### PR TITLE
[12.0][IMP] l10n_it_account: Hide fields to not italy company

### DIFF
--- a/l10n_it_account/__manifest__.py
+++ b/l10n_it_account/__manifest__.py
@@ -18,6 +18,7 @@
         'account_fiscal_year',
         'account_tax_balance',
         'web',
+        'l10n_multi_country'
     ],
     "data": [
         'views/account_setting.xml',

--- a/l10n_it_account/models/account_group.py
+++ b/l10n_it_account/models/account_group.py
@@ -5,7 +5,8 @@ from odoo.exceptions import ValidationError
 
 
 class AccountGroup(models.Model):
-    _inherit = 'account.group'
+    _name = 'account.group'
+    _inherit = ['account.group', 'l10n_multi_country.mixin']
 
     account_ids = fields.One2many(
         comodel_name='account.account',
@@ -15,6 +16,7 @@ class AccountGroup(models.Model):
     account_balance_sign = fields.Integer(
         compute="_compute_account_balance_sign",
         string="Balance sign",
+        country='IT'
     )
 
     @api.constrains('parent_id')

--- a/l10n_it_account/models/account_type.py
+++ b/l10n_it_account/models/account_type.py
@@ -17,11 +17,13 @@ ACCOUNT_TYPES_NEGATIVE_SIGN = [
 
 
 class AccountType(models.Model):
-    _inherit = 'account.account.type'
+    _name = 'account.account.type'
+    _inherit = ['account.account.type', 'l10n_multi_country.mixin']
 
     account_balance_sign = fields.Integer(
         default=1,
         string="Balance sign",
+        country='IT'
     )
 
     @api.model

--- a/l10n_it_account/models/res_company.py
+++ b/l10n_it_account/models/res_company.py
@@ -8,5 +8,4 @@ class ResCompany(models.Model):
 
     def is_country_id_code_it(self):
         self.ensure_one()
-        country_it = self.env.ref("base.it")
-        return self.partner_id.country_id == country_it
+        return self.country_id == self.env.ref("base.it")

--- a/l10n_it_account/tests/__init__.py
+++ b/l10n_it_account/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_l10n_it_account
+from . import test_l10n_it_account_mixin

--- a/l10n_it_account/tests/test_l10n_it_account.py
+++ b/l10n_it_account/tests/test_l10n_it_account.py
@@ -1,3 +1,7 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from lxml import etree
 from odoo.tests.common import TransactionCase
 from odoo.exceptions import ValidationError
 

--- a/l10n_it_account/tests/test_l10n_it_account_mixin.py
+++ b/l10n_it_account/tests/test_l10n_it_account_mixin.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.addons.l10n_multi_country.tests.test_base import TestHideFieldsBase
+
+
+class TestAccountMixin(TestHideFieldsBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_it = cls.env["res.company"].create({
+            "name": "Italy test company",
+            "country_id": cls.env.ref("base.it").id,
+        })
+
+    def test_show_it_fields_account_group(self):
+        self.assertTrue(
+            "'invisible': [('company_country_code','!=', 'IT')]}" in
+            self._get_field_name_attrs(
+                'account_balance_sign', self.company_it, 'account.group', False
+            )
+        )
+
+    def test_show_it_fields_account_account_type(self):
+        self.assertTrue(
+            "'invisible': [('company_country_code','!=', 'IT')]}" in
+            self._get_field_name_attrs(
+                'account_balance_sign', self.company_it, 'account.account.type', False
+            )
+        )


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by: 
- [ ] `l10n_multi_country` https://github.com/OCA/server-ux/pull/262

@Tecnativa TT27571