### PR TITLE
[12.0][IMP] l10n_it_split_payment: Hide fields to not italy company

### DIFF
--- a/l10n_it_split_payment/models/__init__.py
+++ b/l10n_it_split_payment/models/__init__.py
@@ -3,6 +3,7 @@
 # Copyright 2016  Alessio Gerace - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import l10n_it_split_payment_mixin
 from . import account
 from . import config
 from . import account_tax

--- a/l10n_it_split_payment/models/account.py
+++ b/l10n_it_split_payment/models/account.py
@@ -9,23 +9,27 @@ from odoo.exceptions import UserError
 
 
 class AccountFiscalPosition(models.Model):
-    _inherit = 'account.fiscal.position'
+    _name = 'account.fiscal.position'
+    _inherit = ['account.fiscal.position', 'l10n_it_esigibilita_iva.mixin']
 
     split_payment = fields.Boolean('Split Payment')
 
 
 class AccountInvoice(models.Model):
-    _inherit = 'account.invoice'
+    _name = 'account.invoice'
+    _inherit = ['account.invoice', 'l10n_it_esigibilita_iva.mixin']
 
     amount_sp = fields.Float(
         string='Split Payment',
         digits=dp.get_precision('Account'),
         store=True,
         readonly=True,
-        compute='_compute_amount')
+        compute='_compute_amount'
+    )
     split_payment = fields.Boolean(
         'Is Split Payment',
-        related='fiscal_position_id.split_payment')
+        related='fiscal_position_id.split_payment'
+    )
 
     @api.one
     @api.depends(

--- a/l10n_it_split_payment/models/account_tax.py
+++ b/l10n_it_split_payment/models/account_tax.py
@@ -6,7 +6,8 @@ from odoo import models, fields, api
 class AccountTax(models.Model):
     _inherit = 'account.tax'
     is_split_payment = fields.Boolean(
-        "Is split payment", compute="_compute_is_split_payment")
+        "Is split payment", compute="_compute_is_split_payment"
+    )
 
     @api.multi
     def _compute_is_split_payment(self):

--- a/l10n_it_split_payment/models/config.py
+++ b/l10n_it_split_payment/models/config.py
@@ -21,3 +21,6 @@ class AccountConfigSettings(models.TransientModel):
         related='company_id.sp_account_id',
         string='Split Payment Write-off account',
         help='Account used to write off the VAT amount', readonly=False)
+    company_country_id_code = fields.Char(
+        related="company_id.country_id.code"
+    )

--- a/l10n_it_split_payment/models/l10n_it_split_payment_mixin.py
+++ b/l10n_it_split_payment/models/l10n_it_split_payment_mixin.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Tecnativa - Víctor Martínez
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from odoo import models, fields
+
+
+class L10nItSplitPaymentMixin(models.AbstractModel):
+    _name = 'l10n_it_split_payment.mixin'
+    _description = 'l10n_it_split_payment Mixin'
+
+    is_company_it = fields.Boolean(
+        compute="_compute_is_company_it"
+    )
+
+    def _compute_is_company_it(self):
+        for record in self:
+            record.is_company_it = False
+            country_it = self.env.ref("base.it")
+            if (
+                (
+                    record.company_id and
+                    record.company_id.country_id == country_it
+                ) or (
+                    not record.company_id and
+                    self.env.user.company_id.country_id == country_it
+                )
+            ):
+                record.is_company_it = True

--- a/l10n_it_split_payment/readme/CONTRIBUTORS.rst
+++ b/l10n_it_split_payment/readme/CONTRIBUTORS.rst
@@ -3,3 +3,7 @@
 * Alessio Gerace <alessio.gerace@agilebg.com>
 * Giacomo Grasso <giacomo.grasso.82@gmail.com>
 * Ruben Tonetto <https://github.com/ruben-tonetto>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_split_payment/views/account_view.xml
+++ b/l10n_it_split_payment/views/account_view.xml
@@ -1,32 +1,36 @@
 <?xml version="1.0" ?>
 <odoo>
-
-
         <record id="account_fiscal_position_form_sp" model="ir.ui.view">
         <field name="name">account.fiscal.position.form.sp</field>
         <field name="model">account.fiscal.position</field>
         <field name="inherit_id" ref="account.view_account_position_form"/>
         <field name="arch" type="xml">
             <field name="country_group_id" position="after">
-                            <field name="split_payment"/>
-                        </field>
+                <field name="is_company_it" invisible="1" />
+                <field
+                    name="split_payment"
+                    attrs="{'invisible': [('is_company_it', '=', False)]}"
+                />
+            </field>
         </field>
     </record>
-
-        <record id="account_invoice_form_sp" model="ir.ui.view">
+    <record id="account_invoice_form_sp" model="ir.ui.view">
         <field name="name">account.invoice.form.sp</field>
         <field name="model">account.invoice</field>
         <field name="inherit_id" ref="account.invoice_form"/>
         <field name="arch" type="xml">
-                        <field name="move_id" position="after">
-                            <field name="split_payment" invisible="1"/>
-                        </field>
+            <field name="move_id" position="after">
+                <field name="split_payment" invisible="1"/>
+            </field>
             <field name="amount_tax" position="after">
-                            <field name="amount_sp" widget="monetary"
-                                options="{'currency_field': 'currency_id'}"
-                                attrs="{'invisible': [('split_payment', '=', False)]}"/>
-                        </field>
+                <field name="is_company_it" invisible="1" />
+                <field
+                    name="amount_sp"
+                    widget="monetary"
+                    options="{'currency_field': 'currency_id'}"
+                    attrs="{'invisible': [('split_payment', '=', False),('is_company_it', '=', False)]}"
+                />
+            </field>
         </field>
     </record>
-
 </odoo>

--- a/l10n_it_split_payment/views/config_view.xml
+++ b/l10n_it_split_payment/views/config_view.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" ?>
 <odoo>
-
     <record id="view_account_config_settings" model="ir.ui.view">
         <field name="name">view_account_config_settings</field>
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <div id="eu_service" position="after">
+                <field name="company_country_id_code" invisible="1" />
                 <div class="col-12 col-lg-6 o_setting_box"
-                     title="Configuration for Split Payment module">
+                    attrs="{'invisible': [('company_country_id_code', '!=', 'IT')]}"
+                    title="Configuration for Split Payment module">
                     <div class="o_setting_left_pane"/>
                     <div class="o_setting_right_pane">
                         <span class="o_form_label">Configuration for Split Payment module</span>
@@ -27,8 +28,6 @@
                     </div>
                 </div>
             </div>
-
         </field>
     </record>
-
 </odoo>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:
- [ ] https://github.com/OCA/server-ux/pull/262 `l10n_multi_country`

@Tecnativa TT27568