### PR TITLE
[12.0][IMP] l10n_it_fiscal_payment_term: Hide fields to not italy company

### DIFF
--- a/l10n_it_fiscal_payment_term/models/__init__.py
+++ b/l10n_it_fiscal_payment_term/models/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2014 Davide Corio <davide.corio@abstract.it>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+from . import l10n_it_fiscal_payment_term_mixin
 from . import account

--- a/l10n_it_fiscal_payment_term/models/account.py
+++ b/l10n_it_fiscal_payment_term/models/account.py
@@ -25,9 +25,14 @@ class FatturapaPaymentMethod(models.Model):
 #  used in fatturaPa export
 class AccountPaymentTerm(models.Model):
     # _position = ['2.4.2.2']
-    _inherit = 'account.payment.term'
+    _name = 'account.payment.term'
+    _inherit = ['account.payment.term', 'l10n_it_fiscal_payment_term.mixin']
 
     fatturapa_pt_id = fields.Many2one(
-        'fatturapa.payment_term', string="Fiscal Payment Term")
+        comodel_name='fatturapa.payment_term',
+        string="Fiscal Payment Term"
+    )
     fatturapa_pm_id = fields.Many2one(
-        'fatturapa.payment_method', string="Fiscal Payment Method")
+        comodel_name='fatturapa.payment_method',
+        string="Fiscal Payment Method"
+    )

--- a/l10n_it_fiscal_payment_term/models/l10n_it_fiscal_payment_term_mixin.py
+++ b/l10n_it_fiscal_payment_term/models/l10n_it_fiscal_payment_term_mixin.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Tecnativa - Víctor Martínez
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from odoo import models, fields
+
+
+class L10nItFiscalPaymentTermMixin(models.AbstractModel):
+    _name = 'l10n_it_fiscal_payment_term.mixin'
+    _description = 'l10n_it_fiscal_payment_term Mixin'
+
+    is_company_it = fields.Boolean(
+        compute="_compute_is_company_it"
+    )
+
+    def _compute_is_company_it(self):
+        for record in self:
+            record.is_company_it = False
+            country_it = self.env.ref("base.it")
+            if (
+                (
+                    record.company_id and
+                    record.company_id.country_id == country_it
+                ) or (
+                    not record.company_id and
+                    self.env.user.company_id.country_id == country_it
+                )
+            ):
+                record.is_company_it = True

--- a/l10n_it_fiscal_payment_term/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fiscal_payment_term/readme/CONTRIBUTORS.rst
@@ -3,3 +3,7 @@
 * Roberto Onnis <roberto.onnis@innoviu.com>
 * Alessio Gerace <alessio.gerace@agilebg.com>
 * Sergio Zanchetta <https://github.com/primes2h>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_fiscal_payment_term/views/account_view.xml
+++ b/l10n_it_fiscal_payment_term/views/account_view.xml
@@ -7,25 +7,39 @@
             <field name="inherit_id" ref="account.view_payment_term_form"/>
             <field name="arch" type="xml">
                 <field name="line_ids" position="after">
+                    <field name="is_company_it" invisible="1" />
                     <group col="2" colspan="2">
-                        <field name="fatturapa_pt_id" options="{'no_create': True, 'no_edit': True}"/>
-                        <field name="fatturapa_pm_id" options="{'no_create': True, 'no_edit': True}"/>
+                        <field
+                            name="fatturapa_pt_id"
+                            attrs="{'invisible': [('is_company_it', '=', False)]}"
+                            options="{'no_create': True, 'no_edit': True}"
+                        />
+                        <field
+                            name="fatturapa_pm_id"
+                            attrs="{'invisible': [('is_company_it', '=', False)]}"
+                            options="{'no_create': True, 'no_edit': True}"
+                        />
                     </group>
                 </field>
             </field>
         </record>
-
         <record id="view_payment_term_tree_fatturapa" model="ir.ui.view">
             <field name="name">account.payment.term.fatturapa</field>
             <field name="model">account.payment.term</field>
             <field name="inherit_id" ref="account.view_payment_term_tree"></field>
             <field name="arch" type="xml">
                 <field name="name" position="after">
-                    <field name="fatturapa_pt_id"/>
-                    <field name="fatturapa_pm_id"/>
+                    <field name="is_company_it" invisible="1" />
+                    <field
+                        name="fatturapa_pt_id"
+                        attrs="{'invisible': [('is_company_it', '=', False)]}"
+                    />
+                    <field
+                        name="fatturapa_pm_id"
+                        attrs="{'invisible': [('is_company_it', '=', False)]}"
+                    />
                 </field>
             </field>
         </record>
-
     </data>
 </odoo>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:
- [ ] https://github.com/OCA/server-ux/pull/262 `l10n_multi_country`

@Tecnativa TT27567