### PR TITLE
[12.0][IMP] l10n_it_esigibilita_iva: Hide fields to not italy company

### DIFF
--- a/l10n_it_esigibilita_iva/models/__init__.py
+++ b/l10n_it_esigibilita_iva/models/__init__.py
@@ -1,2 +1,3 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from . import l10n_it_esigibilita_iva_mixin
 from . import account

--- a/l10n_it_esigibilita_iva/models/account.py
+++ b/l10n_it_esigibilita_iva/models/account.py
@@ -1,12 +1,17 @@
+# Copyright 2020 Tecnativa - Víctor Martínez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 from odoo import models, fields
 
 
 class AccountTax(models.Model):
-    _inherit = 'account.tax'
+    _name = 'account.tax'
+    _inherit = ['account.tax', 'l10n_it_esigibilita_iva.mixin']
 
-    payability = fields.Selection([
-        ('I', 'VAT payable immediately'),
-        ('D', 'unrealized VAT'),
-        ('S', 'split payments'),
-    ], string="VAT payability")
+    payability = fields.Selection(
+        [
+            ('I', 'VAT payable immediately'),
+            ('D', 'unrealized VAT'),
+            ('S', 'split payments'),
+        ],
+        string="VAT payability"
+    )

--- a/l10n_it_esigibilita_iva/models/l10n_it_esigibilita_iva_mixin.py
+++ b/l10n_it_esigibilita_iva/models/l10n_it_esigibilita_iva_mixin.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Tecnativa - Víctor Martínez
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from odoo import models, fields
+
+
+class L10nItEsigibilitaIvaMixin(models.AbstractModel):
+    _name = 'l10n_it_esigibilita_iva.mixin'
+    _description = 'l10n_it_esigibilita_iva Mixin'
+
+    is_company_it = fields.Boolean(
+        compute="_compute_is_company_it"
+    )
+
+    def _compute_is_company_it(self):
+        for record in self:
+            record.is_company_it = False
+            country_it = self.env.ref("base.it")
+            if (
+                (
+                    record.company_id and
+                    record.company_id.country_id == country_it
+                ) or (
+                    not record.company_id and
+                    self.env.user.company_id.country_id == country_it
+                )
+            ):
+                record.is_company_it = True

--- a/l10n_it_esigibilita_iva/readme/CONTRIBUTORS.rst
+++ b/l10n_it_esigibilita_iva/readme/CONTRIBUTORS.rst
@@ -1,3 +1,7 @@
 * Alessandro Camilli <alessandrocamilli@openforce.it>
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Gianmarco Conte <gconte@dinamicheaziendali.it>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_esigibilita_iva/views/account_view.xml
+++ b/l10n_it_esigibilita_iva/views/account_view.xml
@@ -7,7 +7,11 @@
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='tag_ids']" position="after">
-                <field name="payability" />
+                <field name="is_company_it" invisible="1" />
+                <field
+                    name="payability"
+                    attrs="{'invisible': [('is_company_it', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:
- [ ] https://github.com/OCA/server-ux/pull/262 `l10n_multi_country`

@Tecnativa TT27566