### PR TITLE
[8.0][FIX] l10n_it_withholding_tax: view mancanti + migrate per vecchie fatture con WT

### DIFF
--- a/l10n_it_withholding_tax/migrations/8.0.4.0.1/post-migration.py
+++ b/l10n_it_withholding_tax/migrations/8.0.4.0.1/post-migration.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2020 Ciro Urselli (<http://www.apuliasoftware.it>).
+# Copyright 2020 Vincenzo Terzulli <v.terzulli@elvenstudio.it>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from openerp import SUPERUSER_ID, api
+from openupgradelib import openupgrade
+import time
+import logging
+_log = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        _log.info('Recomputing WT on existing invoices...')
+
+        counter = 0
+        start_time = time.time()
+        block_time = start_time
+
+        invoice_model = env['account.invoice']
+        domain = [('withholding_tax_backup', '=', True)]
+        ids_invoices = invoice_model.search_read(domain=domain, fields=['id'])
+        ids_invoices = [v['id'] for v in ids_invoices]
+
+        items = 20
+        while ids_invoices:
+            ids = ids_invoices[:items]
+            del ids_invoices[:items]
+            invoice_ids = invoice_model.browse(ids)
+
+            # dalla posizione fiscale
+            # for invoice_id in invoice_ids:
+            #     wt_ids = invoice_id.fiscal_position.withholding_tax_ids
+            #     for line_id in invoice_id.invoice_line:
+            #         if not line_id.withholding_tax_exclude:
+            #             line_id.invoice_line_tax_wt_ids = [(6, 0, wt_ids.ids)]
+            #     invoice_id.button_reset_taxes()
+
+            # dal castelletto delle ritenute
+            # si è scelto di adottare questo approccio per considerare i casi in cui
+            # le ritenute applicate alla fattura siano stato modificate manualmente
+            # nel castelletto.
+            for invoice_id in invoice_ids:
+                wt_ids = invoice_id.withholding_tax_line.mapped('withholding_tax_id')
+                for line_id in invoice_id.invoice_line:
+                    if not line_id.withholding_tax_exclude:
+                        line_id.invoice_line_tax_wt_ids = [(6, 0, wt_ids.ids)]
+                invoice_id.button_reset_taxes()
+
+            counter += len(ids)
+            duration = time.time() - block_time
+            _log.info('   Done: %d invoices - Avg single duration: %fs' %
+                      (counter, duration/items))
+
+        _log.info('Completed in %fs' % (time.time() - start_time))
+
+        # remove field withholding_tax_backup
+        openupgrade.drop_columns(cr, {
+            ('account_invoice', 'withholding_tax_backup'),
+        })
+
+    return True

--- a/l10n_it_withholding_tax/migrations/8.0.4.0.1/pre-migration.py
+++ b/l10n_it_withholding_tax/migrations/8.0.4.0.1/pre-migration.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2020 Ciro Urselli (<http://www.apuliasoftware.it>).
+# Copyright 2020 Vincenzo Terzulli <v.terzulli@elvenstudio.it>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(cr, version):
+    if not version:
+        return
+
+    # backup existing 'withholding_tax' field values
+    openupgrade.copy_columns(cr, {
+        'account_invoice': [
+            ('withholding_tax', 'withholding_tax_backup', None),
+        ]
+    })

--- a/l10n_it_withholding_tax/views/account.xml
+++ b/l10n_it_withholding_tax/views/account.xml
@@ -78,6 +78,11 @@
                 <xpath expr="//page/field[@name='invoice_line']" position="attributes">
                     <attribute name="context">{'fiscal_position_id': fiscal_position, 'type': type, 'journal_id': journal_id}</attribute>
                 </xpath>
+
+                <xpath expr="//page/field[@name='invoice_line']/tree/field[@name='invoice_line_tax_id']" position="after">
+                    <field name="invoice_line_tax_wt_ids" widget="many2many_tags" options="{'no_create': True}"/>
+                </xpath>
+
                 <xpath expr="//field[@name='tax_line']" position="after">
                     <field name="withholding_tax_line"
                            attrs="{'invisible': [('withholding_tax', '=', False)]}">
@@ -116,6 +121,41 @@
             </field>
         </record>
 
+        <record id="invoice_supplier_tree" model="ir.ui.view">
+            <field name="name">view.withholding.invoice.supplier.tree</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_tree"/>
+            <field name="arch" type="xml">
+                    <field name="residual" position="after">
+                        <field name="amount_net_pay" widget="monetary"
+                               invisible="context.get('type', 'in_invoice') not in ['in_invoice', 'in_refund']"
+                               options="{'currency_field': 'currency_id'}"
+                               sum="Net to pay"/>
+                    </field>
+            </field>
+        </record>
+
+        <!--
+        INVOICE LINE
+        -->
+        <record model="ir.ui.view" id="view_wt_invoice_line_form">
+            <field name="name">view.withholding.invoice.supplier.form</field>
+            <field name="model">account.invoice.line</field>
+            <field name="inherit_id" ref="account.view_invoice_line_form"/>
+            <field name="arch" type="xml">
+
+                <field name="invoice_line_tax_id" position="after">
+                    <field name="invoice_line_tax_wt_ids" widget="many2many_tags" options="{'no_create': True}"
+                        invisible="context.get('type', 'out_invoice') not in ['in_invoice', 'in_refund']"/>
+                </field>
+
+                <field name="discount" position="after">
+                    <field name="withholding_tax_exclude"/>
+                </field>
+
+            </field>
+        </record>
+
         <!--
         FISCAL POSITION
          -->
@@ -140,8 +180,8 @@
             </field>
         </record>
 
-        <record model="ir.ui.view" id="view_withholding_tax_exclude_tree">
-            <field name="name">view.withholding.tax.exclude.tree</field>
+        <record model="ir.ui.view" id="view_withholding_tax_exclude_form">
+            <field name="name">view.withholding.tax.exclude.form</field>
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_form"/>
             <field name="arch" type="xml">
@@ -152,8 +192,8 @@
             </field>
         </record>
 
-        <record model="ir.ui.view" id="view_withholding_tax_exclude_supplier_tree">
-            <field name="name">view.withholding.tax.exclude.supplier.tree</field>
+        <record model="ir.ui.view" id="view_withholding_tax_exclude_supplier_form">
+            <field name="name">view.withholding.tax.exclude.supplier.form</field>
             <field name="model">account.invoice</field>
             <field name="inherit_id" ref="account.invoice_supplier_form"/>
             <field name="arch" type="xml">


### PR DESCRIPTION
### Descrizione del problema o della funzionalità:

**ATTENZIONE:** Con gli aggiornamenti a FE 1.6, le ritenute in fattura si applicano a livello di riga. Tuttavia il campo `invoice_line_tax_wt_ids` non è a vista nelle view form e tree di linee fattura, impedendo così sia all'utente di impostare manualmente le ritenute, sia al metodo `_default_withholding_tax` di pre-avvalorare il correttamente il campo. Quindi è NECESSARIO avere il campo `invoice_line_tax_wt_ids` a vista.

### Comportamento attuale prima di questa PR:
- le fatture esistenti con ritenute applicate solo a livello di fattura ma non a livello di riga (introdotti negli aggiornamenti a FE 1.6) non presentano nessuna ritenuta nelle righe
- manca a vista il campo `invoice_line_tax_wt_ids` nella tree delle linee fattura
- manca a vista il campo `invoice_line_tax_wt_ids` nella form view delle linee fattura (per chi la usa) 
- manca a vista il campo `withholding_tax_exclude` nella form view delle linee fattura (per chi la usa)
- manca a vista il campo `amount_net_pay` nella tree delle fatture fornitore
- il totale delle ritenute è errato perché è impossibile compilare le ritenute manualmente/automaticamente

### Comportamento desiderato dopo questa PR:
- le fatture esistenti con ritenute vengono correttamente aggiornate aggiungendo le ritenute anche nelle linee
- tutti i campi necessari sono correttamente visualizzati
- il totale delle ritenute è correttamente aggiornato
- fix minori sui nomi delle view

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
