### PR TITLE
[12.0][IMP] l10n_it_account_tax_kind: Hide fields to not italy company

### DIFF
--- a/l10n_it_account_tax_kind/model/account_tax.py
+++ b/l10n_it_account_tax_kind/model/account_tax.py
@@ -4,8 +4,8 @@ from odoo import models, fields
 
 
 class AccountTax(models.Model):
-
-    _inherit = 'account.tax'
+    _name = 'account.tax'
+    _inherit = ['account.tax', 'l10n_it_account.mixin']
 
     kind_id = fields.Many2one('account.tax.kind', string="Exemption Kind")
     law_reference = fields.Char('Law reference')

--- a/l10n_it_account_tax_kind/readme/CONTRIBUTORS.rst
+++ b/l10n_it_account_tax_kind/readme/CONTRIBUTORS.rst
@@ -2,3 +2,7 @@
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Alex Comba <alex.comba@agilebg.com>
 * Gianmarco Conte <gconte@dinamicheaziendali.it>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_account_tax_kind/view/account_tax_view.xml
+++ b/l10n_it_account_tax_kind/view/account_tax_view.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" ?>
 <odoo>
-
     <record id="view_tax_form_account_tax_kind" model="ir.ui.view">
         <field name="name">account.tax.form.account.tax.kind</field>
         <field name="model">account.tax</field>
         <field name="inherit_id" ref="account.view_tax_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='tag_ids']" position="after">
-                <field name="kind_id" />
-                <field name="law_reference" attrs="{'required': [('kind_id', '!=', False),('type_tax_use', '!=', 'purchase')], 'invisible': ['|',('kind_id', '=', False),('type_tax_use', '=', 'purchase')]}"></field>
+                <field name="is_company_it" invisible="1" />
+                <field
+                    name="kind_id"
+                    attrs="{'invisible': [('is_company_it', '=', False)]}"
+                />
+                <field
+                    name="law_reference"
+                    attrs="{'required': [('kind_id', '!=', False),('type_tax_use', '!=', 'purchase')], 'invisible': ['|',('kind_id', '=', False),('type_tax_use', '=', 'purchase')]}"
+                />
             </xpath>
         </field>
     </record>
-
 </odoo>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:
- [ ] `l10n_it_account` https://github.com/OCA/l10n-italy/pull/2011

@Tecnativa TT27569