### PR TITLE
[12.0][IMP] l10n_it_ipa: Hide fields to not italy company

### DIFF
--- a/l10n_it_ipa/model/__init__.py
+++ b/l10n_it_ipa/model/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import l10n_it_ipa_mixin
 from . import partner

--- a/l10n_it_ipa/model/l10n_it_ipa_mixin.py
+++ b/l10n_it_ipa/model/l10n_it_ipa_mixin.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Tecnativa - Víctor Martínez
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from odoo import models, fields
+
+
+class L10nItIpaMixin(models.AbstractModel):
+    _name = 'l10n_it_ipa.mixin'
+    _description = 'l10n_it_ipa Mixin'
+
+    is_company_it = fields.Boolean(
+        compute="_compute_is_company_it"
+    )
+
+    def _compute_is_company_it(self):
+        for record in self:
+            record.is_company_it = False
+            country_it = self.env.ref("base.it")
+            if (
+                (
+                    record.company_id and
+                    record.company_id.country_id == country_it
+                ) or (
+                    not record.company_id and
+                    self.env.user.company_id.country_id == country_it
+                )
+            ):
+                record.is_company_it = True

--- a/l10n_it_ipa/model/partner.py
+++ b/l10n_it_ipa/model/partner.py
@@ -9,7 +9,8 @@ from odoo import models, fields
 
 
 class ResPartner(models.Model):
-    _inherit = 'res.partner'
+    _name = 'res.partner'
+    _inherit = ['res.partner', 'l10n_it_ipa.mixin']
 
     ipa_code = fields.Char(string='IPA Code')
     is_pa = fields.Boolean("Public administration")

--- a/l10n_it_ipa/readme/CONTRIBUTORS.rst
+++ b/l10n_it_ipa/readme/CONTRIBUTORS.rst
@@ -1,3 +1,7 @@
 * Luigi Di Naro <luigi.dinaro@ktec.it>
 * Alex Comba <alex.comba@agilebg.com>
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_ipa/view/partner_view.xml
+++ b/l10n_it_ipa/view/partner_view.xml
@@ -11,7 +11,8 @@
                     <field name="ipa_code" placeholder="IPA123" attrs="{'invisible': [('is_pa','=', False)]}"/>
                 </field>
                 <field name="company_type" position="after">
-                    <div attrs="{'invisible': [('is_company','=', False)]}" class="oe_edit_only">
+                    <field name="is_company_it" invisible="1" />
+                    <div attrs="{'invisible': [('is_company_it','=', False)]}" class="oe_edit_only">
                         <field name="is_pa"/><label for="is_pa"/>
                     </div>
                 </field>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:
- [ ] https://github.com/OCA/server-ux/pull/262 `l10n_multi_country`

@Tecnativa TT27566