### PR TITLE
[12.0][IMP] l10n_it_fiscalcode: Hide fields to not italy company

### DIFF
--- a/l10n_it_fiscalcode/model/__init__.py
+++ b/l10n_it_fiscalcode/model/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import l10n_it_fiscalcode_mixin
 from . import res_partner
 from . import res_city_it_code
 from . import res_company

--- a/l10n_it_fiscalcode/model/l10n_it_fiscalcode_mixin.py
+++ b/l10n_it_fiscalcode/model/l10n_it_fiscalcode_mixin.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Tecnativa - Víctor Martínez
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from odoo import models, fields
+
+
+class L10nItFiscalcodeMixin(models.AbstractModel):
+    _name = 'l10n_it_fiscalcode.mixin'
+    _description = 'l10n_it_fiscalcode Mixin'
+
+    is_company_it = fields.Boolean(
+        compute="_compute_is_company_it"
+    )
+
+    def _compute_is_company_it(self):
+        for record in self:
+            record.is_company_it = False
+            country_it = self.env.ref("base.it")
+            if (
+                (
+                    record.company_id and
+                    record.company_id.country_id == country_it
+                ) or (
+                    not record.company_id and
+                    self.env.user.company_id.country_id == country_it
+                )
+            ):
+                record.is_company_it = True

--- a/l10n_it_fiscalcode/model/res_company.py
+++ b/l10n_it_fiscalcode/model/res_company.py
@@ -6,4 +6,8 @@ from odoo import models, fields
 class ResCompany(models.Model):
     _inherit = 'res.company'
     fiscalcode = fields.Char(
-        related='partner_id.fiscalcode', store=True, readonly=False)
+        related='partner_id.fiscalcode', store=True, readonly=False
+    )
+    country_id_code = fields.Char(
+        related="country_id.code"
+    )

--- a/l10n_it_fiscalcode/model/res_partner.py
+++ b/l10n_it_fiscalcode/model/res_partner.py
@@ -4,7 +4,8 @@ from odoo import models, fields, api
 
 
 class ResPartner(models.Model):
-    _inherit = 'res.partner'
+    _name = 'res.partner'
+    _inherit = ['res.partner', 'l10n_it_fiscalcode.mixin']
 
     @api.multi
     def check_fiscalcode(self):

--- a/l10n_it_fiscalcode/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fiscalcode/readme/CONTRIBUTORS.rst
@@ -10,3 +10,7 @@
 * Andrea Cometa <info@andreacometa.it>
 * Andrea Gallina
 * Matteo Bilotta <mbilotta@linkgroup.it>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_fiscalcode/view/company_view.xml
+++ b/l10n_it_fiscalcode/view/company_view.xml
@@ -6,7 +6,11 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <field name="vat" position="after">
-                <field name="fiscalcode" />
+                <field name="country_id_code" invisible="1" />
+                <field
+                    name="fiscalcode"
+                    attrs="{'invisible': [('country_id_code', '!=', 'IT')]}"
+                />
             </field>
         </field>
     </record>

--- a/l10n_it_fiscalcode/view/fiscalcode_view.xml
+++ b/l10n_it_fiscalcode/view/fiscalcode_view.xml
@@ -6,8 +6,9 @@
         <field name="inherit_id" ref="base_vat.view_partner_form"/>
         <field name="arch" type="xml">
             <field name="type" position="after">
-                <label for="fiscalcode" />
-                <div name="fiscalcode_info" class="o_row">
+                <field name="is_company_it" invisible="1" />
+                <label for="fiscalcode" attrs="{'invisible': [('is_company_it', '=', False)]}" />
+                <div name="fiscalcode_info" attrs="{'invisible': [('is_company_it', '=', False)]}" class="o_row">
                     <field name="fiscalcode" class="oe_inline" />
                 </div>
             </field>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:
- [ ] https://github.com/OCA/server-ux/pull/262 `l10n_multi_country`

@Tecnativa TT27566