### PR TITLE
[12.0][IMP] l10n_it_rea: Hide fields to not italy company

### DIFF
--- a/l10n_it_rea/models/__init__.py
+++ b/l10n_it_rea/models/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
+from . import l10n_it_rea_mixin
 from . import res_partner
 from . import res_company

--- a/l10n_it_rea/models/l10n_it_rea_mixin.py
+++ b/l10n_it_rea/models/l10n_it_rea_mixin.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Tecnativa - Víctor Martínez
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+from odoo import models, fields
+
+
+class L10nItReaMixin(models.AbstractModel):
+    _name = 'l10n_it_rea.mixin'
+    _description = 'l10n_it_rea Mixin'
+
+    is_company_it = fields.Boolean(
+        compute="_compute_is_company_it"
+    )
+
+    def _compute_is_company_it(self):
+        for record in self:
+            record.is_company_it = False
+            country_it = self.env.ref("base.it")
+            if (
+                (
+                    record.company_id and
+                    record.company_id.country_id == country_it
+                ) or (
+                    not record.company_id and
+                    self.env.user.company_id.country_id == country_it
+                )
+            ):
+                record.is_company_it = True

--- a/l10n_it_rea/models/res_company.py
+++ b/l10n_it_rea/models/res_company.py
@@ -25,6 +25,9 @@ class Company(models.Model):
          ('LN', 'Not in liquidation')], 'Liquidation State',
         related='partner_id.rea_liquidation_state',
         store=True, readonly=False)
+    country_id_code = fields.Char(
+        related="country_id.code"
+    )
 
     @api.onchange(
         "rea_office", "rea_code", "rea_capital", "rea_member_type",

--- a/l10n_it_rea/models/res_partner.py
+++ b/l10n_it_rea/models/res_partner.py
@@ -4,7 +4,8 @@ from odoo import fields, models
 
 
 class ResPartner(models.Model):
-    _inherit = 'res.partner'
+    _name = 'res.partner'
+    _inherit = ['res.partner', 'l10n_it_rea.mixin']
 
     rea_office = fields.Many2one(
         'res.country.state', string='Office Province')

--- a/l10n_it_rea/readme/CONTRIBUTORS.rst
+++ b/l10n_it_rea/readme/CONTRIBUTORS.rst
@@ -3,3 +3,7 @@
 * Lorenzo Battistini <https://github.com/eLBati>
 * Andrea Gallina
 * Sergio Zanchetta <https://github.com/primes2h>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_rea/views/company_view.xml
+++ b/l10n_it_rea/views/company_view.xml
@@ -7,7 +7,8 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <notebook position="inside">
-                <page string="REA Data">
+                <field name="country_id_code" invisible="1" />
+                <page string="REA Data" attrs="{'invisible': [('country_id_code', '!=', 'IT')]}">
                     <group>
                         <field name="rea_office" />
                         <field name="rea_code" />

--- a/l10n_it_rea/views/partner_view.xml
+++ b/l10n_it_rea/views/partner_view.xml
@@ -8,7 +8,8 @@
         <field name="arch" type="xml">
             <group name="accounting_entries" position="after">
                 <newline/>
-                <group string="REA Registration" name="rea_data">
+                <field name="is_company_it" invisible="1" />
+                <group string="REA Registration" attrs="{'invisible': [('is_company_it', '=', False)]}" name="rea_data">
                     <field name="rea_office" />
                     <field name="rea_code" />
                     <field name="rea_capital" />


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:
- [ ] https://github.com/OCA/server-ux/pull/262 `l10n_multi_country`

@Tecnativa TT27566