### PR TITLE
[12.0][IMP] l10n_it_fatturapa: Hide fields to not italy company

### DIFF
--- a/l10n_it_fatturapa/models/account.py
+++ b/l10n_it_fatturapa/models/account.py
@@ -262,7 +262,8 @@ class FatturapaRelatedDdt(models.Model):
 
 class AccountInvoiceLine(models.Model):
     # _position = ['2.2.1']
-    _inherit = "account.invoice.line"
+    _name = 'account.invoice.line'
+    _inherit = ['account.invoice.line', 'l10n_it_account.mixin']
 
     related_documents = fields.One2many(
         'fatturapa.related_document_type', 'invoice_line_id',

--- a/l10n_it_fatturapa/models/company.py
+++ b/l10n_it_fatturapa/models/company.py
@@ -110,6 +110,9 @@ class AccountConfigSettings(models.TransientModel):
         default='fatturaordinaria_v1.2.1.xsl',
         readonly=False
         )
+    company_country_id_code = fields.Char(
+        related="company_id.country_id.code"
+    )
 
     @api.onchange('company_id')
     def onchange_company_id(self):

--- a/l10n_it_fatturapa/models/partner.py
+++ b/l10n_it_fatturapa/models/partner.py
@@ -8,7 +8,8 @@ STANDARD_ADDRESSEE_CODE = '0000000'
 
 
 class ResPartner(models.Model):
-    _inherit = "res.partner"
+    _name = 'res.partner'
+    _inherit = ['res.partner', 'l10n_it_account.mixin']
 
     eori_code = fields.Char('EORI Code', size=20)
     license_number = fields.Char('License Code', size=20)

--- a/l10n_it_fatturapa/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fatturapa/readme/CONTRIBUTORS.rst
@@ -5,3 +5,7 @@
 * Sergio Zanchetta <https://github.com/primes2h>
 * Gianluigi Tiesi <https://github.com/sherpya>
 * Roberto Fichera <https://github.com/robyf70>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_fatturapa/views/account_view.xml
+++ b/l10n_it_fatturapa/views/account_view.xml
@@ -10,13 +10,14 @@
             <field name="inherit_id" ref="account.view_invoice_line_form"></field>
             <field name="arch" type="xml">
                 <field name="name" position="after">
+                    <field name="is_company_it" invisible="1" />
                     <separator string="Electronic Invoice"></separator>
-                    <div id="admin_ref">
+                    <div id="admin_ref" attrs="{'invisible': [('is_company_it', '=', False)]}">
                         <group>
                             <field name="admin_ref"/>
                         </group>
                    </div>
-                    <group string="Related Documents">
+                    <group string="Related Documents" attrs="{'invisible': [('is_company_it', '=', False)]}">
                         <field name="related_documents" nolabel="1"/>
                     </group>
                 </field>

--- a/l10n_it_fatturapa/views/company_view.xml
+++ b/l10n_it_fatturapa/views/company_view.xml
@@ -7,68 +7,71 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@id='analytic']" position="after">
-            <h2>Electronic Invoices</h2>
-                <div class="row mt16 o_settings_container" id="fatturapa_settings">
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane"/>
-                        <div class="o_setting_right_pane">
-                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                            <div class="content-group">
-                                <div class="row">
-                                    <label for="fatturapa_fiscal_position_id" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_fiscal_position_id" options="{'no_create': True, 'no_open':True}"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_tax_representative" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_tax_representative"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_stabile_organizzazione" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_stabile_organizzazione"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_sender_partner" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_sender_partner"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_preview_style" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_preview_style"/>
+                <field name="company_country_id_code" invisible="1" />
+                <div attrs="{'invisible': [('company_country_id_code', '!=', 'IT')]}">
+                    <h2>Electronic Invoices</h2>
+                    <div class="row mt16 o_settings_container" id="fatturapa_settings">
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane"/>
+                            <div class="o_setting_right_pane">
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
+                                <div class="content-group">
+                                    <div class="row">
+                                        <label for="fatturapa_fiscal_position_id" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_fiscal_position_id" options="{'no_create': True, 'no_open':True}"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_tax_representative" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_tax_representative"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_stabile_organizzazione" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_stabile_organizzazione"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_sender_partner" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_sender_partner"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_preview_style" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_preview_style"/>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-12 col-lg-6 o_setting_box">
-                        <div class="o_setting_left_pane"/>
-                        <div class="o_setting_right_pane">
-                            <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
-                             <div class="content-group">
-                                <div class="row">
-                                    <label for="fatturapa_art73" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_art73"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_pub_administration_ref" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_pub_administration_ref"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_rea_office" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_rea_office"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_rea_number" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_rea_number"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_rea_capital" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_rea_capital"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_rea_partner" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_rea_partner"/>
-                                </div>
-                                <div class="row">
-                                    <label for="fatturapa_rea_liquidation" class="col-lg-3 o_light_label"/>
-                                    <field name="fatturapa_rea_liquidation"/>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane"/>
+                            <div class="o_setting_right_pane">
+                                <span class="fa fa-lg fa-building-o" title="Values set here are company-specific." aria-label="Values set here are company-specific." groups="base.group_multi_company" role="img"/>
+                                <div class="content-group">
+                                    <div class="row">
+                                        <label for="fatturapa_art73" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_art73"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_pub_administration_ref" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_pub_administration_ref"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_rea_office" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_rea_office"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_rea_number" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_rea_number"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_rea_capital" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_rea_capital"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_rea_partner" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_rea_partner"/>
+                                    </div>
+                                    <div class="row">
+                                        <label for="fatturapa_rea_liquidation" class="col-lg-3 o_light_label"/>
+                                        <field name="fatturapa_rea_liquidation"/>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/l10n_it_fatturapa/views/partner_view.xml
+++ b/l10n_it_fatturapa/views/partner_view.xml
@@ -7,23 +7,29 @@
         <field name="inherit_id" ref="account.view_partner_property_form"/>
         <field name="arch" type="xml">
             <notebook position="inside">
-            <page name="fatturapa" string="Electronic Invoice" groups="account.group_account_invoice">
-                <group name="fatturapa_group">
-                    <label for="electronic_invoice_no_contact_update" attrs="{'invisible': [('supplier', '=', False)]}"/>
-                    <field name="electronic_invoice_no_contact_update" attrs="{'invisible': [('supplier', '=', False)]}"/>
-                    <group>
-                        <field name="electronic_invoice_subjected"/>
-                        <field name="electronic_invoice_obliged_subject" attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}"/>
+                <field name="is_company_it" invisible="1" />
+                <page
+                    name="fatturapa"
+                    string="Electronic Invoice"
+                    attrs="{'invisible': [('is_company_it', '=', False)]}"
+                    groups="account.group_account_invoice"
+                >
+                    <group name="fatturapa_group">
+                        <label for="electronic_invoice_no_contact_update" attrs="{'invisible': [('supplier', '=', False)]}"/>
+                        <field name="electronic_invoice_no_contact_update" attrs="{'invisible': [('supplier', '=', False)]}"/>
+                        <group>
+                            <field name="electronic_invoice_subjected"/>
+                            <field name="electronic_invoice_obliged_subject" attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}"/>
+                        </group>
+                        <group attrs="{'invisible': ['|',('electronic_invoice_subjected', '=', False), ('electronic_invoice_obliged_subject', '=', False)]}">
+                            <field name="ipa_code" placeholder="IPA123" attrs="{'invisible': [('is_pa','=', False)]}"/>
+                            <field name="codice_destinatario" attrs="{'invisible': [('is_pa', '=', True)]}"/>
+                            <field name="pec_destinatario"
+                                attrs="{'invisible': ['|',('is_pa', '=', True), ('codice_destinatario', '!=', '0000000')]}"/>
+                            <field name="eori_code"/>
+                        </group>
                     </group>
-                    <group attrs="{'invisible': ['|',('electronic_invoice_subjected', '=', False), ('electronic_invoice_obliged_subject', '=', False)]}">
-                        <field name="ipa_code" placeholder="IPA123" attrs="{'invisible': [('is_pa','=', False)]}"/>
-                        <field name="codice_destinatario" attrs="{'invisible': [('is_pa', '=', True)]}"/>
-                        <field name="pec_destinatario"
-                               attrs="{'invisible': ['|',('is_pa', '=', True), ('codice_destinatario', '!=', '0000000')]}"/>
-                        <field name="eori_code"/>
-                    </group>
-	        </group>
-            </page>
+                </page>
             </notebook>
         </field>
     </record>
@@ -43,10 +49,11 @@
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='div_address']/../../.." position="after">
+                <field name="is_company_it" invisible="1" />
                 <group string="E-invoicing" name="e_invoice_info" groups="account.group_account_invoice"
                         attrs="{'invisible': ['|', ('type', '=', 'contact'), '|', ('parent.electronic_invoice_subjected', '=', False), ('parent.electronic_invoice_obliged_subject', '=', False)]}">
                     <group>
-                        <field name="electronic_invoice_use_this_address"/>
+                        <field name="electronic_invoice_use_this_address" attrs="{'invisible': [('is_company_it', '=', False)]}"/>
                     </group>
                     <group attrs="{'invisible': [('electronic_invoice_use_this_address','=', False)]}">
                         <field name="ipa_code" placeholder="IPA123" attrs="{'invisible': [('parent.is_pa','=', False)]}"/>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:
- [ ] `l10n_it_account` https://github.com/OCA/l10n-italy/pull/2011

@Tecnativa TT27566