### PR TITLE
[12.0][IMP][l10n_it_ricevute_bancarie] Flag per escludere un partner dalle …

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account/account.py
+++ b/l10n_it_ricevute_bancarie/models/account/account.py
@@ -158,7 +158,8 @@ class AccountInvoice(models.Model):
                 invoice.type != 'out_invoice' or not
                 invoice.payment_term_id or not
                 invoice.payment_term_id.riba or
-                invoice.payment_term_id.riba_payment_cost == 0.0
+                invoice.payment_term_id.riba_payment_cost == 0.0 or
+                invoice.partner_id.commercial_partner_id.riba_exclude_expenses
             ):
                 continue
             if not invoice.company_id.due_cost_service_id:

--- a/l10n_it_ricevute_bancarie/models/partner/partner.py
+++ b/l10n_it_ricevute_bancarie/models/partner/partner.py
@@ -17,3 +17,6 @@ class ResPartner(models.Model):
     group_riba = fields.Boolean(
         "Group C/O",
         help="Group C/O by customer while issuing.")
+    riba_exclude_expenses = fields.Boolean(
+        string="Exclude expenses Ri.Ba."
+    )

--- a/l10n_it_ricevute_bancarie/tests/test_riba.py
+++ b/l10n_it_ricevute_bancarie/tests/test_riba.py
@@ -48,6 +48,17 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         # ---- first due date for partner
         self.assertEqual(len(self.invoice2.invoice_line_ids), 1)
 
+    def test_not_add_due_cost_for_partner_exclude_expense(self):
+        # ---- Set Service in Company Config
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        # ---- Exclude expense for partner
+        self.invoice.partner_id.riba_exclude_expenses = True
+        # ---- Validate Invoice
+        self.invoice.action_invoice_open()
+        # ---- Test Invoice has 1 line, no collection fees added because
+        # ---- the partner is excluded from due costs
+        self.assertEqual(len(self.invoice2.invoice_line_ids), 1)
+
     def test_delete_due_cost_line(self):
         # ---- Set Service in Company Config
         self.invoice.company_id.due_cost_service_id = self.service_due_cost.id

--- a/l10n_it_ricevute_bancarie/views/partner_view.xml
+++ b/l10n_it_ricevute_bancarie/views/partner_view.xml
@@ -12,6 +12,7 @@
         <field name="arch" type="xml">
             <field name="property_payment_term_id" position="after">
                 <field name="group_riba"/>
+                <field name="riba_exclude_expenses"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION

Descrizione del problema o della funzionalità:
Il modulo aggiunge un flag nell'anagrafica del partner per evitare che
gli vengano addebitate spese di emissione riba
Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
