### PR TITLE
[12.0][FIX] ricevute bancarie ASCII instead UTF-8

### DIFF
--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_file_export.py
@@ -286,8 +286,9 @@ class RibaFileExport(models.TransientModel):
             ]
             arrayRiba.append(Riba)
 
-        out = base64.encodestring(
-            self._creaFile(array_testata, arrayRiba).encode("utf8"))
+        out = base64.encodebytes(
+            self._creaFile(array_testata, arrayRiba).encode(
+                'ascii', errors='replace'))
         self.write({
             'state': 'get',
             'riba_txt': out,


### PR DESCRIPTION
Descrizione del problema o della funzionalità: il tracciato esportato viene rifiutato nel caso ci siano caratteri speciali

Comportamento attuale prima di questa PR: l'importazione in home-banking fallisce

Comportamento desiderato dopo questa PR: l'importazione in home-banking riesce




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing