### PR TITLE
12.0-fix-l10n_it_ricevute_bancarie

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account/account.py
+++ b/l10n_it_ricevute_bancarie/models/account/account.py
@@ -177,7 +177,8 @@ class AccountInvoice(models.Model):
             previous_date_due = move_line.mapped('date_maturity')
             pterm = self.env['account.payment.term'].browse(
                 self.payment_term_id.id)
-            pterm_list = pterm.compute(value=1, date_ref=self.date_invoice)
+            pterm_list = pterm.compute(value=invoice.amount_total,
+                                       date_ref=self.date_invoice)
             for pay_date in pterm_list[0]:
                 if not self.month_check(pay_date[0], previous_date_due):
                     # ---- Get Line values for service product


### PR DESCRIPTION
Generate multiple expenses on invoice if the payment term is with multiple due

Descrizione del problema o della funzionalità:


Comportamento attuale prima di questa PR:
Su fattura con termini di pagamento Riba con più scadenze(ad esempio 30/60/90 gg), non venivano create tutte le righe con le spese di incasso.

Comportamento desiderato dopo questa PR:
Le spese multiple relative all'emissione Riba vengono create correttamente in fattura.



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
