### PR TITLE
[12.0] [FIX] l10n_it_fatturapa: Changed inherit for partner related views for a missing reference of field `electronic_invoice_subjected`

### DIFF
--- a/l10n_it_fatturapa/views/partner_view.xml
+++ b/l10n_it_fatturapa/views/partner_view.xml
@@ -1,10 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="view_partner_form_e_inv" model="ir.ui.view">
+        <field name="name">res.partner.form.e.invoice</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='div_address']/../../.." position="after">
+                <group string="E-invoicing" name="e_invoice_info" groups="account.group_account_invoice">
+                    <group>
+                        <field name="electronic_invoice_use_this_address"/>
+                    </group>
+                    <group attrs="{'invisible': [('electronic_invoice_use_this_address','=', False)]}">
+                        <field name="ipa_code" placeholder="IPA123" attrs="{'invisible': [('parent.is_pa','=', False)]}"/>
+                        <field name="codice_destinatario" attrs="{'invisible': [('parent.is_pa', '=', True)]}"/>
+                        <field name="pec_destinatario"
+                               attrs="{'invisible': ['|',('parent.is_pa', '=', True), ('codice_destinatario', '!=', '0000000')]}"/>
+                        <field name="eori_code"/>
+                    </group>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
     <record model="ir.ui.view" id="view_partner_form_fatturapa">
         <field name="name">partner.form.fatturapa</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="account.view_partner_property_form"/>
+        <field name="inherit_id" ref="l10n_it_fatturapa.view_partner_form_e_inv"/>
         <field name="arch" type="xml">
             <notebook position="inside">
             <page name="fatturapa" string="Electronic Invoice" groups="account.group_account_invoice">
@@ -25,6 +47,9 @@
 	        </group>
             </page>
             </notebook>
+            <xpath expr="//group[@name='e_invoice_info']" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('type', '=', 'contact'), '|', ('parent.electronic_invoice_subjected', '=', False), ('parent.electronic_invoice_obliged_subject', '=', False)]}</attribute>
+            </xpath>
         </field>
     </record>
 
@@ -37,26 +62,4 @@
         </field>
     </record>
 
-    <record id="view_partner_form_e_inv" model="ir.ui.view">
-        <field name="name">res.partner.form.e.invoice</field>
-        <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//div[@name='div_address']/../../.." position="after">
-                <group string="E-invoicing" name="e_invoice_info" groups="account.group_account_invoice"
-                        attrs="{'invisible': ['|', ('type', '=', 'contact'), '|', ('parent.electronic_invoice_subjected', '=', False), ('parent.electronic_invoice_obliged_subject', '=', False)]}">
-                    <group>
-                        <field name="electronic_invoice_use_this_address"/>
-                    </group>
-                    <group attrs="{'invisible': [('electronic_invoice_use_this_address','=', False)]}">
-                        <field name="ipa_code" placeholder="IPA123" attrs="{'invisible': [('parent.is_pa','=', False)]}"/>
-                        <field name="codice_destinatario" attrs="{'invisible': [('parent.is_pa', '=', True)]}"/>
-                        <field name="pec_destinatario"
-                               attrs="{'invisible': ['|',('parent.is_pa', '=', True), ('codice_destinatario', '!=', '0000000')]}"/>
-                        <field name="eori_code"/>
-                    </group>
-                </group>
-            </xpath>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
Riferimento alla issue https://github.com/OCA/l10n-italy/issues/2045

Riconosco che la strada più pulita sarebbe stata quella di definire tutto in un'unica vista. Ho deciso di tenere la vista `view_partner_form_e_inv` perché, essendo il modulo di OCA ed essendo legato alla contabilità, è molto probabile che nelle singole installazioni ci siano moduli personalizzati che si agganciano a essa. Per evitare che diversi ambienti potessero rompersi, ho pensato fosse giusto mantenere una certa compatibilità con l'attuale struttura.

Ho solo spostato la sezione in cui viene definito `attrs` così da lasciare ogni vostro xpath esistente ancora valido e funzionante.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
