### PR TITLE
[12.0][FIX] l10n_it_fatturapa_in: Fix error tests in previous chart template load (multi-location)

### DIFF
--- a/l10n_it_fatturapa_in/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fatturapa_in/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
 * Sergio Zanchetta <https://github.com/primes2h>
 * Giovanni Serra <giovanni@gslab.it>
 * Gianmarco Conte <gconte@dinamicheaziendali.it>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_fatturapa_in/tests/fatturapa_common.py
+++ b/l10n_it_fatturapa_in/tests/fatturapa_common.py
@@ -164,9 +164,21 @@ class FatturapaCommon(SingleTransactionCase):
         arrotondamenti_attivi_account_id = self.env['account.account'].\
             search([('user_type_id', '=', self.env.ref(
                 'account.data_account_type_other_income').id)], limit=1).id
-        arrotondamenti_passivi_account_id = self.env['account.account'].\
-            search([('user_type_id', '=', self.env.ref(
-                'account.data_account_type_direct_costs').id)], limit=1).id
+        # Fix try to get account data if previous addons not account chart template init
+        domain = [
+            (
+                'user_type_id', '=', self.env.ref(
+                    'account.data_account_type_direct_costs'
+                ).id
+            )
+        ]
+        total = self.env['account.account'].search_count(domain)
+        if total > 0:
+            arrotondamenti_passivi_account_id = self.env[
+                'account.account'
+            ].search(domain, limit=1).id
+        else:
+            arrotondamenti_passivi_account_id = arrotondamenti_attivi_account_id
         arrotondamenti_tax_id = self.env['account.tax'].search(
             [('type_tax_use', '=', 'purchase'),
              ('amount', '=', 0.0)], order='sequence', limit=1)


### PR DESCRIPTION
Tests about it work fine but if is installed with other addons (`l10n_es_vat_book` for example) appear errors in test because other addon load account chart template and not exist accounts related to some types.
Although isn't a very good solution it's a fast fix.

IMO a good solution it's very difficult because will need to use a base test that auto-install itally account chart template and prevent errors in tests BUT affect to almost all addons to `l10n-italy`.

@Tecnativa TT26985