### PR TITLE
[12.0][IMP] l10n_it_withholding_tax: Hide fields to not italy company

### DIFF
--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -285,7 +285,7 @@ class AccountAbstractPayment(models.AbstractModel):
 
 
 class AccountMoveLine(models.Model):
-    _inherit = "account.move.line"
+    _inherit = ['account.move.line', 'l10n_it_account.mixin']
 
     withholding_tax_id = fields.Many2one(
         'withholding.tax', string='Withholding Tax')
@@ -356,7 +356,7 @@ class AccountReconciliation(models.AbstractModel):
 
 
 class AccountFiscalPosition(models.Model):
-    _inherit = "account.fiscal.position"
+    _inherit = ['account.fiscal.position', 'l10n_it_account.mixin']
 
     withholding_tax_ids = fields.Many2many(
         'withholding.tax', 'account_fiscal_position_withholding_tax_rel',
@@ -364,7 +364,7 @@ class AccountFiscalPosition(models.Model):
 
 
 class AccountInvoice(models.Model):
-    _inherit = "account.invoice"
+    _inherit = ['account.invoice', 'l10n_it_account.mixin']
 
     @api.multi
     @api.depends(
@@ -541,7 +541,7 @@ class AccountInvoice(models.Model):
 
 
 class AccountInvoiceLine(models.Model):
-    _inherit = "account.invoice.line"
+    _inherit = ['account.invoice.line', 'l10n_it_account.mixin']
 
     @api.model
     def _default_withholding_tax(self):

--- a/l10n_it_withholding_tax/readme/CONTRIBUTORS.rst
+++ b/l10n_it_withholding_tax/readme/CONTRIBUTORS.rst
@@ -1,2 +1,6 @@
 * Alessandro Camilli <alessandrocamilli@openforce.it>
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_withholding_tax/views/account.xml
+++ b/l10n_it_withholding_tax/views/account.xml
@@ -19,26 +19,30 @@
                 </xpath>
 
                 <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='invoice_line_tax_ids']" position="after">
-                    <field name="invoice_line_tax_wt_ids" widget="many2many_tags" options="{'no_create': True}"/>
+                    <field name="is_company_it" invisible="1" />
+                    <field name="invoice_line_tax_wt_ids" widget="many2many_tags" options="{'no_create': True}" attrs="{'invisible': [('is_company_it', '=', False)]}"/>
                 </xpath>
 
                 <xpath expr="//page/field[@name='tax_line_ids']" position="after">
                     <field name="withholding_tax_line_ids" attrs="{'invisible': [('withholding_tax', '=', False)]}">
                         <tree>
-                            <field name="withholding_tax_id"/>
+                            <field name="is_company_it" invisible="1" />
+                            <field name="withholding_tax_id" attrs="{'invisible': [('is_company_it', '=', False)]}"/>
                             <field name="base"/>
                             <field name="tax"/>
                         </tree>
                         <form>
                             <group colspan="2">
-                                <field name="withholding_tax_id" />
+                                <field name="is_company_it" invisible="1" />
+                                <field name="withholding_tax_id" attrs="{'invisible': [('is_company_it', '=', False)]}" />
                                 <field name="base"/>
                                 <field name="tax"/>
                             </group>
                         </form>
 
                         <tree  editable="bottom" string="Withholding Taxes">
-                            <field name="withholding_tax_id"/>
+                            <field name="is_company_it" invisible="1" />
+                            <field name="withholding_tax_id" attrs="{'invisible': [('is_company_it', '=', False)]}"/>
                             <field name="base"/>
                             <field name="tax"/>
                         </tree>
@@ -84,20 +88,23 @@
                 <xpath expr="//group/div/field[@name='tax_line_ids']" position="after">
                     <field name="withholding_tax_line_ids" attrs="{'invisible': [('withholding_tax', '=', False)]}">
                         <tree>
-                            <field name="withholding_tax_id"/>
+                            <field name="is_company_it" invisible="1" />
+                            <field name="withholding_tax_id" attrs="{'invisible': [('is_company_it', '=', False)]}"/>
                             <field name="base"/>
                             <field name="tax"/>
                         </tree>
                         <form>
                             <group colspan="2">
-                                <field name="withholding_tax_id" />
+                                <field name="is_company_it" invisible="1" />
+                                <field name="withholding_tax_id" attrs="{'invisible': [('is_company_it', '=', False)]}" />
                                 <field name="base"/>
                                 <field name="tax"/>
                             </group>
                         </form>
 
                         <tree  editable="bottom" string="Withholding Taxes">
-                            <field name="withholding_tax_id"/>
+                            <field name="is_company_it" invisible="1" />
+                            <field name="withholding_tax_id" attrs="{'invisible': [('is_company_it', '=', False)]}"/>
                             <field name="base"/>
                             <field name="tax"/>
                         </tree>
@@ -106,7 +113,7 @@
                 </xpath>
 
                 <xpath expr="//group[hasclass('oe_subtotal_footer', 'oe_right')]/field[@name='amount_total']" position="after">
-                    <field name="withholding_tax_amount" widget="monetary" options="{'currency_field': 'currency_id'}" 
+                    <field name="withholding_tax_amount" widget="monetary" options="{'currency_field': 'currency_id'}"
                         attrs="{'invisible': [('withholding_tax', '=', False)]}"/>
                     <field name="amount_net_pay" widget="monetary" options="{'currency_field': 'currency_id'}" class="oe_subtotal_footer_separator"
                         attrs="{'invisible': [('withholding_tax', '=', False)]}"/>
@@ -158,7 +165,8 @@
             <field name="arch" type="xml">
 
                 <xpath expr="//page[@name='account_mapping']" position="after">
-                    <page name="account_withholding_tax" string="Withholding Tax">
+                    <field name="is_company_it" invisible="1" />
+                    <page name="account_withholding_tax" string="Withholding Tax" attrs="{'invisible': [('is_company_it', '=', False)]}">
                         <field name="withholding_tax_ids" nolabel="1">
                             <tree editable="bottom">
                                 <field name="name"/>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:

- [ ] `l10n_it_fatturapa` https://github.com/OCA/l10n-italy/pull/2021

@Tecnativa TT27793