### PR TITLE
[12.0][IMP] l10n_it_fatturapa_in: Hide fields to not italy company

### DIFF
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -6,7 +6,7 @@ import odoo.addons.decimal_precision as dp
 
 
 class AccountInvoice(models.Model):
-    _inherit = "account.invoice"
+    _inherit = ['account.invoice', 'l10n_it_account.mixin']
 
     fatturapa_attachment_in_id = fields.Many2one(
         'fatturapa.attachment.in', 'E-bill Import File',

--- a/l10n_it_fatturapa_in/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fatturapa_in/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
 * Sergio Zanchetta <https://github.com/primes2h>
 * Giovanni Serra <giovanni@gslab.it>
 * Gianmarco Conte <gconte@dinamicheaziendali.it>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_fatturapa_in/views/account_view.xml
+++ b/l10n_it_fatturapa_in/views/account_view.xml
@@ -126,31 +126,32 @@
             </xpath>
             <field name="partner_id" position="after">
                 <field name="electronic_invoice_subjected" invisible="1"/>
-                <field name="tax_representative_id" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
-                <field name="intermediary" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
+                <field name="tax_representative_id" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False),('is_company_it', '=', False)]}"></field>
+                <field name="intermediary" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False),('is_company_it', '=', False)]}"></field>
             </field>
             <field name="date_invoice" position="before">
-                <field name="sender" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
-                <field name="protocol_number" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
-                <field name="e_invoice_received_date" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}"></field>
+                <field name="sender" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False),('is_company_it', '=', False)]}"></field>
+                <field name="protocol_number" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False),('is_company_it', '=', False)]}"></field>
+                <field name="e_invoice_received_date" readonly="1" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False),('is_company_it', '=', False)]}"></field>
             </field>
             <field name="price_unit" position="before">
+                <field name="is_company_it" invisible="1" />
                 <field name="fatturapa_attachment_in_id" invisible="1"/>
             </field>
             <field name="analytic_tag_ids" position="after">
-                <field name="admin_ref"/>
+                <field name="admin_ref" attrs="{'invisible': [('is_company_it', '=', False)]}"/>
             </field>
             <field name="amount_tax" position="after">
-                <field name="efatt_rounding" widget="monetary" attrs="{'invisible': [('efatt_rounding', '=', 0)]}"/>
+                <field name="efatt_rounding" widget="monetary" attrs="{'invisible': [('efatt_rounding', '=', 0),('is_company_it', '=', False)]}"/>
             </field>
             <xpath expr="//notebook" position="inside">
-                <page string="E-bill Inconsistencies" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}">
+                <page string="E-bill Inconsistencies" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False),('is_company_it', '=', False)]}">
                     <group>
                         <field name="e_invoice_force_validation" attrs="{'invisible': [('e_invoice_validation_error','=',False)]}"/>
                     </group>
                     <field name="inconsistencies" nolabel="1" colspan="4" readonly="1"></field>
                 </page>
-                <page string="E-bill Details" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False)]}">
+                <page string="E-bill Details" attrs="{'invisible': [('fatturapa_attachment_in_id', '=', False),('is_company_it', '=', False)]}">
                     <group>
                         <group string="Amount Summary">
                             <field name="e_invoice_amount_untaxed"/>
@@ -333,7 +334,8 @@
                 </page>
             </xpath>
             <field name="move_id" position="after">
-                <field name="fatturapa_attachment_in_id" attrs="{'readonly': [('state', 'not in', ('draft'))]}"></field>
+                <field name="fatturapa_attachment_in_id" attrs="{'readonly': [('state', 'not in', ('draft'))], 'invisible': [('is_company_it', '=', False)]}"></field>
+                <field name="is_company_it" invisible="1" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:

- [ ] `l10n_it_fatturapa` https://github.com/OCA/l10n-italy/pull/2021

@Tecnativa TT27779