### PR TITLE
[12.0][IMP] l10n_it_fatturapa_out: Hide fields to not italy company

### DIFF
--- a/l10n_it_fatturapa_out/models/account.py
+++ b/l10n_it_fatturapa_out/models/account.py
@@ -8,7 +8,7 @@ from odoo.tools.translate import _
 
 
 class AccountInvoice(models.Model):
-    _inherit = "account.invoice"
+    _inherit = ['account.invoice', 'l10n_it_account.mixin']
 
     fatturapa_attachment_out_id = fields.Many2one(
         'fatturapa.attachment.out', 'E-invoice Export File',

--- a/l10n_it_fatturapa_out/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fatturapa_out/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
 * Alessio Gerace
 * Alex Comba
 * Sergio Zanchetta <https://github.com/primes2h>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez

--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -9,9 +9,10 @@
             <button name="preview_invoice" position="before">
                 <button name="%(action_wizard_export_fatturapa)d" type="action"
                         string="Export E-invoice" class="oe_highlight"
-                        attrs="{'invisible': ['|', '|', ('fatturapa_attachment_out_id', '!=', False), ('state' ,'not in', ['open', 'paid']), ('electronic_invoice_subjected', '=', False)]}"/>
+                        attrs="{'invisible': ['|', '|', '|', ('is_company_it', '=', False), ('fatturapa_attachment_out_id', '!=', False), ('state' ,'not in', ['open', 'paid']), ('electronic_invoice_subjected', '=', False)]}"/>
             </button>
             <field name="partner_id" position="after">
+                 <field name="is_company_it" invisible="1" />
                 <field name="electronic_invoice_subjected" invisible="1"/>
             </field>
             <field name="analytic_tag_ids" position="after">
@@ -19,7 +20,7 @@
             </field>
             <xpath expr="//notebook" position="inside">
                 <page string="Related Documents"
-                      attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}">
+                      attrs="{'invisible': [('electronic_invoice_subjected', '=', False),('is_company_it', '=', False)]}">
                     <group string="Related Documents">
                         <field name="related_documents" nolabel="1">
                             <tree editable="bottom" string="Related Documents">
@@ -37,7 +38,8 @@
                 </page>
                 <page string="Electronic Invoice"
                     attrs="{'invisible': [('electronic_invoice_subjected', '=', False),
-                                          ('fatturapa_attachment_out_id', '=', False)]}">
+                                          ('fatturapa_attachment_out_id', '=', False),
+                                          ('is_company_it', '=', False)]}">
                     <group>
                         <group string="Results">
                             <field name="fatturapa_attachment_out_id"/>
@@ -48,7 +50,8 @@
                 </page>
                 <page string="Electronic Invoice Attachments"
                     attrs="{'invisible': [('electronic_invoice_subjected', '=', False),
-                                          ('fatturapa_attachment_out_id', '=', False)]}">
+                                          ('fatturapa_attachment_out_id', '=', False),
+                                          ('is_company_it', '=', False)]}">
                     <group string="Attachments">
                         <field name="fatturapa_doc_attachments" nolabel="1" >
                             <tree string="Attachments">

--- a/l10n_it_fatturapa_out/views/partner_view.xml
+++ b/l10n_it_fatturapa_out/views/partner_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="l10n_it_fatturapa.view_partner_form_fatturapa"/>
         <field name="arch" type="xml">
             <field name="ipa_code" position="before">
-                <field name="max_invoice_in_xml"/>
+                <field name="max_invoice_in_xml" attrs="{'invisible': [('is_company_it', '=', False)]}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
This is for hiding specific Italian fields when using these modules in a multi-localization DB and being logged in a non-Italian company.

Issue: https://github.com/OCA/l10n-italy/issues/2053

Locked by:

- [ ] `l10n_it_fatturapa` https://github.com/OCA/l10n-italy/pull/2021

@Tecnativa TT27780