### PR TITLE
[10.0][FIX] l10n_it_intrastat: campo Paese di pagamento errato

### DIFF
--- a/l10n_it_intrastat/models/account.py
+++ b/l10n_it_intrastat/models/account.py
@@ -86,10 +86,14 @@ class AccountInvoiceLine(models.Model):
         country_payment_id = self.env['res.country'].browse()
         if self.invoice_id.type in ('out_invoice', 'out_refund'):
             country_payment_id = \
-                self.invoice_id.partner_id.country_id
+                self.invoice_id.company_id.partner_id.country_id
+            if self.invoice_id.partner_bank_id:
+                country_id = self.invoice_id.partner_bank_id.bank_id.country
+                if country_id:
+                    country_payment_id = country_id
         elif self.invoice_id.type in ('in_invoice', 'in_refund'):
             country_payment_id = \
-                self.invoice_id.company_id.partner_id.country_id
+                self.invoice_id.partner_id.country_id
         res.update({
             'country_payment_id': country_payment_id.id})
 


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Issue [https://github.com/OCA/l10n-italy/issues/2058](https://github.com/OCA/l10n-italy/issues/2058)

Comportamento attuale prima di questa PR:
Il campo Paese di pagamento viene valorizzato con il paese del cliente.

Comportamento desiderato dopo questa PR:
Il campo Paese di pagamento viene valorizzato con il paese del fornitore (o il paese dove ha sede il conto corrente bancario che viene coinvolto nella transazione oggetto di comunicazione).



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
