### PR TITLE
[8.0] [FIX] add FatturaBody.DatiGenerali.DatiGeneraliDocumento.Numero to supplier_invoice_number field

### DIFF
--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -24,6 +24,7 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.assertEqual(
             invoice.partner_id.register_fiscalpos.code, 'RF02')
         self.assertEqual(invoice.reference, 'FT/2015/0006')
+        self.assertEqual(invoice.supplier_invoice_number, 'FT/2015/0006')
         self.assertEqual(invoice.amount_total, 57.00)
         self.assertEqual(invoice.gross_weight, 0.00)
         self.assertEqual(invoice.net_weight, 0.00)

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1012,6 +1012,11 @@ class WizardImportFatturapa(models.TransientModel):
                 'reference':
                     FatturaBody.DatiGenerali.DatiGeneraliDocumento.Numero,
             })
+        if not invoice.supplier_invoice_number:
+            invoice.update({
+                'supplier_invoice_number':
+                    FatturaBody.DatiGenerali.DatiGeneraliDocumento.Numero,
+            })
 
     def set_parent_invoice_data(self, FatturaBody, invoice):
         ParentInvoice = FatturaBody.DatiGenerali.FatturaPrincipale


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
in questo commit https://github.com/OCA/l10n-italy/commit/269e9185157deda3cfcdd564287b1ebdea76233f#diff-6e5ecab00b3a56c79037d98b3df6bd889ed412107f1da64933a8cfbb3ee5fc59 è stato cambiato il campo che porta l'informazione di **FatturaBody.DatiGenerali.DatiGeneraliDocumento.Numero** da **supplier_invoice_number** a **reference** in fase di import della fattura elettronica, ma dal punto di vista funzionale è più corretto che l'informazione rimanga in **supplier_invoice_number**.

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:
in fase di import di fattura elettronica verrà valorizzato il campo **supplier_invoice_number** con l'informazione di **FatturaBody.DatiGenerali.DatiGeneraliDocumento.Numero** 




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
