### PR TITLE
[12.0] [FIX] l10n_it_fatturapa_in: unset date_invoice caused date_due being based on today

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -960,12 +960,12 @@ class WizardImportFatturapa(models.TransientModel):
         self.set_welfares_fund(
             FatturaBody, credit_account_id, invoice, wt_founds)
 
+        self.set_vendor_bill_data(FatturaBody, invoice)
+
         invoice._onchange_invoice_line_wt_ids()
         invoice._onchange_payment_term_date_invoice()
         invoice.write(invoice._convert_to_write(invoice._cache))
         invoice_id = invoice.id
-
-        self.set_vendor_bill_data(FatturaBody, invoice)
 
         rel_docs_dict = {
             # 2.1.2


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Il mancato settaggio della date_invoice fa sì che la date_due sia basata a partire da oggi in base alle scadenze, invece che a partire dalla data fattura

Comportamento attuale prima di questa PR:
Data scandenza fattura era oggi + termini di pagamento

Comportamento desiderato dopo questa PR:
Data scandenza fattura è data fattuta (date_invoice) + termini di pagamento



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
