### PR TITLE
[12.0][FIX] forbid set to draft of self invoice with vendor invoice linked not cancelled

### DIFF
--- a/l10n_it_fatturapa_out_rc/models/account_invoice.py
+++ b/l10n_it_fatturapa_out_rc/models/account_invoice.py
@@ -1,4 +1,5 @@
-from odoo import models
+from odoo import api, models, _
+from odoo.exceptions import UserError
 
 
 class Invoice(models.Model):
@@ -23,3 +24,16 @@ class Invoice(models.Model):
                 })
             ]
         return res
+
+    @api.multi
+    def action_invoice_draft(self):
+        super().action_invoice_draft()
+        for inv in self:
+            if not inv.env.context.get("rc_set_to_draft") and \
+                    inv.rc_purchase_invoice_id.state in ['draft', 'cancel']:
+                raise UserError(_(
+                    "Vendor invoice that has generated this self invoice isn't "
+                    "validated. "
+                    "Validate vendor invoice before."
+                ))
+        return True

--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -486,9 +486,10 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def action_invoice_draft(self):
-        super(AccountInvoice, self).action_invoice_draft()
-        invoice_model = self.env['account.invoice']
-        for inv in self:
+        new_self = self.with_context(rc_set_to_draft=True)
+        super(AccountInvoice, new_self).action_invoice_draft()
+        invoice_model = new_self.env['account.invoice']
+        for inv in new_self:
             if inv.rc_self_invoice_id:
                 self_invoice = invoice_model.browse(
                     inv.rc_self_invoice_id.id)


### PR DESCRIPTION
Descrizione del problema o della funzionalità: è possibile validare un'autofattura che ha una fattura fornitore collegata in stato bozza.

Comportamento attuale prima di questa PR: la fattura fornitore va in stato annullato ma non è possibile rivalidarla in quanto tenta di reimpostare a bozza l'autofattura con xml già inviato

Comportamento desiderato dopo questa PR: la fattura non viene validata, segnalando all'utente che deve validare prima la fattura del fornitore che ha generato l'autofattura




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing