### PR TITLE
[12.0] [ADD] l10n_it_delivery_note: gross_weight and net_weight computation from pickings

### DIFF
--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -144,6 +144,9 @@ class StockDeliveryNote(models.Model):
                                     domain=_domain_volume_uom,
                                     states=DONE_READONLY_STATE)
     gross_weight = fields.Float(string="Gross weight",
+                                store=True,
+                                readonly=False,
+                                compute='_compute_weights',
                                 states=DONE_READONLY_STATE)
     gross_weight_uom_id = fields.Many2one('uom.uom',
                                           string="Gross weight UoM",
@@ -151,6 +154,9 @@ class StockDeliveryNote(models.Model):
                                           domain=_domain_weight_uom,
                                           states=DONE_READONLY_STATE)
     net_weight = fields.Float(string="Net weight",
+                              store=True,
+                              readonly=False,
+                              compute='_compute_weights',
                               states=DONE_READONLY_STATE)
     net_weight_uom_id = fields.Many2one('uom.uom',
                                         string="Net weight UoM",
@@ -260,6 +266,30 @@ class StockDeliveryNote(models.Model):
     def _compute_get_pickings(self):
         for note in self:
             note.pickings_picker = note.picking_ids
+
+    @api.multi
+    @api.depends('picking_ids')
+    def _compute_weights(self):
+        for note in self:
+            if note.picking_ids:
+                # fill gross & net weight from pickings
+                gross_weight = net_weight = 0.0
+                # this is the unit used for shipping_weight
+                weight_uom = self.env['product.template']\
+                    ._get_weight_uom_id_from_ir_config_parameter()
+                for pick in note.picking_ids:
+                    gross_weight += weight_uom._compute_quantity(
+                        pick.shipping_weight,
+                        note.gross_weight_uom_id)
+                    net_weight += weight_uom._compute_quantity(
+                        pick.shipping_weight,
+                        note.net_weight_uom_id)
+                note.gross_weight = gross_weight
+                note.net_weight = net_weight
+
+    @api.onchange('picking_ids')
+    def _onchange_picking_ids(self):
+        self._compute_weights()
 
     @api.multi
     def _inverse_set_pickings(self):


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Il modulo delivery aggiunge il calcolo del shipping_weight nei picking, ma nel DDT non viene riportato

Comportamento attuale prima di questa PR:
I campi peso netto/lordo rimangono a 0
Comportamento desiderato dopo questa PR:
I campi peso netto/lordo sono popolati da valori calcolati in base al shipping_weight dei picking.



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
