### PR TITLE
[12.0][FIX] l10n_it_fatturapa_sale: field permissions

### DIFF
--- a/l10n_it_fatturapa_sale/models/sale_order.py
+++ b/l10n_it_fatturapa_sale/models/sale_order.py
@@ -12,7 +12,7 @@ class SaleOrder (models.Model):
         inverse_name='sale_order_id',
         string='Related Documents',
         copy=False,
-        groups="account.group_account_user",
+        groups="account.group_account_user,sales_team.group_sale_salesman",
     )
 
     @api.multi

--- a/l10n_it_fatturapa_sale/models/sale_order_line.py
+++ b/l10n_it_fatturapa_sale/models/sale_order_line.py
@@ -12,13 +12,13 @@ class SaleOrderLine(models.Model):
         inverse_name='sale_order_line_id',
         string='Related Documents',
         copy=False,
-        groups="account.group_account_user",
+        groups="account.group_account_user,sales_team.group_sale_salesman",
     )
     admin_ref = fields.Char(
         string="Admin. ref.",
         size=20,
         copy=False,
-        groups="account.group_account_user",
+        groups="account.group_account_user,sales_team.group_sale_salesman",
     )
 
     @api.multi


### PR DESCRIPTION
Added fields groups set to "sales_team.group_sale_salesman" instead of
"account.group_account_user".

Descrizione del problema o della funzionalità:
La creazione di una fattura da ordine di vendita con l10n_it_fatturapa_sale installato fallisce da parte di utenti con permessi di Fatturazione ma non Responsabile Fatturazione. Allineato con permessi simili.

Ditemi se è il caso di creare anche la issue o se basta così.


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
