### PR TITLE
[12.0][FIX] generazione fattura normale senza rc con posizione fiscale con rc

### DIFF
--- a/l10n_it_fatturapa_out_rc/models/account_invoice.py
+++ b/l10n_it_fatturapa_out_rc/models/account_invoice.py
@@ -6,19 +6,20 @@ class Invoice(models.Model):
 
     def generate_self_invoice(self):
         res = super(Invoice, self).generate_self_invoice()
-        rc_type = self.fiscal_position_id.rc_type_id
-        if rc_type.fiscal_document_type_id:
-            self.rc_self_invoice_id.fiscal_document_type_id =\
-                rc_type.fiscal_document_type_id.id
-        if self.fatturapa_attachment_in_id:
-            doc_id = self.fatturapa_attachment_in_id.name
-        else:
-            doc_id = self.reference if self.reference else self.number
-        self.rc_self_invoice_id.related_documents = [
-            (0, 0, {
-                "type": "invoice",
-                "name": doc_id,
-                "date": self.date_invoice,
-            })
-        ]
+        if self.rc_self_invoice_id:
+            rc_type = self.fiscal_position_id.rc_type_id
+            if rc_type.fiscal_document_type_id:
+                self.rc_self_invoice_id.fiscal_document_type_id =\
+                    rc_type.fiscal_document_type_id.id
+            if self.fatturapa_attachment_in_id:
+                doc_id = self.fatturapa_attachment_in_id.name
+            else:
+                doc_id = self.reference if self.reference else self.number
+            self.rc_self_invoice_id.related_documents = [
+                (0, 0, {
+                    "type": "invoice",
+                    "name": doc_id,
+                    "date": self.date_invoice,
+                })
+            ]
         return res


### PR DESCRIPTION
Descrizione del problema o della funzionalità: una posizione fiscale non può essere usata per emettere fatture normali e con rc contemporaneamente

Comportamento attuale prima di questa PR: bisogna modificare la pos.fiscale al volo ogni volta

Comportamento desiderato dopo questa PR: la pos. fiscale viene usata correttamente




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing