### PR TITLE
[8.0][FIX] account.account deprecated no more exist

### DIFF
--- a/l10n_it_fatturapa_in/models/company.py
+++ b/l10n_it_fatturapa_in/models/company.py
@@ -18,12 +18,10 @@ class ResCompany(models.Model):
 
     arrotondamenti_attivi_account_id = fields.Many2one(
         'account.account', 'Round Up Account',
-        domain=[('deprecated', '=', False)],
         help="Account used to round up bills amount."
     )
     arrotondamenti_passivi_account_id = fields.Many2one(
         'account.account', 'Round Down Account',
-        domain=[('deprecated', '=', False)],
         help="Account used to round down bills amount."
     )
     arrotondamenti_tax_id = fields.Many2one(


### PR DESCRIPTION
Il campo `deprecated` nell'oggetto `account.account` non esiste, per cui quando si va a selezionare un conto per l'arrotondamento nelle impostazioni della fattura elettronica viene generato questo errore: `ValueError: Invalid field 'deprecated' in leaf "<osv.ExtendedLeaf: ('deprecated', '=', False) on account_account (ctx: )>"`