### PR TITLE
[12.0][IMP] l'onchange non dovrebbe cambiare una banca valida già impostata

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account/account.py
+++ b/l10n_it_ricevute_bancarie/models/account/account.py
@@ -154,13 +154,15 @@ class AccountInvoice(models.Model):
 
     @api.onchange('partner_id', 'payment_term_id', 'type')
     def _onchange_riba_partner_bank_id(self):
-        bank_id = None
-        if (
-            self.partner_id and self.payment_term_id.riba
-            and self.type == 'out_invoice'
-        ):
-            bank_id = self.partner_id.mapped('bank_ids')
-        self.riba_partner_bank_id = bank_id[0] if bank_id else None
+        if not self.riba_partner_bank_id or \
+                self.riba_partner_bank_id not in self.partner_id.bank_ids:
+            bank_id = None
+            if (
+                self.partner_id and self.payment_term_id.riba
+                and self.type == 'out_invoice'
+            ):
+                bank_id = self.partner_id.mapped('bank_ids')
+            self.riba_partner_bank_id = bank_id[0] if bank_id else None
 
     def month_check(self, invoice_date_due, all_date_due):
         """


### PR DESCRIPTION
Descrizione del problema o della funzionalità: cambiando il termine di pagamento, se c'è già una banca di appoggio riba selezionata valida, viene comunque cambiata

Comportamento attuale prima di questa PR: la banca viene cambiata

Comportamento desiderato dopo questa PR: la banca non viene cambiata




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing