### PR TITLE
[12.0][FIX] l10n_it_account_stamp: Adapt to multi-company (multi-location)

### DIFF
--- a/l10n_it_account_stamp/readme/CONTRIBUTORS.rst
+++ b/l10n_it_account_stamp/readme/CONTRIBUTORS.rst
@@ -3,3 +3,7 @@
 * Ermanno Gnan
 * Enrico Ganzaroli
 * Sergio Zanchetta <https://github.com/primes2h>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Víctor Martínez


### PR DESCRIPTION
Adapt to multi-company (multi-location)

Although i had  try to create tests to check it it's very difficult because don't exist some `it_account_base` (similar to [`l10n_es_aeat`](https://github.com/OCA/l10n-spain/tree/12.0/l10n_es_aeat)) because is need to: 
- create new company
- assign chart template
- create journals
- create taxes
- create products
 and IMO add much code that it's not necessary only for these addon.

Please @pedrobaeza  can you review it?

@Tecnativa TT28019