### PR TITLE
[12.0] Allow to cancel (and re-generate) invoice when e-invoice is in error state

### DIFF
--- a/l10n_it_fatturapa_out/models/account.py
+++ b/l10n_it_fatturapa_out/models/account.py
@@ -25,7 +25,10 @@ class AccountInvoice(models.Model):
     @api.multi
     def action_invoice_cancel(self):
         for invoice in self:
-            if invoice.fatturapa_attachment_out_id:
+            if (
+                invoice.fatturapa_attachment_out_id and
+                not self.env.context.get("skip_e_invoice_cancel_check")
+            ):
                 raise UserError(_(
                     "Invoice %s has XML and can't be canceled. "
                     "Delete the XML before."

--- a/l10n_it_fatturapa_pec/models/account.py
+++ b/l10n_it_fatturapa_pec/models/account.py
@@ -36,3 +36,13 @@ class AccountInvoice(models.Model):
         for record in self:
             record.fatturapa_state = fatturapa_attachment_state_mapping.get(
                 record.fatturapa_attachment_out_id.state)
+
+    @api.multi
+    def action_invoice_cancel(self):
+        for invoice in self:
+            if invoice.fatturapa_state == "error":
+                res = super(AccountInvoice, invoice.with_context(
+                    skip_e_invoice_cancel_check=True)).action_invoice_cancel()
+            else:
+                res = super(AccountInvoice, invoice).action_invoice_cancel()
+        return res

--- a/l10n_it_fatturapa_pec/tests/test_e_invoice_send.py
+++ b/l10n_it_fatturapa_pec/tests/test_e_invoice_send.py
@@ -92,11 +92,25 @@ class TestEInvoiceSend(EInvoiceCommon):
         # Set the e_invoice to error
         e_invoice.state = 'sender_error'
 
-        # We can reset e-invoice whose state is 'sender_error'
-        e_invoice.reset_to_ready()
+        wizard.with_context(active_id=invoice.id).\
+            exportFatturaPARegenerate()
+        self.assertEqual(e_invoice.state, "ready")
+
+        with self.assertRaises(UserError):
+            invoice.action_invoice_cancel()
+
+        e_invoice.state = 'sender_error'
+        invoice.journal_id.update_posted = True
+        invoice.action_invoice_cancel()
+        invoice.refresh()
+        invoice.action_invoice_draft()
+        invoice.refresh()
+        invoice.action_invoice_open()
+        invoice.refresh()
 
         action = wizard.with_context(active_id=invoice.id).\
             exportFatturaPARegenerate()
+
         e_invoice = self.env[action['res_model']].browse(action['res_id'])
 
         # set SDI address after first sending

--- a/l10n_it_fatturapa_pec/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_pec/wizard/wizard_export_fatturapa.py
@@ -26,6 +26,7 @@ class WizardExportFatturapa(models.TransientModel):
         fatturapaBDS.reset()
         attach.write({
             'datas': base64.encodestring(attach_str),
+            'state': 'ready',
         })
 
     def exportFatturaPARegenerate(self):


### PR DESCRIPTION
Comportamento attuale prima di questa PR:

Esportare un XML con un errore, ad esempio un errore di calcolo IVA.
Inviarlo a SDI e ottenere la notifica di scarto.
Non è possibile ri-generare l'XML senza prima eliminarlo

Comportamento desiderato dopo questa PR:

È possibile annullare la fattura, modificarle e ri-generare l'XML senza eilminarlo.


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
