### PR TITLE
[12.0] l10n_it_intrastat: campo Paese di pagamento errato

### DIFF
--- a/l10n_it_intrastat/models/account.py
+++ b/l10n_it_intrastat/models/account.py
@@ -85,10 +85,14 @@ class AccountInvoiceLine(models.Model):
         country_payment_id = self.env['res.country'].browse()
         if self.invoice_id.type in ('out_invoice', 'out_refund'):
             country_payment_id = \
-                self.invoice_id.partner_id.country_id
+                self.invoice_id.company_id.partner_id.country_id
+            if self.invoice_id.partner_bank_id:
+                country_id = self.invoice_id.partner_bank_id.bank_id.country
+                if country_id:
+                    country_payment_id = country_id
         elif self.invoice_id.type in ('in_invoice', 'in_refund'):
             country_payment_id = \
-                self.invoice_id.company_id.partner_id.country_id
+                self.invoice_id.partner_id.country_id
         res.update({
             'country_payment_id': country_payment_id.id})
 


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

https://github.com/OCA/l10n-italy/issues/2058




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
