### PR TITLE
[12.0][IMP] self-refund invoice for intra partners

### DIFF
--- a/l10n_it_fatturapa_out_rc/tests/data/IT10538570960_00003.xml
+++ b/l10n_it_fatturapa_out_rc/tests/data/IT10538570960_00003.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ns1:FatturaElettronica xmlns:ns1="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" versione="FPR12">
+   <FatturaElettronicaHeader>
+      <DatiTrasmissione>
+         <IdTrasmittente>
+            <IdPaese>IT</IdPaese>
+            <IdCodice>10538570960</IdCodice>
+         </IdTrasmittente>
+         <ProgressivoInvio>00003</ProgressivoInvio>
+         <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+         <CodiceDestinatario>0000000</CodiceDestinatario>
+         <ContattiTrasmittente>
+            <Telefono>06543534343</Telefono>
+            <Email>info@yourcompany.example.com</Email>
+         </ContattiTrasmittente>
+      </DatiTrasmissione>
+      <CedentePrestatore>
+         <DatiAnagrafici>
+            <IdFiscaleIVA>
+               <IdPaese>BE</IdPaese>
+               <IdCodice>0477472701</IdCodice>
+            </IdFiscaleIVA>
+            <Anagrafica>
+               <Denominazione>Intra EU supplier</Denominazione>
+            </Anagrafica>
+            <RegimeFiscale>RF01</RegimeFiscale>
+         </DatiAnagrafici>
+         <Sede>
+            <Indirizzo>Street</Indirizzo>
+            <CAP>12345</CAP>
+            <Comune>city</Comune>
+            <Nazione>BE</Nazione>
+         </Sede>
+      </CedentePrestatore>
+      <CessionarioCommittente>
+         <DatiAnagrafici>
+            <IdFiscaleIVA>
+               <IdPaese>IT</IdPaese>
+               <IdCodice>10538570960</IdCodice>
+            </IdFiscaleIVA>
+            <Anagrafica>
+               <Denominazione>YourCompany</Denominazione>
+            </Anagrafica>
+         </DatiAnagrafici>
+         <Sede>
+            <Indirizzo>Via Milano, 1</Indirizzo>
+            <CAP>00100</CAP>
+            <Comune>Roma</Comune>
+            <Provincia>AK</Provincia>
+            <Nazione>IT</Nazione>
+         </Sede>
+      </CessionarioCommittente>
+   </FatturaElettronicaHeader>
+   <FatturaElettronicaBody>
+      <DatiGenerali>
+         <DatiGeneraliDocumento>
+            <TipoDocumento>TD17</TipoDocumento>
+            <Divisa>EUR</Divisa>
+            <Data>2020-12-01</Data>
+            <Numero>SLF/2020/0016</Numero>
+            <ImportoTotaleDocumento>-122.00</ImportoTotaleDocumento>
+            <Causale>Reverse charge self invoice.</Causale>
+            <Causale>Supplier: Intra EU supplier</Causale>
+            <Causale>Reference: EU-SUPPLIER-REF</Causale>
+            <Causale>Date: 2020-12-01</Causale>
+            <Causale>Internal reference: BILL/2020/0026</Causale>
+         </DatiGeneraliDocumento>
+         <DatiFattureCollegate>
+            <IdDocumento>EU-SUPPLIER-REF</IdDocumento>
+            <Data>2020-12-01</Data>
+         </DatiFattureCollegate>
+      </DatiGenerali>
+      <DatiBeniServizi>
+         <DettaglioLinee>
+            <NumeroLinea>1</NumeroLinea>
+            <CodiceArticolo>
+               <CodiceTipo>ODOO</CodiceTipo>
+               <CodiceValore>DESK0004</CodiceValore>
+            </CodiceArticolo>
+            <Descrizione>Invoice for sample product</Descrizione>
+            <Quantita>1.000</Quantita>
+            <UnitaMisura>Unit(s)</UnitaMisura>
+            <PrezzoUnitario>-100.00000</PrezzoUnitario>
+            <PrezzoTotale>-100.00</PrezzoTotale>
+            <AliquotaIVA>22.00</AliquotaIVA>
+         </DettaglioLinee>
+         <DatiRiepilogo>
+            <AliquotaIVA>22.00</AliquotaIVA>
+            <ImponibileImporto>-100.00</ImponibileImporto>
+            <Imposta>-22.00</Imposta>
+         </DatiRiepilogo>
+      </DatiBeniServizi>
+   </FatturaElettronicaBody>
+</ns1:FatturaElettronica>

--- a/l10n_it_fatturapa_out_rc/tests/test_e_invoice_out_rc.py
+++ b/l10n_it_fatturapa_out_rc/tests/test_e_invoice_out_rc.py
@@ -20,9 +20,15 @@ class TestReverseCharge(ReverseChargeCommon, FatturaPACommon):
         self.customer_invoice_account = self.env['account.account'].search(
             [('user_type_id', '=', self.env.ref(
                 'account.data_account_type_receivable').id)], limit=1).id
+        self.supplier_invoice_account = self.env['account.account'].search(
+            [('user_type_id', '=', self.env.ref(
+                'account.data_account_type_payable').id)], limit=1).id
         self.sale_invoice_line_account = self.env['account.account'].search(
             [('user_type_id', '=', self.env.ref(
                 'account.data_account_type_revenue').id)], limit=1).id
+        self.purchase_invoice_line_account = self.env['account.account'].search(
+            [('user_type_id', '=', self.env.ref(
+                'account.data_account_type_direct_costs').id)], limit=1).id
 
     def set_sequence_journal_selfinvoice(self, invoice_number, dt):
         inv_seq = self.journal_selfinvoice.sequence_id
@@ -144,3 +150,47 @@ class TestReverseCharge(ReverseChargeCommon, FatturaPACommon):
         self.assertEqual(invoice.rc_self_invoice_id.state, 'cancel')
         with self.assertRaises(UserError):
             invoice.rc_self_invoice_id.action_invoice_draft()
+
+    def test_intra_EU_supplier_refund(self):
+        self.set_sequence_journal_selfinvoice(16, '2020-12-01')
+        self.set_bill_sequence(26, '2020-12-01')
+        self.supplier_intraEU.property_payment_term_id = self.term_15_30.id
+        invoice = self.invoice_model.create({
+            'partner_id': self.supplier_intraEU.id,
+            'account_id': self.supplier_invoice_account,
+            'type': 'in_refund',
+            'date_invoice': '2020-12-01',
+            'reference': 'EU-SUPPLIER-REF',
+        })
+        self.assertEqual(
+            invoice.fiscal_document_type_id.code, "TD04")
+        invoice_line_vals = {
+            'name': 'Invoice for sample product',
+            'account_id': self.purchase_invoice_line_account,
+            'invoice_id': invoice.id,
+            'product_id': self.sample_product.id,
+            'price_unit': 100,
+            'invoice_line_tax_ids': [(4, self.tax_22ai.id, 0)]}
+        invoice_line = self.invoice_line_model.create(invoice_line_vals)
+        invoice_line.onchange_invoice_line_tax_id()
+        invoice.compute_taxes()
+        invoice.action_invoice_open()
+        self.assertEqual(
+            invoice.rc_self_invoice_id.fiscal_document_type_id.code, "TD17")
+        with self.assertRaises(UserError):
+            # Impossible to set IdFiscaleIVA
+            self.run_wizard(invoice.rc_self_invoice_id.id)
+        self.supplier_intraEU.vat = "BE0477472701"
+        with self.assertRaises(UserError):
+            # Street is not set
+            self.run_wizard(invoice.rc_self_invoice_id.id)
+        self.supplier_intraEU.street = "Street"
+        self.supplier_intraEU.zip = "12345"
+        self.supplier_intraEU.city = "city"
+        self.supplier_intraEU.country_id = self.env.ref("base.be")
+        res = self.run_wizard(invoice.rc_self_invoice_id.id)
+        attachment = self.attach_model.browse(res['res_id'])
+        self.set_e_invoice_file_id(attachment, 'IT10538570960_00003.xml')
+        xml_content = base64.decodebytes(attachment.datas)
+        self.check_content(
+            xml_content, 'IT10538570960_00003.xml', "l10n_it_fatturapa_out_rc")

--- a/l10n_it_fatturapa_out_rc/wizard/wizard_export_e_invoice.py
+++ b/l10n_it_fatturapa_out_rc/wizard/wizard_export_e_invoice.py
@@ -133,4 +133,36 @@ class WizardExportFatturapa(models.TransientModel):
                 invoice.rc_purchase_invoice_id.fiscal_position_id.rc_type_id.
                 fiscal_document_type_id.code
             )
+        if invoice.type in ['out_refund', 'in_refund'] \
+                and invoice.fiscal_document_type_id.code not in ['TD04', 'TD08']:
+            body.DatiGenerali.DatiGeneraliDocumento.ImportoTotaleDocumento = \
+                - body.DatiGenerali.DatiGeneraliDocumento.ImportoTotaleDocumento
         return res
+
+    def setDettaglioLinea(
+        self, line_no, line, body, price_precision, uom_precision
+    ):
+        DettaglioLinea = super(WizardExportFatturapa, self).setDettaglioLinea(
+            line_no, line, body, price_precision, uom_precision)
+        if line.invoice_id.type in ['out_refund', 'in_refund'] and \
+                line.invoice_id.fiscal_document_type_id.code not in ['TD04', 'TD08']:
+            DettaglioLinea.PrezzoUnitario = - DettaglioLinea.PrezzoUnitario
+            DettaglioLinea.PrezzoTotale = - DettaglioLinea.PrezzoTotale
+        return DettaglioLinea
+
+    def setDatiRiepilogo(self, invoice, body):
+        super(WizardExportFatturapa, self).setDatiRiepilogo(invoice, body)
+        for DatiRiepilogo in body.DatiBeniServizi.DatiRiepilogo:
+            if invoice.type in ['out_refund', 'in_refund'] \
+                    and invoice.fiscal_document_type_id.code not in ['TD04', 'TD08']:
+                DatiRiepilogo.ImponibileImporto = - DatiRiepilogo.ImponibileImporto
+                DatiRiepilogo.Imposta = - DatiRiepilogo.Imposta
+        return True
+
+    def setDatiPagamento(self, invoice, body):
+        super(WizardExportFatturapa, self).setDatiPagamento(invoice, body)
+        for DatiPagamento in body.DatiPagamento:
+            if invoice.type in ['out_refund', 'in_refund'] \
+                    and invoice.fiscal_document_type_id.code not in ['TD04', 'TD08']:
+                DatiPagamento.ImportoPagamento = - DatiPagamento.ImportoPagamento
+        return True


### PR DESCRIPTION
Descrizione del problema o della funzionalità: nota di credito ricevuta da fornitore comunitario, registrata con codice TD04, fatta l'autofattura(nota di credito) con codice TD18, dovrebbe andare in negativo nell'xml

Comportamento attuale prima di questa PR: la nota di credito è in positivo nell'xml

Comportamento desiderato dopo questa PR: la nota di credito è in negativo nell'xml

rif. pag 8 guida fatturazione elettronica Agenzia delle Entrate: 
```
il fornitore francese il 3/11/2020 emette (con facoltà di trasmissione della stessa tramite
SDI), con riferimento alla fattura n. 15 del 05/10/2020, una nota di credito dell’importo di
20 euro;
conseguentemente il cessionario residente o stabilito in Italia può trasmettere a SDI un
documento TD18 rettificativo di quello trasmesso il 6/10/2020, riportando un imponibile di -
20 euro e un’imposta di - 4,4 euro.
```

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing