### PR TITLE
[12.0] FIX l10n_it_fatturapa_out: max_invoice_in_xml position

### DIFF
--- a/l10n_it_fatturapa_out/views/partner_view.xml
+++ b/l10n_it_fatturapa_out/views/partner_view.xml
@@ -6,9 +6,9 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="l10n_it_fatturapa.view_partner_form_fatturapa"/>
         <field name="arch" type="xml">
-            <field name="ipa_code" position="before">
+            <xpath expr="//group[@name='fatturapa_group']//field[@name='ipa_code']" position="before">
                 <field name="max_invoice_in_xml"/>
-            </field>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
After having moved view_partner_form_e_inv, max_invoice_in_xml is not visible in main partner form

Descrizione del problema o della funzionalità:

Dopo https://github.com/OCA/l10n-italy/pull/2046 il campo `max_invoice_in_xml` è scomparso

Issue https://github.com/OCA/l10n-italy/issues/2045




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
