### PR TITLE
[12.0] FIX fiscal_epos_print: lottery code input focus

### DIFF
--- a/fiscal_epos_print/static/src/js/popups.js
+++ b/fiscal_epos_print/static/src/js/popups.js
@@ -77,7 +77,7 @@ odoo.define("fiscal_epos_print.popups", function (require) {
             this._super(options);
             this.update_lottery_info_button = options.update_lottery_info_button;
             this.renderElement();
-            this.$('lottery_code').focus();
+            this.$('#lottery_code').focus();
         },
         // TODO automatically close popup on barcode scanned
         click_confirm: function(){


### PR DESCRIPTION
Comportamento attuale prima di questa PR:

Facendo click su Lottery Code viene aperto il popup ma il focus non è sul campo testuale

Comportamento desiderato dopo questa PR:

Il focus è sul campo testuale:

![image](https://user-images.githubusercontent.com/1033131/107368400-cbd6c280-6ae0-11eb-9f4c-68abc5ddc1c9.png)



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
