### PR TITLE
[12.0][FIX]account_invoice_report_ddt_group: set generic session line name when invoice line has no reference in ddt lines.

### DIFF
--- a/account_invoice_report_ddt_group/models/account_invoice.py
+++ b/account_invoice_report_ddt_group/models/account_invoice.py
@@ -1,6 +1,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, api, fields
+from odoo import models, api, fields, _
 import collections
 
 
@@ -18,7 +18,7 @@ class AccountInvoice(models.Model):
         for ddt in grouped_lines:
             new_line = self.env['account.invoice.line'].create({
                 'sequence': line_number,
-                'name': ddt,
+                'name': ddt or _('No TD'),
                 'display_type': 'line_section',
                 'invoice_id': self.id
             })


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
See [https://github.com/OCA/l10n-italy/issues/2108](https://github.com/OCA/l10n-italy/issues/2108)
Raggruppamento righe fattura per ddt, con righe senza riferimenti a ddt (es: spese trasporto).

Comportamento attuale prima di questa PR:
La riga di sezione ha il campo Prodotto vuoto.

Comportamento desiderato dopo questa PR:
La riga di sezione viene creata con un nome generico ("No TD").



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
