### PR TITLE
[11.0] [FIX] l10n_it_central_journal: fix query for ambiguous column

### DIFF
--- a/l10n_it_central_journal/wizard/print_giornale.py
+++ b/l10n_it_central_journal/wizard/print_giornale.py
@@ -99,7 +99,7 @@ class WizardGiornale(models.TransientModel):
             aml.date >= %(date_from)s
             AND aml.date <= %(date_to)s
             AND am.state in %(target_type)s
-            AND journal_id in %(journal_ids)s
+            AND aml.journal_id in %(journal_ids)s
             ORDER BY am.date, am.name
         """
         params = {


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Il campo journal_id è in account_move e anche in account_move_line, per questo quando el girornale viene stampato, c'e un errore



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
