### PR TITLE
[12.0] FIX fiscal_epos_print: lottery_code could also be false

### DIFF
--- a/fiscal_epos_print/static/src/js/epson_epos_print.js
+++ b/fiscal_epos_print/static/src/js/epson_epos_print.js
@@ -400,7 +400,7 @@ odoo.define("fiscal_epos_print.epson_epos_print", function (require) {
             });
             // footer can go only as promo code so within a fiscal receipt body
             xml += this.printFiscalReceiptFooter(receipt);
-            if (receipt.lottery_code != null) {
+            if (receipt.lottery_code) {
                 // TX
                 // 1 135   OP   ID CODE   NU
                 // Example: 113501ABCDEFGN        0000

--- a/fiscal_epos_print/static/src/js/screens.js
+++ b/fiscal_epos_print/static/src/js/screens.js
@@ -219,7 +219,7 @@ odoo.define("fiscal_epos_print.screens", function (require) {
         lottery_get_button_color: function() {
             var order = this.pos.get_order();
             var color = '#e2e2e2';
-            if(order.lottery_code != null) {
+            if (order.lottery_code) {
                 color = 'lightgreen';
             }
             return color;


### PR DESCRIPTION

Comportamento attuale prima di questa PR:

- fare scontrino
- a partire dall'elenco scontrini emessi fare il reso > il pulsante per il codice lotteria è verde ma non dovrebbe
- stampare scontrino > errore javascript



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
