### PR TITLE
[12.0] Close issue #2111

### DIFF
--- a/l10n_it_fatturapa_out_ddt/__init__.py
+++ b/l10n_it_fatturapa_out_ddt/__init__.py
@@ -1,2 +1,3 @@
 
 from . import wizard
+from . import models

--- a/l10n_it_fatturapa_out_ddt/models/__init__.py
+++ b/l10n_it_fatturapa_out_ddt/models/__init__.py
@@ -1,0 +1,2 @@
+
+from . import fattura_differita_ddt

--- a/l10n_it_fatturapa_out_ddt/models/fattura_differita_ddt.py
+++ b/l10n_it_fatturapa_out_ddt/models/fattura_differita_ddt.py
@@ -1,0 +1,20 @@
+from odoo import api, models
+
+
+class StockPickingPackagePreparation(models.Model):
+    _inherit = 'stock.picking.package.preparation'
+
+    @api.multi
+    def action_invoice_create(self):
+        invoice_ids = super().action_invoice_create()
+
+        doc_type_obj = self.env['fiscal.document.type'].search(
+            [('code', '=', 'TD24')], limit=1)
+
+        invs_obj = self.env['account.invoice'].browse(invoice_ids)
+
+        if doc_type_obj:
+            for inv in invs_obj:
+                inv.fiscal_document_type_id = doc_type_obj
+
+        return invoice_ids

--- a/l10n_it_fatturapa_out_ddt/tests/data/IT06363391001_00006.xml
+++ b/l10n_it_fatturapa_out_ddt/tests/data/IT06363391001_00006.xml
@@ -61,7 +61,7 @@
    <FatturaElettronicaBody>
       <DatiGenerali>
          <DatiGeneraliDocumento>
-            <TipoDocumento>TD01</TipoDocumento>
+            <TipoDocumento>TD24</TipoDocumento>
             <Divisa>USD</Divisa>
             <Data>2018-01-07</Data>
             <Numero>INV/2018/0013</Numero>

--- a/l10n_it_fatturapa_out_ddt/tests/data/IT06363391001_00007.xml
+++ b/l10n_it_fatturapa_out_ddt/tests/data/IT06363391001_00007.xml
@@ -61,7 +61,7 @@
    <FatturaElettronicaBody>
       <DatiGenerali>
          <DatiGeneraliDocumento>
-            <TipoDocumento>TD01</TipoDocumento>
+            <TipoDocumento>TD24</TipoDocumento>
             <Divisa>USD</Divisa>
             <Data>2018-01-07</Data>
             <Numero>INV/2018/0014</Numero>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Fattura Differita TD24 come tipo di documento della fattura elettronica quando si crea fattura da DDT

#2111

Comportamento attuale prima di questa PR:
Veniva assegnato come tipo di documento TD01 Fattura

Comportamento desiderato dopo questa PR:
Viene assegnato come tipo di documento TD24 Fattura Differita



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
