### PR TITLE
[10.0][FIX] l10n_it_intrastat_statement: Arrotondamento amount_euro e statistic_amount_euro, troncamento amount_currency

### DIFF
--- a/l10n_it_intrastat_statement/models/intrastat_statement.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement.py
@@ -47,7 +47,21 @@ class AccountIntrastatStatement(models.Model):
     _rec_name = 'number'
 
     @api.multi
-    def round_min_amount(self, amount, company=None, prec_digits=None):
+    def round_min_amount(self, amount,
+                         company=None, prec_digits=None, truncate=False):
+        """
+        Return an integer representing `amount`,
+        ready for usage in the statement.
+
+        :param amount: Amount to be edited
+        :param company: Company to be used for fetching minimal value,
+                        if not present the statement's company is used
+        :param prec_digits: Digits to be used for rounding,
+                            if not present it is rounded to the unit
+        :param truncate: True if the float number
+                         has to be truncated, otherwise it is rounded
+        :return: An integer representing `amount`
+        """
         self.ensure_one()
         if company is None:
             company = self.company_id
@@ -56,6 +70,11 @@ class AccountIntrastatStatement(models.Model):
             round_amount = float_round(amount, precision_digits=prec_digits)
         else:
             round_amount = round(amount)
+
+        if truncate:
+            round_amount = int(round_amount)
+        else:
+            round_amount = int(round(round_amount))
 
         return max(round_amount or 1, company.intrastat_min_amount)
 

--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
@@ -36,7 +36,9 @@ class IntrastatStatementPurchaseSection(models.AbstractModel):
             amount_currency = statement_id.round_min_amount(
                 inv_intra_line.amount_currency,
                 statement_id.company_id or company_id,
-                dp_model.precision_get('Account'))
+                dp_model.precision_get('Account'),
+                truncate=True,
+            )
 
         res.update({
             'amount_currency': amount_currency,

--- a/l10n_it_intrastat_statement/tests/test_intrastat_statement.py
+++ b/l10n_it_intrastat_statement/tests/test_intrastat_statement.py
@@ -73,7 +73,10 @@ class TestIntrastatStatement (AccountingTestCase):
         company.intrastat_sale_transaction_nature_id = \
             self.ref('l10n_it_intrastat.code_9')
 
-    def _get_intrastat_computed_bill(self, product, currency=None):
+    def _get_intrastat_computed_bill(
+            self, product=None, currency=None, price_unit=100.0):
+        if product is None:
+            product = self.product01
         invoice = self.invoice_model.create({
             'partner_id': self.partner01.id,
             'type': 'in_invoice',
@@ -85,7 +88,7 @@ class TestIntrastatStatement (AccountingTestCase):
                 'product_id': product.id,
                 'account_id': self.account_account_payable.id,
                 'quantity': 1,
-                'price_unit': 100,
+                'price_unit': price_unit,
                 'invoice_line_tax_ids': [(6, 0, {
                     self.tax22_purchase.id
                 })]
@@ -98,7 +101,7 @@ class TestIntrastatStatement (AccountingTestCase):
         invoice.compute_intrastat_lines()
         return invoice
 
-    def _get_intrastat_computed_invoice(self):
+    def _get_intrastat_computed_invoice(self, price_unit=100.0):
         invoice = self.invoice_model.create({
             'partner_id': self.partner01.id,
             'journal_id': self.sales_journal.id,
@@ -109,7 +112,7 @@ class TestIntrastatStatement (AccountingTestCase):
                 'product_id': self.product01.id,
                 'account_id': self.account_account_receivable.id,
                 'quantity': 1,
-                'price_unit': 100,
+                'price_unit': price_unit,
                 'invoice_line_tax_ids': [(6, 0, {
                     self.tax22_sale.id
                 })]
@@ -161,7 +164,7 @@ class TestIntrastatStatement (AccountingTestCase):
         self.assertEqual(len(file_content.splitlines()[-1]), 64)
 
     def test_statement_purchase(self):
-        bill = self._get_intrastat_computed_bill(self.product01)
+        bill = self._get_intrastat_computed_bill()
 
         statement = self.statement_model.create({
             'period_number':
@@ -183,8 +186,7 @@ class TestIntrastatStatement (AccountingTestCase):
         self.assertEqual(len(file_content.splitlines()[-1]), 118)
 
     def test_statement_purchase_currency(self):
-        bill = self._get_intrastat_computed_bill(self.product01,
-                                                 currency=self.currency_gbp)
+        bill = self._get_intrastat_computed_bill(currency=self.currency_gbp)
 
         statement = self.statement_model.create({
             'period_number': fields.Date.from_string(bill.date_invoice).month,
@@ -197,7 +199,7 @@ class TestIntrastatStatement (AccountingTestCase):
                          line.amount_currency)
 
     def test_statement_purchase_refund(self):
-        bill = self._get_intrastat_computed_bill(self.product01)
+        bill = self._get_intrastat_computed_bill()
 
         bill_refund = bill.refund()
         # This refund will be subtracted from bill
@@ -234,7 +236,7 @@ class TestIntrastatStatement (AccountingTestCase):
                             {75, 130, 118})
 
     def test_statement_purchase_refund_no_subtract(self):
-        bill = self._get_intrastat_computed_bill(self.product01)
+        bill = self._get_intrastat_computed_bill()
 
         bill_refund = bill.refund()
         # Change the partner so that this refund is not subtracted from bill
@@ -323,7 +325,7 @@ class TestIntrastatStatement (AccountingTestCase):
                             {99, 118})
 
     def test_statement_purchase_quarter(self):
-        bill = self._get_intrastat_computed_bill(self.product01)
+        bill = self._get_intrastat_computed_bill()
         month = fields.Date.from_string(bill.date_invoice).month
         quarter = 1 + (month - 1) // 3
         statement = self.statement_model.create({
@@ -358,7 +360,7 @@ class TestIntrastatStatement (AccountingTestCase):
 
     def test_purchase_default_transaction_nature(self):
         """Check default value for purchase's transaction nature."""
-        bill = self._get_intrastat_computed_bill(self.product01)
+        bill = self._get_intrastat_computed_bill()
 
         statement = self.statement_model.create({
             'period_number':
@@ -386,3 +388,91 @@ class TestIntrastatStatement (AccountingTestCase):
             company.intrastat_sale_transaction_nature_id,
             line.transaction_nature_id
         )
+
+    def test_statement_sale_round_up_amounts(self):
+        """
+        Check that amount_euro and statistic_amount_euro are rounded up.
+        """
+        invoice = self._get_intrastat_computed_invoice(price_unit=100.5)
+
+        statement = self.statement_model.create({
+            'period_number':
+                fields.Date.from_string(invoice.date_invoice).month,
+        })
+        statement.compute_statement()
+        statement_invoice_line = statement.sale_section1_ids \
+            .filtered(lambda l: l.invoice_id == invoice)
+        self.assertEqual(statement_invoice_line.amount_euro, 101)
+        self.assertEqual(statement_invoice_line.statistic_amount_euro, 101)
+
+    def test_statement_sale_round_down_amounts(self):
+        """
+        Check that amount_euro and statistic_amount_euro are rounded down.
+        """
+        invoice = self._get_intrastat_computed_invoice(price_unit=100.4)
+
+        statement = self.statement_model.create({
+            'period_number':
+                fields.Date.from_string(invoice.date_invoice).month,
+        })
+        statement.compute_statement()
+        statement_invoice_line = statement.sale_section1_ids \
+            .filtered(lambda l: l.invoice_id == invoice)
+        self.assertEqual(statement_invoice_line.amount_euro, 100)
+        self.assertEqual(statement_invoice_line.statistic_amount_euro, 100)
+
+    def test_statement_purchase_round_up_amounts(self):
+        """
+        Check that amount_euro and statistic_amount_euro are rounded up,
+        but amount_currency is truncated.
+        """
+        bill = self._get_intrastat_computed_bill(
+            currency=self.currency_gbp,
+            price_unit=100.5,
+        )
+
+        statement = self.statement_model.create({
+            'period_number':
+                fields.Date.from_string(bill.date_invoice).month,
+        })
+        statement.compute_statement()
+        statement_invoice_line = statement.purchase_section1_ids \
+            .filtered(lambda l: l.invoice_id == bill)
+
+        bill_amount_euro = bill.intrastat_line_ids.amount_euro
+        self.assertEqual(statement_invoice_line.amount_euro,
+                         int(round(bill_amount_euro)))
+        self.assertEqual(statement_invoice_line.statistic_amount_euro,
+                         int(round(bill_amount_euro)))
+
+        amount_currency = int(bill.intrastat_line_ids.amount_currency)
+        self.assertEqual(statement_invoice_line.amount_currency,
+                         amount_currency)
+
+    def test_statement_purchase_round_down_amounts(self):
+        """
+        Check that amount_euro and statistic_amount_euro are rounded down,
+        but amount_currency is truncated.
+        """
+        bill = self._get_intrastat_computed_bill(
+            currency=self.currency_gbp,
+            price_unit=100.4,
+        )
+
+        statement = self.statement_model.create({
+            'period_number':
+                fields.Date.from_string(bill.date_invoice).month,
+        })
+        statement.compute_statement()
+        statement_invoice_line = statement.purchase_section1_ids \
+            .filtered(lambda l: l.invoice_id == bill)
+
+        bill_amount_euro = bill.intrastat_line_ids.amount_euro
+        self.assertEqual(statement_invoice_line.amount_euro,
+                         int(round(bill_amount_euro)))
+        self.assertEqual(statement_invoice_line.statistic_amount_euro,
+                         int(round(bill_amount_euro)))
+
+        amount_currency = int(bill.intrastat_line_ids.amount_currency)
+        self.assertEqual(statement_invoice_line.amount_currency,
+                         amount_currency)

--- a/l10n_it_intrastat_statement/views/intrastat.xml
+++ b/l10n_it_intrastat_statement/views/intrastat.xml
@@ -358,7 +358,7 @@
                             <field name="invoice_date"/>
                             <field name="supply_method"/>
                             <field name="payment_method"/>
-                            <field name="country_payment_id"/>
+                            <field name="country_payment_id" required="True"/>
                         </group>
                     </group>
                 </form>
@@ -580,7 +580,7 @@
                             <field name="invoice_date"/>
                             <field name="supply_method"/>
                             <field name="payment_method"/>
-                            <field name="country_payment_id"/>
+                            <field name="country_payment_id" required="True"/>
                         </group>
                     </group>
                 </form>


### PR DESCRIPTION
Fix https://github.com/OCA/l10n-italy/issues/2133 per v10

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
