### PR TITLE
[12.0] FIX l10n_it_fiscal_document_type when generating refund when a fiscal position is set

### DIFF
--- a/l10n_it_fiscal_document_type/models/account_invoice.py
+++ b/l10n_it_fiscal_document_type/models/account_invoice.py
@@ -40,12 +40,15 @@ class AccountInvoice(models.Model):
             dt = self.env['fiscal.document.type'].search([
                 (type, '=', True)]).ids
         # Refund Document type
-        if dt and 'refund' in type:
-            fdt = self.env['fiscal.document.type'].browse(dt[0])
+        if (dt or doc_id) and 'refund' in type:
+            fdt = self.env['fiscal.document.type'].browse(doc_id or dt[0])
             if fdt and not fdt.out_refund\
                     and not fdt.in_refund\
                     and fdt.refund_fiscal_document_type_id:
-                dt[0] = fdt.refund_fiscal_document_type_id.id
+                if dt:
+                    dt[0] = fdt.refund_fiscal_document_type_id.id
+                else:
+                    dt.append(fdt.refund_fiscal_document_type_id.id)
         if doc_id:
             dt.append(doc_id)
         return dt

--- a/l10n_it_fiscal_document_type/tests/test_doc_type.py
+++ b/l10n_it_fiscal_document_type/tests/test_doc_type.py
@@ -16,6 +16,10 @@ class TestDocType(TransactionCase):
             [('code', '=', 'TD04')], limit=1)
         self.inv_model = self.env['account.invoice']
         self.partner3 = self.env.ref('base.res_partner_3')
+        self.fp = self.env["account.fiscal.position"].create({
+            "name": "FP",
+            "fiscal_document_type_id": self.TD01.id,
+        })
 
     def test_doc_type(self):
         self.TD01.journal_ids = [self.journalrec.id]
@@ -54,6 +58,19 @@ class TestDocType(TransactionCase):
         self.TD01.journal_ids = [self.journalrec.id]
         invoice = self.inv_model.create({
             'partner_id': self.partner3.id
+        })
+        invoice._set_document_fiscal_type()
+        refund = invoice.refund(
+            invoice.date_invoice,
+            invoice.date,
+            'refund test',
+            invoice.journal_id.id
+        )
+        self.assertEqual(refund.fiscal_document_type_id.id, self.TD04.id)
+
+        invoice = self.inv_model.create({
+            'partner_id': self.partner3.id,
+            "fiscal_position_id": self.fp.id,
         })
         invoice._set_document_fiscal_type()
         refund = invoice.refund(


### PR DESCRIPTION
Steps:
 - Create a fiscal position setting Fiscal doc type = TD01
 - Create an invoice with the above fiscal position
 - Create a refund from the invoice above

Observed: refund has got TD01
Desired: refund has got TD04






--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
