### PR TITLE
[12.0][FIX] Nella stampa del registro IVA acquisti ci sono i riferimenti agli ordini di acquisto nel campo numero fattura

### DIFF
--- a/l10n_it_vat_registries/report/report_registro_iva.xml
+++ b/l10n_it_vat_registries/report/report_registro_iva.xml
@@ -86,7 +86,7 @@
                                                 <td class="left_without_line_bold"><div style="page-break-inside: avoid" t-esc="format_date(line['invoice_date'],date_format)"/></td>
                                                 <t t-if="move.journal_id.type == 'purchase'">
                                                     <!-- Numero fattura (fornitore)-->
-                                                    <td class="left_without_line_bold"><div style="page-break-inside: avoid" t-esc="line['reference']"/></td>
+                                                    <td class="left_without_line_bold"><div style="page-break-inside: avoid" t-esc="line['reference'].split(',')[0]"/></td>
                                                 </t>
                                                 <t t-if="move.journal_id.type == 'sale'">
                                                     <!-- Numero fattura -->


### PR DESCRIPTION
Descrizione del problema o della funzionalità: Nella stampa del registro IVA acquisti ci sono i riferimenti agli ordini di acquisto nel campo numero fattura

Comportamento attuale prima di questa PR: il numero fattura fornitore è compresi di riferimenti agli ordini di acquisto

Comportamento desiderato dopo questa PR: il numero fattura fornitore è senza altri riferimenti




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing