### PR TITLE
[FIX][12.0] l10n_it_reverse_charge fix self invoice date

### DIFF
--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -89,7 +89,7 @@ class AccountInvoice(models.Model):
             'account_id': account.id,
             'journal_id': rc_type.journal_id.id,
             'invoice_line_ids': lines,
-            'date_invoice': self.date,
+            'date_invoice': self.date_invoice,
             'date': self.date,
             'origin': self.number,
             'rc_purchase_invoice_id': self.id,
@@ -385,7 +385,7 @@ class AccountInvoice(models.Model):
 
         # because this field has copy=False
         supplier_invoice.date = self.date
-        supplier_invoice.date_invoice = self.date
+        supplier_invoice.date_invoice = self.date_invoice
         supplier_invoice.date_due = self.date
         supplier_invoice.partner_id = rc_type.partner_id.id
         supplier_invoice.journal_id = rc_type.supplier_journal_id.id


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Data errata nell'autofattura

Comportamento attuale prima di questa PR:
Le autofatture vengono create con data uguale alla data registrazione (e non data) della fattura originale

Comportamento desiderato dopo questa PR:
Le autofatture vengono create con la data uguale alla data della fattura originale, e data registrazione uguale a quella della fattura originale

Domanda. È un comportamento generale o avrebbe senso trasformalo in una opzione di configurazione? Dipende dal cliente?

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
