### PR TITLE
[8.0][IMP] l10n_it_vat_registries: add year for footer 

### DIFF
--- a/l10n_it_account/reports/account_reports_view.xml
+++ b/l10n_it_account/reports/account_reports_view.xml
@@ -74,7 +74,14 @@
                   <div class="col-xs-4 col-xs-offset-4 text-right">
                     <span style="display: none;" id="l10n_it_count_fiscal_page_base" t-esc="l10n_it_count_fiscal_page_base" />
                     <ul class="list-inline">Pag:
-                        <li><span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y')"/></li>
+                        <li>
+                            <t t-if="l10n_it_count_fiscal_year">
+                                <span t-esc="l10n_it_count_fiscal_year"/>
+                            </t>
+                            <t t-if="not l10n_it_count_fiscal_year">
+                                <span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y')"/>
+                            </t>
+                        </li>
                         <li>/</li>
                         <li><span class="page"/></li>
                     </ul>

--- a/l10n_it_vat_registries/vat_registry.py
+++ b/l10n_it_vat_registries/vat_registry.py
@@ -259,6 +259,8 @@ class Parser(report_sxw.rml_parse):
             'tax_registry_name': data['form'].get('tax_registry_name'),
             'l10n_it_count_fiscal_page_base': data['form'].get(
                 'fiscal_page_base'),
+            'l10n_it_count_fiscal_year': data['form'].get(
+                'year_footer')
         })
         return super(Parser, self).set_context(
             objects, data, ids, report_type=report_type)

--- a/l10n_it_vat_registries/views/report_registro_iva.xml
+++ b/l10n_it_vat_registries/views/report_registro_iva.xml
@@ -15,11 +15,12 @@
         <t t-if="registry_type == 'corrispettivi'">
             <t t-set="title" t-value="'Registro Corrispettivi'"/>
         </t>
+        <t t-set="l10n_it_count_fiscal_year" t-value="year_footer"/>
         <t t-call="l10n_it_account.internal_layout">
             <div class="page">
                 <t t-set="print_details" t-value="1"/>
                 <t t-if="only_totals == True">
-                    <t t-set="print_details" t-value="0"/>               
+                    <t t-set="print_details" t-value="0"/>
                 </t>
                 <table style="width:100%; font-size: small;" cellspacing="0">
                     <thead>
@@ -29,9 +30,9 @@
                             </t>
                             <t t-if="registry_type != 'corrispettivi'">
                                 <td colspan="9" style="padding:10;" t-esc="tax_registry_name + ' Periodo di stampa dal ' + formatLang(start_date(), date=True) + ' al ' + formatLang(end_date(), date=True)"/>
-                            </t>    
+                            </t>
                         </tr>
-                       
+
                         <t t-if="print_details > 0 ">
                             <tr style="page-break-inside: avoid">
                                 <th class="left_without_line">DATA REG.</th>
@@ -59,9 +60,9 @@
                                 <th class="right_with_line_bottom">Imposta</th>
                                 <th class="right_with_line_bottom"></th>
                             </tr>
-                        </t>    
+                        </t>
                     </thead>
-                    
+
                     <t t-set="counter" t-value="0"/>
                     <tbody>
                         <t t-foreach="get_move(data['ids'])" t-as="move">
@@ -128,7 +129,7 @@
                     </tbody>
                 </table>
                 <br/>
-            
+
                 <t t-set="tot_base" t-value="0"/>
                 <t t-set="tot_tax" t-value="0"/>
                 <t t-set="tot_ded" t-value="0"/>
@@ -147,7 +148,7 @@
                                             <th class="right_without_line_bold">Detraibile</th>
                                             <th class="right_without_line_bold">Indetraibile</th>
                                         </tr>
-                                    </thead>    
+                                    </thead>
                                     <t t-foreach="tax_codes()" t-as="tax_code_tuple">
                                         <t t-set="tot_base" t-value="tot_base + tax_code_tuple[1]"/>
                                         <t t-set="tot_tax" t-value="tot_tax + tax_code_tuple[2]"/>

--- a/l10n_it_vat_registries/views/report_registro_iva.xml
+++ b/l10n_it_vat_registries/views/report_registro_iva.xml
@@ -15,7 +15,6 @@
         <t t-if="registry_type == 'corrispettivi'">
             <t t-set="title" t-value="'Registro Corrispettivi'"/>
         </t>
-        <t t-set="l10n_it_count_fiscal_year" t-value="year_footer"/>
         <t t-call="l10n_it_account.internal_layout">
             <div class="page">
                 <t t-set="print_details" t-value="1"/>

--- a/l10n_it_vat_registries/wizard/print_registro_iva.py
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.py
@@ -119,7 +119,7 @@ class WizardRegistroIva(models.TransientModel):
         datas = {
             'ids': move_ids,
             'model': 'account.move',
-            'form': datas_form
+            'form': datas_form,
         }
         return self.pool['report'].get_action(
             cr, uid, [], report_name, data=datas, context=context)

--- a/l10n_it_vat_registries/wizard/print_registro_iva.py
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.py
@@ -23,6 +23,7 @@
 
 from openerp import models, fields, api, _
 from openerp.exceptions import Warning as UserError
+from datetime import datetime
 
 
 class WizardRegistroIva(models.TransientModel):
@@ -70,6 +71,9 @@ class WizardRegistroIva(models.TransientModel):
     only_totals = fields.Boolean(
         string='Prints only totals')
     fiscal_page_base = fields.Integer('Last printed page', required=True)
+    year_footer = fields.Char(
+        string='Year for Footer',
+        help="Value printed near number of page in the footer")
 
     @api.onchange('tax_registry_id')
     def on_change_vat_registry(self):
@@ -80,6 +84,13 @@ class WizardRegistroIva(models.TransientModel):
                 self.tax_sign = -1
             else:
                 self.tax_sign = 1
+
+    @api.onchange('period_ids')
+    def get_year_footer(self):
+        if self.period_ids:
+            from_date = self.period_ids[-1].date_start
+            self.year_footer = datetime.strptime(from_date,
+                                                 "%Y-%m-%d").year
 
     def print_registro(self, cr, uid, ids, context=None):
         wizard = self.browse(cr, uid, ids[0], context=context)
@@ -98,6 +109,7 @@ class WizardRegistroIva(models.TransientModel):
         datas_form['tax_sign'] = wizard.tax_sign
         datas_form['fiscal_page_base'] = wizard.fiscal_page_base
         datas_form['registry_type'] = wizard.type
+        datas_form['year_footer'] = wizard.year_footer
         if wizard.tax_registry_id:
             datas_form['tax_registry_name'] = wizard.tax_registry_id.name
         else:

--- a/l10n_it_vat_registries/wizard/print_registro_iva.xml
+++ b/l10n_it_vat_registries/wizard/print_registro_iva.xml
@@ -21,6 +21,7 @@
                         <field name="fiscal_page_base"/>
                         <newline/>
                         <field name="message" nolabel="1" colspan="4"/>
+                        <field name="year_footer"/>
                     </group>
                     <footer>
                         <button string="Print" name="print_registro" type="object" class="oe_highlight"/>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Inserire campo "anno piè di pagina" per inserire un anno diverso da quello corrente (funzionalità già presente a partire dalla versione 10.0).
Comportamento attuale prima di questa PR:
L'anno nel piè di pagina sulla stampa dei registri IVA è sempre quello corrente.
Comportamento desiderato dopo questa PR:
L'anno nel piè di pagina sulla stampa dei registri IVA è l'anno nel campo 'year for footer' se presente, altrimenti è quello corrente.

[https://github.com/OCA/l10n-italy/blob/10.0/l10n_it_vat_registries/report/report_registro_iva.xml#L16](https://github.com/OCA/l10n-italy/blob/10.0/l10n_it_vat_registries/report/report_registro_iva.xml#L16)



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
