### PR TITLE
[12.0] FIX l10n_it_account_stamp when auto_compute_stamp is False

### DIFF
--- a/l10n_it_account_stamp/__manifest__.py
+++ b/l10n_it_account_stamp/__manifest__.py
@@ -2,7 +2,7 @@
 # Copyright 2018 Enrico Ganzaroli (enrico.gz@gmail.com)
 # Copyright 2018 Ermanno Gnan (ermannognan@gmail.com)
 # Copyright 2018 Lorenzo Battistini (https://github.com/eLBati)
-# Copyright 2018-2020 Sergio Zanchetta (https://github.com/primes2h)
+# Copyright 2018-2019 Sergio Zanchetta (https://github.com/primes2h)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 {

--- a/l10n_it_account_stamp/readme/CONFIGURE.rst
+++ b/l10n_it_account_stamp/readme/CONFIGURE.rst
@@ -10,7 +10,7 @@ Modalità manuale:
 
 - andare sul prodotto "Imposta di bollo 2 euro" e deselezionare la casella "Calcolo automatico".
 
-- per ciascuna fattura, abilitare manualmente la casella di selezione "Imposta di bollo". L'applicabilità dell'imposta di bollo verrà calcolata in base alla somma degli imponibili relativi alle imposte selezionate.
+- per ciascuna fattura, abilitare manualmente la casella di selezione "Imposta di bollo".
 
 Impostare i conti di ricavo/costo nella scheda "Contabilità", generalmente ricavo="Debiti per bolli" e costo="Valori bollati".
 
@@ -20,12 +20,12 @@ Automatic mode:
 
 - Go to 'Tax Stamp 2 euro' product and configure 'Stamp taxes' (exemption taxes).
 
-- For each invoice, the base amount for each selected tax will be added up and used to automatically determine the application of the account stamp.
+- For each invoice, the base amount for each selected tax will be added up and used to determine the application of the account stamp.
 
 Manual mode:
 
 - Go to 'Tax Stamp 2 euro' product and deselect 'Auto-compute' checkbox.
 
-- For each invoice, manually enable 'Tax Stamp' checkbox. The base amount for each selected tax will be added up and used to determine the application of the account stamp.
+- For each invoice, manually enable 'Tax Stamp' checkbox.
 
 Also set income/expense accounts, typically income = 'Debiti per bolli' and expense = 'Valori bollati'.

--- a/l10n_it_account_stamp/views/invoice_view.xml
+++ b/l10n_it_account_stamp/views/invoice_view.xml
@@ -19,7 +19,8 @@
 
                 <field name="date_due" position="after">
                     <field name="auto_compute_stamp" invisible="1"/>
-                    <field name="tax_stamp"  string="Tax stamp" attrs="{'invisible': [('auto_compute_stamp', '=', True)]}"/>
+                    <field name="tax_stamp" string="Tax stamp" invisible="1"/>
+                    <field name="manually_apply_tax_stamp"  attrs="{'invisible': [('auto_compute_stamp', '=', True)]}"/>
                 </field>
 
                 <field name="invoice_line_ids" position="after">

--- a/l10n_it_account_stamp/views/product_view.xml
+++ b/l10n_it_account_stamp/views/product_view.xml
@@ -13,13 +13,10 @@
                         <field name="is_stamp"/>
                         <field name="auto_compute" attrs="{'invisible': [('is_stamp', '=', False)]}"/>
                         <p attrs="{'invisible': ['|',('auto_compute', '=', False), ('is_stamp', '=', False)]}" colspan="2">
-                            For each invoice, the base amount for each selected tax will be added up and used to automatically determine the application of the account stamp.
+                            For each invoice, the base amount for each selected tax will be added up and used to determine the application of the account stamp.
                         </p>
-                        <p attrs="{'invisible': ['|',('auto_compute', '=', True), ('is_stamp', '=', False)]}" colspan="2">
-                            For each invoice, manually enable 'Tax Stamp' checkbox. The base amount for each selected tax will be added up and used to determine the application of the account stamp.
-                        </p>
-                        <field name="stamp_apply_min_total_base" attrs="{'invisible': [('is_stamp', '=', False)]}"/>
-                        <field name="stamp_apply_tax_ids" attrs="{'invisible': [('is_stamp', '=', False)]}" widget="many2many_tags">
+                        <field name="stamp_apply_min_total_base" attrs="{'invisible': ['|',('auto_compute', '=', False), ('is_stamp', '=', False)], 'required': [('auto_compute', '=', True)]}"/>
+                        <field name="stamp_apply_tax_ids" attrs="{'invisible': ['|',('auto_compute', '=', False), ('is_stamp', '=', False)]}" widget="many2many_tags">
                         </field>
                     </group>
                 </group>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

solo nel caso di applicazione del bollo con il metodo manuale: validando la fattura, il bollo viene rimosso





--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
