### PR TITLE
[12.0] IMP l10n_it_fatturapa_in adding "Recompute XML fields" button when fields like "invoices_number" and "registered" are not valorized

### DIFF
--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -74,6 +74,11 @@ class FatturaPAAttachmentIn(models.Model):
         return self.ir_attachment_id.get_xml_string()
 
     @api.multi
+    def recompute_xml_fields(self):
+        self._compute_xml_data()
+        self._compute_registered()
+
+    @api.multi
     @api.depends('ir_attachment_id.datas')
     def _compute_xml_data(self):
         for att in self:

--- a/l10n_it_fatturapa_in/views/account_view.xml
+++ b/l10n_it_fatturapa_in/views/account_view.xml
@@ -19,6 +19,8 @@
                                 <field name="datas" filename="datas_fname"/>
                                 <field name="ftpa_preview_link" widget="url" text="Show preview"
                                        attrs="{'invisible': [('id', '=', False)]}"/>
+                                <button type="object" name="recompute_xml_fields" string="Recompute XML fields" icon="fa-refresh"
+                                    attrs="{'invisible': [('invoices_number', '!=', 0), ('xml_supplier_id', '!=', False), ('invoices_date', '!=', False)]}"/>
                             </div>
                             <field name="datas_fname" invisible="1"></field>
                             <field name="name" invisible="1"></field>


### PR DESCRIPTION
This may happen in case of temporary errors while importing from SDI






--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
