### PR TITLE
[12.0][FIX] l10n_it_intrastat_statement: Arrotondamento amount_euro e statistic_amount_euro, troncamento amount_currency

### DIFF
--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
@@ -35,7 +35,9 @@ class IntrastatStatementPurchaseSection(models.AbstractModel):
             amount_currency = statement_id.round_min_amount(
                 inv_intra_line.amount_currency,
                 statement_id.company_id or company_id,
-                dp_model.precision_get('Account'))
+                dp_model.precision_get('Account'),
+                truncate=True,
+            )
 
         res.update({
             'amount_currency': amount_currency,

--- a/l10n_it_intrastat_statement/views/intrastat.xml
+++ b/l10n_it_intrastat_statement/views/intrastat.xml
@@ -191,8 +191,6 @@
             <field name="help"></field>
             <field name="search_view_id" ref="view_search_account_intrastat_statement" />
         </record>
-        
-        
 
         <menuitem id="menu_account_intrastat_statement"
             action="account_intrastat_statement_action"


### PR DESCRIPTION
Descrizione del problema o della funzionalità: Fix #2133

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing