### PR TITLE
[ADD][l10n_it_fiscal_payment_term] add missing payment method on elec…

### DIFF
--- a/l10n_it_fiscal_payment_term/data/fatturapa_data.xml
+++ b/l10n_it_fiscal_payment_term/data/fatturapa_data.xml
@@ -109,5 +109,9 @@
             <field name="code">MP22</field>
             <field name="name">Trattenuta su somme già riscosse</field>
         </record>
+        <record id="fatturapa_mp23" model="fatturapa.payment_method">
+            <field name="code">MP23</field>
+            <field name="name">PagoPA</field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
…tronic invoice

Descrizione del problema o della funzionalità:
Attualmente nel branch 11 manca il metodo id pagamento MP23 PAgo pa
Comportamento attuale prima di questa PR:
Manca il metodo di pagamento segnalato
Comportamento desiderato dopo questa PR:
Avere il metodo di pagamento mancante



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
