### PR TITLE
[UPD][l10n_it_vat_registries] Lesser update to '_get_tax_lines' metho…

### DIFF
--- a/l10n_it_vat_registries/models/vat_registry.py
+++ b/l10n_it_vat_registries/models/vat_registry.py
@@ -174,6 +174,17 @@ class ReportRegistroIva(models.AbstractModel):
                     invoice and invoice.date_invoice or move.date or ''),
                 'reference': (
                     invoice and invoice.reference or ''),
+
+                # These 4 items are added to make the dictionary more usable
+                # in further customizations, allowing inheriting modules to
+                # retrieve the records that have been used to create the
+                # dictionary itself (instead of receiving a raw-data-only dict)
+                'tax_rec': tax,
+                'move_rec': move,
+                'move_line_rec': self.env['account.move.line'].browse(
+                    [l.id for l in move_lines]
+                ),
+                'invoice_rec': invoice,
             }
             inv_taxes.append(tax_item)
             index += 1


### PR DESCRIPTION
…d to make it more customizable

Comportamento desiderato dopo questa PR:
Rendere i dati che arrivano nel template di stampa dei registri IVA più semplici da manipolare, aggiungendo (oltre ai dati grezzi) i riferimenti ai record che li hanno generati.



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
