### PR TITLE
[12.0][ADD] l10n_it_withholding_tax - print withholding_tax in invoice

### DIFF
--- a/l10n_it_withholding_tax/__manifest__.py
+++ b/l10n_it_withholding_tax/__manifest__.py
@@ -17,6 +17,7 @@
     ],
     "data": [
         'views/account.xml',
+        'views/report_invoice.xml',
         'views/withholding_tax.xml',
         'security/ir.model.access.csv',
         'security/security.xml',

--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -387,6 +387,8 @@ class AccountInvoice(models.Model):
             invoice.amount_net_pay_residual = amount_net_pay_residual
 
     withholding_tax = fields.Boolean('Withholding Tax')
+    withholding_tax_in_print = fields.Boolean(
+        "Show Withholding Tax In Print", default=True)
     withholding_tax_line_ids = fields.One2many(
         'account.invoice.withholding.tax', 'invoice_id',
         'Withholding Tax Lines', copy=True,

--- a/l10n_it_withholding_tax/views/account.xml
+++ b/l10n_it_withholding_tax/views/account.xml
@@ -57,6 +57,12 @@
                         attrs="{'invisible': ['|', ('state', '=', 'draft'), ('withholding_tax', '=', False)]}" class="oe_subtotal_footer_separator"/>
                 </xpath>
 
+                <xpath expr="//page[@name='other_info']/group[1]/group[last()]" position="after">
+                    <group name="withholding_tax_info">
+                        <field name="withholding_tax_in_print"/>
+                    </group>
+                </xpath>
+
             </field>
         </record>
 
@@ -114,6 +120,12 @@
                 <xpath expr="//group[hasclass('oe_subtotal_footer', 'oe_right')]/field[@name='residual']" position="after">
                     <field name="amount_net_pay_residual" widget="monetary" options="{'currency_field': 'currency_id'}"
                         attrs="{'invisible': ['|', ('state', '=', 'draft'), ('withholding_tax', '=', False)]}" class="oe_subtotal_footer_separator"/>
+                </xpath>
+
+                <xpath expr="//page[@name='other_info']/group[1]/group[last()]" position="after">
+                    <group name="withholding_tax_info">
+                        <field name="withholding_tax_in_print"/>
+                    </group>
                 </xpath>
 
             </field>

--- a/l10n_it_withholding_tax/views/report_invoice.xml
+++ b/l10n_it_withholding_tax/views/report_invoice.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="print_withholding_tax" model="ir.ui.view">
+        <field name="name">print_withholding_tax</field>
+        <field name="inherit_id" ref="account.report_invoice_document"/>
+        <field name="arch" type="xml">
+            <xpath expr="//table[@name='invoice_line_table']/thead/tr/th[6]" position="after">
+                <t t-if="o.withholding_tax_in_print and o.withholding_tax">
+                    <th class="text-right">
+                        Withholding Tax
+                    </th>
+                </t>
+            </xpath>
+
+            <xpath expr="//table[@name='invoice_line_table']/tbody[hasclass('invoice_tbody')]//td[6]" position="after">
+                <t t-if="o.withholding_tax_in_print and o.withholding_tax">
+                    <td class="text-right">
+                        <span t-esc="', '.join(map(lambda x: (x.name), line.invoice_line_tax_wt_ids))"/>
+                    </td>
+                </t>
+            </xpath>
+
+            <xpath expr="//div[@id='total']//tr[hasclass('o_total')]" position="after">
+                <t t-if="o.withholding_tax_in_print and o.withholding_tax">
+                    <tr>
+                        <td>
+                            <span>Withholding Tax</span>
+                        </td>
+                        <td class="text-right">
+                            <span t-field="o.withholding_tax_amount"/>
+                        </td>
+                    </tr>
+                    <tr class="border-black">
+                        <td>
+                            <strong>Net To Pay</strong>
+                        </td>
+                        <td class="text-right">
+                            <span t-field="o.amount_net_pay"/>
+                        </td>
+                    </tr>
+                </t>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="report_invoice_document_with_payments" model="ir.ui.view">
+        <field name="name">print_withholding_tax_with_payments</field>
+        <field name="inherit_id" ref="account.report_invoice_document_with_payments"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='total']/div/table" position="inside">
+                <t t-if="o.withholding_tax_in_print and len(payments_vals) > 0">
+                    <tr class="border-black">
+                        <td>
+                            <strong>Residual Net To Pay</strong>
+                        </td>
+                        <td class="text-right">
+                            <span t-field="o.amount_net_pay_residual"/>
+                        </td>
+                    </tr>
+                </t>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Added "withholding_tax_in_print" boolean to manage whether withholding tax is added to the printed invoice. 
Extended print templates to print withholding_tax_amount, amount_net_pay and (only in invoice printed with payment) amount_net_pay_residual.

Aggiunto un campo booleano "withholding_tax_in_print" che controlla se la ritenuta d'acconto deve essere mostrata nella fattura stampata in pdf. Estesi template di stampa per mostrare i campi withholding_tax_amount, amount_net_pay e (solo sulla stampa con pagamenti) amount_net_pay_residual.

Descrizione del problema o della funzionalità:
See #1504
Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:
See #2185 
