### PR TITLE
[12.0][IMP] created invoice directly with riba bank

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account/account.py
+++ b/l10n_it_ricevute_bancarie/models/account/account.py
@@ -152,6 +152,13 @@ class AccountInvoice(models.Model):
         states={'draft': [('readonly', False)]},
     )
 
+    @api.model
+    def create(self, vals):
+        invoice = super().create(vals)
+        if not invoice.riba_partner_bank_id:
+            invoice._onchange_riba_partner_bank_id()
+        return invoice
+
     @api.onchange('partner_id', 'payment_term_id', 'type')
     def _onchange_riba_partner_bank_id(self):
         if not self.riba_partner_bank_id or \

--- a/l10n_it_ricevute_bancarie/tests/test_riba.py
+++ b/l10n_it_ricevute_bancarie/tests/test_riba.py
@@ -94,7 +94,6 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                 }
             )]
         })
-        invoice._onchange_riba_partner_bank_id()
         invoice.action_invoice_open()
         riba_move_line_id = False
         for move_line in invoice.move_id.line_ids:
@@ -237,7 +236,6 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                 }
             )]
         })
-        invoice._onchange_riba_partner_bank_id()
         invoice.action_invoice_open()
         for move_line in invoice.move_id.line_ids:
             if move_line.account_id.id == self.account_rec1_id.id:
@@ -338,7 +336,6 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                 }
             )],
         })
-        invoice._onchange_riba_partner_bank_id()
         invoice.action_invoice_open()
         # issue wizard
         riba_move_line_id = invoice.move_id.line_ids.filtered(
@@ -393,7 +390,6 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                 }
             )],
         })
-        invoice._onchange_riba_partner_bank_id()
         invoice.action_invoice_open()
         invoice1 = self.env['account.invoice'].create({
             'date_invoice': recent_date,
@@ -419,7 +415,6 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                 }
             )],
         })
-        invoice1._onchange_riba_partner_bank_id()
         invoice1.action_invoice_open()
         # issue wizard
         riba_move_line_id = invoice.move_id.line_ids.filtered(


### PR DESCRIPTION
Descrizione del problema o della funzionalità: la creazione della fattura attraverso processi automatici (non direttamente) è senza banca di appoggio per le riba

Comportamento attuale prima di questa PR: non c'è la banca

Comportamento desiderato dopo questa PR: c'è la banca




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing