### PR TITLE
[12.0][FIX][l10n_it_fatturapa_out_triple_discount] 

### DIFF
--- a/l10n_it_fatturapa_out_triple_discount/wizards/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out_triple_discount/wizards/wizard_export_fatturapa.py
@@ -21,12 +21,12 @@ class WizardExportFatturapa(models.TransientModel):
                 DettaglioLinea.ScontoMaggiorazione.append(
                     ScontoMaggiorazioneType(
                         Tipo='SC',
-                        Percentuale='%.8f' % float_round(line.discount2, 8)
+                        Percentuale='%.2f' % float_round(line.discount2, 8)
                     ))
             if line.discount3:
                 DettaglioLinea.ScontoMaggiorazione.append(
                     ScontoMaggiorazioneType(
                         Tipo='SC',
-                        Percentuale='%.8f' % float_round(line.discount3, 8)
+                        Percentuale='%.2f' % float_round(line.discount3, 8)
                     ))
         return res


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Issue: #2213

Comportamento attuale prima di questa PR:
la fattura viene scartata dall'ADE/SDI perchè le cifre decimale sono 6 e non sono conformi alle specifiche
Comportamento desiderato dopo questa PR:
la fattura non viene scartata dall'ADE/SDI



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
