### PR TITLE
[10.0][l10n_it_central_journal] Fix proper page subtotals

### DIFF
--- a/account_vat_period_end_statement/views/report_vatperiodendstatement.xml
+++ b/account_vat_period_end_statement/views/report_vatperiodendstatement.xml
@@ -11,6 +11,11 @@ Document
                 <!--
                 Periods detail
                 -->
+                <t t-set="total_vat_deductible_credit" t-value="(0)"/>
+                <t t-set="total_vat_deductible_debit" t-value="(0)"/>
+                <t t-set="total_vat_deductible" t-value="(0)"/>
+                <t t-set="total_vat" t-value="(0)"/>
+
                 <t t-foreach="statement.date_range_ids" t-as="period">
                        <h3><span>Summary</span> <span t-esc="period.name"/> </h3>
 
@@ -20,11 +25,28 @@ Document
                        <t t-set="tax_code_section" t-value="'purchase'"/>
                        <t t-call="account_vat_period_end_statement.report_vatperiodendstatement_tax_code"/>
 
+                        <t t-set="total_vat_deductible" t-value="(0)"/>
+                        <t t-foreach="tax_code_amounts" t-as="tax_code">
+                            <!-- Prepare values -->
+                            <t t-set="tax_code_vat_deductible" t-value="(tax_code_amounts[tax_code]['vat_deductible'])"/>
+                            <t t-set="total_vat_deductible" t-value="(total_vat_deductible + tax_code_vat_deductible)"/>
+                        </t>
+
+                       <t t-set="total_vat_deductible_credit" t-value="(total_vat_deductible_credit + total_vat_deductible)"/>
+
                        <!-- Sale -->
                        <t t-set="tax_code_amounts" t-value="tax_amounts(period.id, [l.tax_id.id for l in statement.debit_vat_account_line_ids], 'customer')"/>
                        <t t-set="tax_code_type" t-value="'debit'"/>
                        <t t-set="tax_code_section" t-value="'sale'"/>
                        <t t-call="account_vat_period_end_statement.report_vatperiodendstatement_tax_code"/>
+
+                        <t t-set="total_vat" t-value="(0)"/>
+                        <t t-foreach="tax_code_amounts" t-as="tax_code">
+                            <t t-set="tax_code_vat" t-value="(tax_code_amounts[tax_code]['vat'])"/>
+                            <t t-set="total_vat" t-value="(total_vat + tax_code_vat)"/>
+                        </t>
+
+                       <t t-set="total_vat_deductible_debit" t-value="(total_vat_deductible_debit + total_vat)"/>
                    </t>
 
                    <!--
@@ -32,30 +54,27 @@ Document
                 -->
                 <t t-set="total_statement" t-value="(0)"/>
 
+                <span>out Credit <t t-esc="total_vat_deductible_credit"/></span>
+                <span>out Debit <t t-esc="total_vat_deductible_debit"/></span>
+
                 <h3>Total Statement</h3>
 
                 <table class="table table-condensed">
                     <!-- tot debit -->
-                       <t t-set="vat_accounts" t-value="account_vat_amounts('debit', statement.debit_vat_account_line_ids)"/>
-                       <t t-foreach="vat_accounts" t-as="account_id">
-                           <tr>
-                               <td class="text-right">Total debit vat</td>
-                               <td class="text-right"><span t-esc="formatLang(env, vat_accounts[account_id]['amount'])" /></td>
-                           </tr>
-                           <!-- sum -->
-                           <t t-set="total_statement" t-value="(total_statement + vat_accounts[account_id]['amount'])"/>
-                       </t>
+                       <tr>
+                           <td class="text-right">Total debit vat</td>
+                           <td class="text-right"><span t-esc="formatLang(env, total_vat_deductible_debit)" /></td>
+                       </tr>
+                       <!-- sum -->
+                       <t t-set="total_statement" t-value="(total_statement + total_vat_deductible_debit)"/>
 
                     <!-- tot credit -->
-                    <t t-set="vat_accounts" t-value="account_vat_amounts('credit', statement.credit_vat_account_line_ids)"/>
-                       <t t-foreach="vat_accounts" t-as="account_id">
-                           <tr>
-                               <td class="text-right">Total credit vat</td>
-                               <td class="text-right"><span t-esc="formatLang(env, vat_accounts[account_id]['amount'])" /></td>
-                           </tr>
-                           <!-- sum -->
-                           <t t-set="total_statement" t-value="(total_statement - vat_accounts[account_id]['amount'])"/>
-                       </t>
+                       <tr>
+                           <td class="text-right">Total credit vat</td>
+                           <td class="text-right"><span t-esc="formatLang(env, total_vat_deductible_credit)" /></td>
+                       </tr>
+                       <!-- sum -->
+                       <t t-set="total_statement" t-value="(total_statement - total_vat_deductible_credit)"/>
 
                        <!-- tot statement -->
                        <tr>

--- a/l10n_it_central_journal/README.rst
+++ b/l10n_it_central_journal/README.rst
@@ -14,6 +14,7 @@ Contributors
 
 * Gianmarco Conte <gconte@dinamicheaziendali.it>
 * Lara Baggio <lbaggio@linkgroup.it>
+* Roberto Fichera <roberto.fichera@levelprime.com>
 
 Maintainer
 ----------

--- a/l10n_it_central_journal/__manifest__.py
+++ b/l10n_it_central_journal/__manifest__.py
@@ -8,21 +8,24 @@
     'name': 'Italian Localization - Account central journal',
     'version': '10.0.1.0.2',
     'category': 'Localization/Italy',
-    'author': 'Dinamiche Aziendali, Odoo Community Association (OCA)',
+    'author': 'Dinamiche Aziendali, '
+              'Level Prime Srl, '
+              'Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/l10n-italy/tree/'
                '10.0/l10n_it_central_journal',
     'license': 'AGPL-3',
     "depends": [
         'account',
         'l10n_it_account',
-        'date_range'
-        ],
+        'date_range',
+        'report',
+    ],
     "data": [
         'security/ir.model.access.csv',
         'report/reports.xml',
         'wizard/print_giornale.xml',
         'views/report_account_central_journal.xml',
-        'views/date_range_view.xml'
+        'views/date_range_view.xml',
     ],
     "installable": True,
 }

--- a/l10n_it_central_journal/views/date_range_view.xml
+++ b/l10n_it_central_journal/views/date_range_view.xml
@@ -20,7 +20,16 @@
             <field name="inherit_id"
                    ref="date_range.view_date_range_form_view"/>
             <field name="arch" type="xml">
-                <xpath expr="/form/group" position="after">
+                <xpath expr="/form/group" position="replace">
+                    <group col="4">
+                        <field name="name"/>
+                        <field name="type_id"/>
+                        <field name="period"/>
+                        <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                        <field name="date_start"/>
+                        <field name="date_end"/>
+                        <field name="active"/>
+                    </group>
                     <separator string="Central journal info"/>
                     <group>
                         <field name="date_last_print"/>
@@ -28,6 +37,7 @@
                         <field name="progressive_line_number"/>
                         <field name="progressive_credit"/>
                         <field name="progressive_debit"/>
+                        <field name="print_row"/>
                     </group>
                 </xpath>
             </field>

--- a/l10n_it_central_journal/views/report_account_central_journal.xml
+++ b/l10n_it_central_journal/views/report_account_central_journal.xml
@@ -1,164 +1,272 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-<data>
-
-<template id="report_giornale">
-    <t t-call="report.html_container">
-        <t t-set="title" t-value="'Stampa libro giornale'"/>
-        <t t-set="l10n_it_count_fiscal_year" t-value="year_footer"/>
-        <t t-call="l10n_it_account.internal_layout">
-            <div class="page">
-                <t t-set="print_details" t-value="1"/>
-                <table style="width:100%; font-size: small;" cellspacing="0">
-                        <style>
-                            table {border: 0px;}
-                            thead {background: #F5F5F5;}
-                            .left_without_line {
-                                text-align:left; vertical-align:text-top; padding:5px;
+    <data>
+        <template id="minimal_layout" inherit_id="report.minimal_layout">
+            <xpath expr="//t[@t-if='subst is True']" position="replace">
+                <t t-if="subst is True">
+                    <script>
+                        function subst() {
+                            var vars = {};
+                            var x = document.location.search.substring(1).split('&amp;');
+                            for (var i in x) {
+                                var z = x[i].split('=', 2);
+                                vars[z[0]] = unescape(z[1]);
                             }
-                            .right_without_line {
-                                text-align:right; vertical-align:text-top; padding:5px;
+                            var x=['frompage', 'topage', 'page', 'webpage', 'section', 'subsection', 'subsubsection'];
+                            var page_base = document.getElementById('l10n_it_count_fiscal_page_base')
+                            for (var i in x) {
+                                var y = document.getElementsByClassName(x[i]);
+                                fiscal_page_base = 0
+                                if (page_base!=null) {
+                                    if (page_base.innerHTML) {
+                                        fiscal_page_base = parseInt(page_base.innerHTML);
+                                    }
+                                }
+                                for (var j=0; j&lt;y.length; ++j) {
+                                    if (page_base!=null) {
+                                        y[j].textContent = parseInt(eval(vars[x[i]]) + fiscal_page_base);
+                                    }
+                                    else
+                                    {
+                                        y[j].textContent = vars[x[i]];
+                                    }
+                                }
                             }
-                            .new_move {
-                                border-top: 1px dotted grey;
-                            }
-                     </style>
-                    <thead>
-                        <tr style="page-break-inside: avoid">
-                            <th class="left_without_line">Row</th>
-                            <th class="left_without_line">Date</th>
-                            <th class="left_without_line">Ref</th>
-                            <th class="left_without_line">Account move</th>
-                            <th class="left_without_line">Account code</th>
-                            <th class="left_without_line">Account name</th>
-                            <th class="left_without_line">Name</th>
-                            <th class="right_without_line">Debit</th>
-                            <th class="right_without_line">Credit</th>
-                        </tr>
-                    </thead>
+                        }
+                    </script>
+                </t>
+            </xpath>
+        </template>
 
-                    <t t-set="counter" t-value="start_row"/>
-                    <t t-set="save_move_id" t-value="0"/>
-                    <t t-set="tot_credit" t-value="progressive_credit"/>
-                    <t t-set="tot_debit" t-value="progressive_debit"/>
-                    <t t-set="class_new_move" t-value="''"/>
+        <template id="report_giornale">
+            <t t-call="report.html_container">
+                <t t-set="title" t-value="'Stampa libro giornale'"/>
+                <t t-set="fiscal_page_base" t-value="l10n_it_count_fiscal_page_base"/>
+                <t t-set="l10n_it_count_fiscal_year" t-value="year_footer"/>
+                <t t-call="l10n_it_central_journal.internal_layout_ice">
+                    <div class="page">
+                        <t t-set="number_row" t-value="print_row"/>
+                        <t t-set="counter" t-value="start_row"/>
+                        <t t-set="save_move_id" t-value="0"/>
+                        <t t-set="tot_credit" t-value="progressive_credit"/>
+                        <t t-set="tot_debit" t-value="progressive_debit"/>
+                        <t t-set="class_new_move" t-value="''"/>
 
-                    <tbody>
-                        <tr style="page-break-inside: avoid;">
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line">Initial Balance</td>
-                            <!-- Debit -->
-                            <td class="right_without_line">
-                                <div style="page-break-inside: avoid"
-                                t-esc="formatLang(env, tot_debit)" />
-                            </td>
-                            <!-- Credit -->
-                            <td class="right_without_line">
-                                <div style="page-break-inside: avoid"
-                                t-esc="formatLang(env, tot_credit)" />
-                            </td>
-                        </tr>
+                        <t t-foreach="get_move(data['ids'],number_row)" t-as="line_main">
+                            <table style="width:100%; font-size: 8px !important;" cellspacing="0">
+                                <style>
+                                    table {border: 0px;}
+                                    thead {background: #F5F5F5;}
+                                    .left_without_line {
+                                    text-align:left; vertical-align:text-top; padding:5px;
+                                    }
+                                    .right_without_line {
+                                    text-align:right; vertical-align:text-top; padding:5px;
+                                    }
+                                    .new_move {
+                                    border-top: 1px dotted grey;
+                                    }
+                                </style>
+                                <thead>
+                                    <tr style="page-break-inside: avoid">
+                                        <th class="left_without_line">Row</th>
+                                        <th class="left_without_line">Date</th>
+                                        <th class="left_without_line">Ref</th>
+                                        <th class="left_without_line">Account move</th>
+                                        <th class="left_without_line">Account code</th>
+                                        <th class="left_without_line">Account name</th>
+                                        <th class="left_without_line">Name</th>
+                                        <th class="right_without_line">Debit</th>
+                                        <th class="right_without_line">Credit</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr style="page-break-inside: avoid;">
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <t t-if="counter==start_row">
+                                            <td class="left_without_line">Initial Balance</td>
+                                            <!-- Debit -->
+                                            <td class="right_without_line">
+                                                <div style="page-break-inside: avoid"
+                                                     t-esc="formatLang(env, tot_debit)"/>
+                                            </td>
+                                            <!-- Credit -->
+                                            <td class="right_without_line">
+                                                <div style="page-break-inside: avoid"
+                                                     t-esc="formatLang(env, tot_credit)"/>
+                                            </td>
+                                        </t>
+                                        <t t-else="">
+                                            <td class="left_without_line">Partial Balance</td>
+                                            <!-- Debit -->
+                                            <td class="right_without_line">
+                                                <div style="page-break-inside: avoid"
+                                                     t-esc="formatLang(env, tot_debit)"/>
+                                            </td>
+                                            <!-- Credit -->
+                                            <td class="right_without_line">
+                                                <div style="page-break-inside: avoid"
+                                                     t-esc="formatLang(env, tot_credit)"/>
+                                            </td>
+                                        </t>
+                                    </tr>
+                                    <t t-foreach="line_main" t-as="line">
 
-                        <t t-foreach="get_move(data['ids'])" t-as="line">
-                            <t t-set="counter" t-value="counter + 1"/>
-                            <t t-set="tot_credit" t-value="tot_credit + line.credit"/>
-                            <t t-set="tot_debit" t-value="tot_debit + line.debit"/>
+                                        <t t-set="counter" t-value="counter + 1"/>
+                                        <t t-set="tot_credit" t-value="tot_credit + line.credit"/>
+                                        <t t-set="tot_debit" t-value="tot_debit + line.debit"/>
+                                        <t t-if="line.move_id.id != save_move_id">
+                                            <t t-set="class_new_move" t-value="'new_move'"/>
+                                        </t>
+                                        <t t-if="line.move_id.id == save_move_id">
+                                            <t t-set="class_new_move" t-value="''"/>
+                                        </t>
 
-                            <t t-if="line.move_id.id != save_move_id">
-                               <t t-set="class_new_move" t-value="'new_move'"/>
-                            </t>
-                            <t t-if="line.move_id.id == save_move_id">
-                               <t t-set="class_new_move" t-value="''"/>
-                            </t>
-
-                            <tr style="page-break-inside: avoid;" t-att-class="class_new_move">
-                                <!-- Row -->
-                                <td class="left_without_line">
-                                    <div style="page-break-inside: avoid"
-                                    t-esc="counter"/>
-                                </td>
-                                <!-- Date -->
-                                <td class="left_without_line">
-                                    <div style="page-break-inside: avoid"
-                                         t-esc="time.strftime(date_format, time.strptime(line['date'],'%Y-%m-%d'))"/>
-                                </td>
-                                <!-- ref -->
-                                <td class="left_without_line">
-                                    <div style="page-break-inside: avoid;word-break: break-all;"
-                                    t-esc="line.ref"/>
-                                </td>
-                                <!-- Account move -->
-                                <td class="left_without_line">
-                                    <div style="page-break-inside: avoid;word-break: break-all;"
-                                    t-esc="line.move_id.name" />
-                                </td>
-                                <!-- Account code -->
-                                <td class="left_without_line">
-                                    <div style="page-break-inside: avoid"
-                                    t-esc="line.account_id.code" />
-                                </td>
-                                <!-- Account name -->
-                                <td class="left_without_line">
-                                    <div style="page-break-inside: avoid;word-break: break-all;"
-                                    t-esc="line.account_id.name" />
-                                </td>
-                                <!-- Name -->
-                                <td class="left_without_line">
-                                    <t t-if="line.account_id.user_type_id.type in ['receivable', 'payable']">
-                                        <div style="page-break-inside: avoid;word-break: break-all;"
-                                        t-esc="line.partner_id.name" />
+                                        <tr style="page-break-inside: avoid;" t-att-class="class_new_move">
+                                            <!-- Row -->
+                                            <td class="left_without_line">
+                                                <div style="page-break-inside: avoid" t-esc="counter"/>
+                                            </td>
+                                            <!-- Date -->
+                                            <td class="left_without_line">
+                                                <div style="page-break-inside: avoid"
+                                                     t-esc="time.strftime(date_format, time.strptime(line['date'],'%Y-%m-%d'))"/>
+                                            </td>
+                                            <!-- ref -->
+                                            <td class="left_without_line">
+                                                <div style="page-break-inside: avoid;word-break: break-all;"
+                                                     t-esc="line.ref"/>
+                                            </td>
+                                            <!-- Account move -->
+                                            <td class="left_without_line">
+                                                <div style="page-break-inside: avoid;word-break: break-all;"
+                                                     t-esc="line.move_id.name"/>
+                                            </td>
+                                            <!-- Account code -->
+                                            <td class="left_without_line">
+                                                <div style="page-break-inside: avoid"
+                                                     t-esc="line.account_id.code"/>
+                                            </td>
+                                            <!-- Account name -->
+                                            <td class="left_without_line">
+                                                <div style="page-break-inside: avoid;word-break: break-all;"
+                                                     t-esc="line.account_id.name"/>
+                                            </td>
+                                            <!-- Name -->
+                                            <td class="left_without_line">
+                                                <t t-if="line.account_id.user_type_id.type in ['receivable', 'payable']">
+                                                    <div style="page-break-inside: avoid;word-break: break-all;"
+                                                         t-esc="line.partner_id.name"/>
+                                                </t>
+                                                <t t-else="">
+                                                    <div style="page-break-inside: avoid;word-break: break-all;"
+                                                         t-esc="line.name"/>
+                                                </t>
+                                            </td>
+                                            <!-- Debit -->
+                                            <td class="right_without_line">
+                                                <div style="page-break-inside: avoid"
+                                                     t-esc="formatLang(env, line.debit)"/>
+                                            </td>
+                                            <!-- Credit -->
+                                            <td class="right_without_line">
+                                                <div style="page-break-inside: avoid"
+                                                     t-esc="formatLang(env, line.credit)"/>
+                                            </td>
+                                        </tr>
+                                        <t t-set="save_move_id" t-value="line.move_id.id"/>
                                     </t>
-                                    <t t-else="">
-                                        <div style="page-break-inside: avoid;word-break: break-all;"
-                                        t-esc="line.name" />
-                                    </t>
-                                </td>
-                                <!-- Debit -->
-                                <td class="right_without_line">
-                                    <div style="page-break-inside: avoid"
-                                    t-esc="formatLang(env, line.debit)" />
-                                </td>
-                                <!-- Credit -->
-                                <td class="right_without_line">
-                                    <div style="page-break-inside: avoid"
-                                    t-esc="formatLang(env, line.credit)" />
-                                </td>
-                            </tr>
+                                </tbody>
+                                <t t-set="class_new_move" t-value="'new_move'"/>
+                                <t t-if="counter==len(data['ids'])">
+                                    <tr style="page-break-inside: avoid;" t-att-class="class_new_move">
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line">Final Balance</td>
 
-                            <t t-set="save_move_id" t-value="line.move_id.id"/>
+                                        <!-- Debit -->
+                                        <td class="right_without_line">
+                                            <div style="page-break-inside: avoid"
+                                                 t-esc="formatLang(env, tot_debit)"/>
+                                        </td>
+                                        <!-- Credit -->
+                                        <td class="right_without_line">
+                                            <div style="page-break-inside: avoid"
+                                                 t-esc="formatLang(env, tot_credit)"/>
+                                        </td>
+                                    </tr>
+                                </t>
+                                <t t-else="counter % number_row == 0">
+                                    <t t-set="fiscal_page_base" t-value="fiscal_page_base+1"/>
+                                    <p style="page-break-after:always"/>
+                                    <tr style="page-break-inside: avoid;" t-att-class="class_new_move">
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line"></td>
+                                        <td class="left_without_line">Balance Page</td>
+
+                                        <!-- Debit -->
+                                        <td class="right_without_line">
+                                            <div style="page-break-inside: avoid"
+                                                 t-esc="formatLang(env, tot_debit)"/>
+                                        </td>
+                                        <!-- Credit -->
+                                        <td class="right_without_line">
+                                            <div style="page-break-inside: avoid"
+                                                 t-esc="formatLang(env, tot_credit)"/>
+                                        </td>
+                                    </tr>
+                                </t>
+
+                            </table>
+                            <t t-if="counter % number_row == 0">
+                                <p style="page-break-after: always;"/>
+                            </t>
                         </t>
-                        <t t-set="class_new_move" t-value="'new_move'"/>
-                        <tr style="page-break-inside: avoid;" t-att-class="class_new_move">
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line"> </td>
-                            <td class="left_without_line">Final Balance</td>
-                            <!-- Debit -->
-                            <td class="right_without_line">
-                                <div style="page-break-inside: avoid"
-                                t-esc="formatLang(env, tot_debit)" />
-                            </td>
-                            <!-- Credit -->
-                            <td class="right_without_line">
-                                <div style="page-break-inside: avoid"
-                                t-esc="formatLang(env, tot_credit)" />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-                <br/>
-            </div>
-            <t t-set="save_move_id" t-value="save_print_info(daterange,print_state,date_move_line_to,counter,tot_debit,tot_credit)"/>
-        </t>
-    </t>
-</template>
+                    </div>
+
+                    <t t-set="save_move_id"
+                       t-value="save_print_info(daterange,print_state,date_move_line_to,counter,tot_debit,tot_credit,fiscal_page_base)"/>
+                </t>
+            </t>
+
+        </template>
+
+        <template id="internal_layout_ice" inherit_id="l10n_it_account.internal_layout">
+            <xpath expr="//div[@class='footer']" position="replace">
+                <div class="footer">
+                    <div class="row">
+                        <div class="col-xs-4"></div>
+                        <div class="col-xs-4 col-xs-offset-4 text-right">
+                            <span style="display: none;" id="l10n_it_count_fiscal_page_base"
+                                  t-esc="l10n_it_count_fiscal_page_base" />
+                            <ul class="list-inline">Esercizio:
+
+                                <t t-if="l10n_it_count_fiscal_year">
+                                    <span t-esc="l10n_it_count_fiscal_year"/>
+                                </t>
+                                <t t-if="not l10n_it_count_fiscal_year">
+                                    <span t-esc="context_timestamp(datetime.datetime.now()).strftime('%Y')"/>
+                                </t>
+                                / Pag: <span class="page"/>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+            </xpath>
+        </template>
 </data>
 </openerp>

--- a/l10n_it_central_journal/wizard/print_giornale.xml
+++ b/l10n_it_central_journal/wizard/print_giornale.xml
@@ -28,6 +28,7 @@
                     <field name="fiscal_page_base"/>
                     <field name="start_row"/>
                     <field name="year_footer"/>
+                    <field name="print_row" invisible="1"/>
                     <field name="progressive_credit" invisible="1"/>
                     <field name="progressive_debit2" invisible="1"/>
                 </group>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Implementa la stampa del libro giornale come da normativa di legge.

A causa del sistema di stampa del ``qweb`` per l'header ed il footer risulta un pò difficoltoso ottenere il risultato con il supporto standard di odoo. La PR utilizza un'approccio per certi versi "brutale" perchè approccia il problama non utilizzando header e footer ma  decidendo a priori quante righe per pagina è possibile stampare e quindi utilizzando la prima e ultima riga per riportare i progressivi e totali di pagina

Comportamento attuale prima di questa PR:

La stampa del libro giornale non rispetta le caratteristiche necessarie di legge che prevedono i riporti ad inizio anno/progressivi ed i totali a fine pagina.

Comportamento desiderato dopo questa PR:

Implementare una vera e propria stampa del libro giornale così come richiesto dalla normativa odierna,


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
