### PR TITLE
[12.0][FIX] add riba partner bank to out_refund for compensated riba

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account/account.py
+++ b/l10n_it_ricevute_bancarie/models/account/account.py
@@ -159,7 +159,7 @@ class AccountInvoice(models.Model):
             bank_id = None
             if (
                 self.partner_id and self.payment_term_id.riba
-                and self.type == 'out_invoice'
+                and self.type in ['out_invoice', 'out_refund']
             ):
                 bank_id = self.partner_id.mapped('bank_ids')
             self.riba_partner_bank_id = bank_id[0] if bank_id else None

--- a/l10n_it_ricevute_bancarie/views/account_view.xml
+++ b/l10n_it_ricevute_bancarie/views/account_view.xml
@@ -117,7 +117,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='payment_term_id']" position="after">
                 <field name="is_riba_payment" invisible="1" />
-                <field name="riba_partner_bank_id" attrs="{'invisible': ['|',('is_riba_payment','=', False),('type','!=','out_invoice')], 'required': ['&amp;',('is_riba_payment','=', True),('type','=', 'out_invoice')]}" domain="[('partner_id','=', partner_id)]"/>
+                <field name="riba_partner_bank_id" attrs="{'invisible': ['|',('is_riba_payment','=', False),('type','not in',['out_invoice', 'out_refund'])], 'required': ['&amp;',('is_riba_payment','=', True),('type', 'in', ['out_invoice', 'out_refund'])]}" domain="[('partner_id','=', partner_id)]"/>
                 <field name="is_unsolved" string="Past Due"
                        attrs="{'invisible': [('is_unsolved', '=', False)]}"/>
             </xpath>


### PR DESCRIPTION
Descrizione del problema o della funzionalità: non è possibile compensare una riba su fattura con una riba su n.c. perchè non c'è la banca sulla n.c.

Comportamento attuale prima di questa PR: la riba su n.c. non può essere compensata

Comportamento desiderato dopo questa PR: la riba su n.c. può essere compensata




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing