### PR TITLE
[10.0][FIX] l10n_it_intrastat_statement: force round to 1 additional_units field only if has a value

### DIFF
--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
@@ -149,10 +149,13 @@ class IntrastatStatementPurchaseSection1(models.Model):
             statement_id.company_id or company_id,
             dp_model.precision_get('Account'))
 
+        # check if additional_units has a value
+        has_additional_units = bool(inv_intra_line.additional_units)
         res.update({
             'transaction_nature_id': transaction_nature_id.id,
             'weight_kg': round(inv_intra_line.weight_kg) or 1,
-            'additional_units': round(inv_intra_line.additional_units) or 1,
+            'additional_units': round(inv_intra_line.additional_units) or (
+                0 if not has_additional_units else 1),
             'statistic_amount_euro': statistic_amount,
             'delivery_code_id': delivery_code_id.id,
             'transport_code_id': transport_code_id.id,

--- a/l10n_it_intrastat_statement/models/intrastat_statement_sale_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_sale_section.py
@@ -113,10 +113,13 @@ class IntrastatStatementSaleSection1(models.Model):
             statement_id.company_id or company_id,
             dp_model.precision_get('Account'))
 
+        # check if additional_units has a value
+        has_additional_units = bool(inv_intra_line.additional_units)
         res.update({
             'transaction_nature_id': transaction_nature_id.id,
             'weight_kg': round(inv_intra_line.weight_kg) or 1,
-            'additional_units': round(inv_intra_line.additional_units) or 1,
+            'additional_units': round(inv_intra_line.additional_units) or (
+                0 if not has_additional_units else 1),
             'statistic_amount_euro': statistic_amount,
             'delivery_code_id': delivery_code_id.id,
             'transport_code_id': transport_code_id.id,


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

Comportamento attuale prima di questa PR:
in fase di ricalcolo della dichiarazione intrastat si verifica un arrotondamento forzato al valore 1 per il campo **additional_units** anche se questo non è valorizzato.

Comportamento desiderato dopo questa PR:
l'arrotondamento forzato a 1 verrà fatto solo se il campo è valorizzato, e quindi con valori compresi tra 0.1 e 0.4



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
