### PR TITLE
[14.0][IMP] l10n_it_account: menu per gestione intervalli data

### DIFF
--- a/l10n_it_account/__manifest__.py
+++ b/l10n_it_account/__manifest__.py
@@ -11,12 +11,13 @@
     "summary": "Modulo base usato come dipendenza di altri moduli contabili",
     "version": "14.0.1.0.0",
     "category": "Hidden",
-    "author": "Agile Business Group, Abstract, " "Odoo Community Association (OCA)",
+    "author": "Agile Business Group, Abstract, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-italy",
     "license": "AGPL-3",
     "depends": [
         "account_fiscal_year",
         "account_tax_balance",
+        "date_range",
         "web",
     ],
     "data": [

--- a/l10n_it_account/views/account_menuitem.xml
+++ b/l10n_it_account/views/account_menuitem.xml
@@ -6,4 +6,23 @@
     <record id="account.menu_finance" model="ir.ui.menu">
         <field name="name">Accounting</field>
     </record>
+    <!-- Add date range menu -->
+    <menuitem
+        id="menu_date_range_accounting"
+        name="Date ranges"
+        parent="account.account_account_menu"
+    >
+        <menuitem
+            id="menu_date_range_action_accounting"
+            action="date_range.date_range_action"
+        />
+        <menuitem
+            id="menu_date_range_type_action_accounting"
+            action="date_range.date_range_type_action"
+        />
+        <menuitem
+            id="menu_date_range_generator_action"
+            action="date_range.date_range_generator_action"
+        />
+    </menuitem>
 </odoo>


### PR DESCRIPTION
**Descrizione della funzionalità**
Per i moduli `account_vat_period_end_statement`, `l10n_it_central_journal`, `l10n_it_vat_registries` è utile avere i menu per la creazione degli intervalli data tra le configurazioni della contabilità.

**Comportamento attuale prima di questa PR**
I menu sono accessibili solo in modalità debug da Impostazioni > Funzioni tecniche > Intervalli data

**Comportamento desiderato dopo questa PR**
I menu sono accessibili da Fatturazione > Configurazione > Contabilità

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
