### PR TITLE
[12.0] [l10n_it_fiscalcode] Codice fiscale per la persona dovrebbe avere caratteri in maiuscolo

### DIFF
--- a/l10n_it_fiscalcode/model/res_partner.py
+++ b/l10n_it_fiscalcode/model/res_partner.py
@@ -31,3 +31,8 @@ class ResPartner(models.Model):
         (check_fiscalcode,
          "The fiscal code doesn't seem to be correct.", ["fiscalcode"])
     ]
+
+    @api.onchange('fiscalcode')
+    def _fiscalcode_changed(self):
+        if self.fiscalcode:
+            self.fiscalcode = self.fiscalcode.upper()


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

https://github.com/OCA/l10n-italy/issues/2250

Il codice fiscale di una persona non viene convertito in maiuscolo e questo causa un errore nella creazione della fattura elettronica oltre che non rispetta la convenzione per cui tutti i codici fiscali sono scritti in maiuscolo

Comportamento attuale prima di questa PR:

Codice fiscale salvato e visualizzato in minuscolo se così scritto

Comportamento desiderato dopo questa PR:

Il codice fiscale viene convertito in maiuscolo se scritto in minuscolo.




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
