### PR TITLE
[12.0][FIX] invoice_ddt.xml xml refactor

### DIFF
--- a/account_invoice_report_ddt_group/views/invoice_ddt.xml
+++ b/account_invoice_report_ddt_group/views/invoice_ddt.xml
@@ -4,9 +4,11 @@
               inherit_id="account.report_invoice_document" >
         <xpath expr="//table[@name='invoice_line_table']/thead/tr/th[1]" position="after">
             <t t-set="has_serial_number" t-value="o.has_serial_number()" groups="stock.group_production_lot"/>
-            <th name="lot_serial" t-if="has_serial_number">
-                <strong>Lots/Serial Numbers</strong>
-            </th>
+            <t t-if="has_serial_number">
+                <th name="lot_serial">
+                    <strong>Lots/Serial Numbers</strong>
+                </th>
+            </t>
         </xpath>
         <xpath expr="//td[@name='account_invoice_line_name']" position="after">
             <t t-if="has_serial_number">


### PR DESCRIPTION
This small PR moves the t-if element in its own <t> element. As a result, the xml is more consistent, and allows other modules to inherit the view in a cleaner way, without undesired behaviour caused by an inconsistent number of th and td elements.

Necessary for #2193

Estraendo il t-if in un elemento <t> a sé stante, l'xml diventa più consistente e si può ereditare la stessa view senza comportamenti indesiderati causati da un numero inconsistente di elementi th e td.

Necessario per #2193
