### PR TITLE
[12.0][FIX] l10n_it_account_stamp: Configurazione mancante in multi-company

### DIFF
--- a/l10n_it_account_stamp/models/company.py
+++ b/l10n_it_account_stamp/models/company.py
@@ -1,6 +1,6 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from odoo import fields, models, api
+from odoo import fields, models
 
 
 class ResCompany(models.Model):
@@ -17,19 +17,5 @@ class AccountConfigSettings(models.TransientModel):
 
     tax_stamp_product_id = fields.Many2one(
         related='company_id.tax_stamp_product_id',
-        string="Tax Stamp Product",
-        help="Product used as Tax Stamp in customer invoices.",
         readonly=False
         )
-
-    @api.onchange('company_id')
-    def onchange_company_id(self):
-        res = super(AccountConfigSettings, self).onchange_company_id()
-        if self.company_id:
-            company = self.company_id
-            self.tax_stamp_product_id = (
-                company.tax_stamp_product_id and
-                company.tax_stamp_product_id.id or False)
-        else:
-            self.tax_stamp_product_id = False
-        return res

--- a/l10n_it_account_stamp/models/invoice.py
+++ b/l10n_it_account_stamp/models/invoice.py
@@ -129,6 +129,7 @@ class AccountInvoice(models.Model):
         res = super(AccountInvoice, self).action_move_create()
         for inv in self:
             if inv.tax_stamp and not inv.is_tax_stamp_line_present():
+                posted = False
                 if inv.move_id.state == 'posted':
                     posted = True
                     inv.move_id.state = 'draft'

--- a/l10n_it_account_stamp/models/invoice.py
+++ b/l10n_it_account_stamp/models/invoice.py
@@ -13,7 +13,7 @@ class AccountInvoice(models.Model):
     manually_apply_tax_stamp = fields.Boolean("Apply tax stamp")
 
     def is_tax_stamp_applicable(self):
-        stamp_product_id = self.env.user.with_context(
+        stamp_product_id = self.with_context(
             lang=self.partner_id.lang).company_id.tax_stamp_product_id
         if not stamp_product_id:
             raise exceptions.Warning(
@@ -50,7 +50,7 @@ class AccountInvoice(models.Model):
         for inv in self:
             if not inv.tax_stamp:
                 raise exceptions.Warning(_("Tax stamp is not applicable"))
-            stamp_product_id = self.env.user.with_context(
+            stamp_product_id = inv.with_context(
                 lang=inv.partner_id.lang).company_id.tax_stamp_product_id
             if not stamp_product_id:
                 raise exceptions.Warning(
@@ -134,7 +134,7 @@ class AccountInvoice(models.Model):
                     posted = True
                     inv.move_id.state = 'draft'
                 line_model = self.env['account.move.line']
-                stamp_product_id = self.env.user.with_context(
+                stamp_product_id = inv.with_context(
                     lang=inv.partner_id.lang).company_id.tax_stamp_product_id
                 if not stamp_product_id:
                     raise exceptions.Warning(

--- a/l10n_it_account_stamp/tests/__init__.py
+++ b/l10n_it_account_stamp/tests/__init__.py
@@ -1,0 +1,4 @@
+#  Copyright 2021 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_account_stamp

--- a/l10n_it_account_stamp/tests/test_account_stamp.py
+++ b/l10n_it_account_stamp/tests/test_account_stamp.py
@@ -1,0 +1,87 @@
+#  Copyright 2021 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.addons.account.tests.account_test_classes import AccountingTestCase
+
+
+class TestAccountStamp (AccountingTestCase):
+
+    def setUp(self):
+        super(TestAccountStamp, self).setUp()
+        self.partner_model = self.env['res.partner']
+        self.product_model = self.env['product.product']
+        self.invoice_model = self.env['account.invoice']
+        self.tax_model = self.env['account.tax']
+        self.account_model = self.env['account.account']
+
+        self.partner = self.partner_model.create({
+            'name': "Test partner for stamp",
+        })
+        self.product = self.product_model.create({
+            'name': "Test product for stamp",
+            'lst_price': 100,
+        })
+        self.receivable_type_id = self.ref('account.data_account_type_receivable')
+        self.account_receivable = self.account_model.search([
+            ('user_type_id', '=', self.receivable_type_id),
+        ], limit=1)
+        self.revenue_type_id = self.ref('account.data_account_type_revenue')
+        self.account_revenue = self.account_model.search([
+            ('user_type_id', '=', self.revenue_type_id),
+        ], limit=1)
+
+        self.income_stamp_account = self.account_model.create({
+            'name': "Test account income stamp",
+            'code': 'TAIS',
+            'user_type_id': self.revenue_type_id,
+            'reconcile': True,
+        })
+        self.expense_stamp_account = self.account_model.create({
+            'name': "Test account expense stamp",
+            'code': 'TAES',
+            'user_type_id': self.receivable_type_id,
+            'reconcile': True,
+        })
+
+    def test_automatic_stamp(self):
+        invoice = self.invoice_model.create({
+            'partner_id': self.partner.id,
+            'name': 'Test invoice automatic stamp',
+            'account_id': self.account_receivable.id,
+            'type': 'out_invoice',
+            'invoice_line_ids': [(0, 0, {
+                'product_id': self.product.id,
+                'quantity': 1,
+                'price_unit': 121.0,
+                'name': 'Test invoice line for stamp',
+                'account_id': self.account_revenue.id,
+            })],
+        })
+        invoice.invoice_line_ids._onchange_product_id()
+        invoice.compute_taxes()
+        self.assertFalse(invoice.tax_stamp)
+
+        stamp_product = invoice.company_id.tax_stamp_product_id
+        # Set the product's tax in stamp product
+        # and check that invoice is now eligible for stamp
+        stamp_product.stamp_apply_tax_ids = [
+            (6, 0, self.product.taxes_id.ids),
+        ]
+        invoice.compute_taxes()
+        self.assertTrue(invoice.tax_stamp)
+
+        stamp_product.property_account_income_id = self.income_stamp_account
+        stamp_product.property_account_expense_id = self.expense_stamp_account
+        invoice.action_invoice_open()
+        self.assertEqual(invoice.move_id.state, 'posted')
+
+        # Check that lines for the stamp have been created in the account move
+        move_lines = invoice.move_id.line_ids
+        income_stamp_line = move_lines.filtered(
+            lambda line: line.account_id
+            == stamp_product.property_account_income_id)
+        self.assertEqual(len(income_stamp_line), 1)
+        expense_stamp_line = move_lines.filtered(
+            lambda line: line.account_id
+            == stamp_product.property_account_expense_id)
+        self.assertEqual(len(expense_stamp_line), 1)


### PR DESCRIPTION
Fix https://github.com/OCA/l10n-italy/issues/2265

Il test che ho aggiunto funziona anche senza la modifica, attualmente non ho tempo di aggiungere un test che riproduca il problema in oggetto.

La root cause della modifica è che `self.env.user.company_id.env.user` restituisce l'utente `OdooBot` per via di https://github.com/odoo/odoo/blob/0617a4724cfda5dc809473ba24e5ae7e5ce965ec/odoo/api.py#L869 mentre `inv.company_id.env.user` è l'utente corrente.
Questa differenza è un problema quando i due utenti sono in aziende diverse perché i campi dei conti nel prodotto (`property_account_expense_id`/`property_account_income_id`) sono `company_dependent`.

Durante le prove ho trovato altri problemi minori che ho corretto in un commit separato.


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
