### PR TITLE
[10.0] FIX l10n_it_central_journal report in database multicompany.

### DIFF
--- a/l10n_it_central_journal/wizard/print_giornale.py
+++ b/l10n_it_central_journal/wizard/print_giornale.py
@@ -103,12 +103,14 @@ class WizardGiornale(models.TransientModel):
             aml.date >= %(date_from)s
             AND aml.date <= %(date_to)s
             AND am.state in %(target_type)s
+            AND aml.journal_id in %(journal_ids)s
             ORDER BY am.date, am.name
         """
         params = {
             'date_from': wizard.date_move_line_from,
             'date_to': wizard.date_move_line_to,
-            'target_type': tuple(target_type)
+            'target_type': tuple(target_type),
+            'journal_ids': tuple(self.journal_ids.ids)
             }
         self.env.cr.execute(sql, params)
         res = self.env.cr.fetchall()


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Il report non può essere stampato in database con multi company attivo, perchè venivano prese registrazioni di tutte le company.

Comportamento desiderato dopo questa PR:
Il report viene correttamente stampato, perchè aggiunto (come per v12) anche i registri del wizard nella query di selection. 



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
