### PR TITLE
[fix] l10n_it_intrastat_statement: fixed missing negative number formatting generating file export

### DIFF
--- a/l10n_it_intrastat_statement/models/intrastat_statement.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement.py
@@ -665,8 +665,8 @@ class AccountIntrastatStatement(models.Model):
                 '%s_section%s_operation_amount' % (kind, section_number)
             amount = self[section_op_amount_field]
             if section_number == 2:
-                self._format_negative_number_frontispiece(amount)
-            rcd += format_9(self[section_op_amount_field], 13)
+                amount = self._format_negative_number_frontispiece(amount)
+            rcd += format_9(amount, 13)
 
         rcd += "\r\n"
         return rcd


### PR DESCRIPTION
in base all'allegato XII del ministero (pagina 5): _il campo 17 può assumere valore negativo, in tale evenienza nell’ultimo byte della stringa il numero viene sostituito da un valore secondo la seguente tabella_:
![image](https://user-images.githubusercontent.com/70569899/117992203-06016b80-b33f-11eb-9821-46837d4c4612.png)

l'implementazione è già presente (metodo **_format_negative_number_frontispiece**) ma il suo valore di ritorno non viene utilizzato.


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
