### PR TITLE
[14.0] REF removing cee_type

### DIFF
--- a/account_vat_period_end_statement/models/account.py
+++ b/account_vat_period_end_statement/models/account.py
@@ -764,20 +764,7 @@ class AccountVatPeriodEndStatement(models.Model):
                 tax.vat_statement_account_id.id in statement.account_ids.ids
                 or not statement.account_ids
             ):
-                # se ho una tassa padre con figli cee_type, condidero le figlie
-                if any(
-                    tax_ch
-                    for tax_ch in tax.children_tax_ids
-                    if tax_ch.cee_type in ("sale", "purchase")
-                ):
-
-                    for tax_ch in tax.children_tax_ids:
-                        if tax_ch.cee_type == "sale":
-                            self._set_debit_lines(tax_ch, debit_line_ids, statement)
-                        elif tax_ch.cee_type == "purchase":
-                            self._set_credit_lines(tax_ch, credit_line_ids, statement)
-
-                elif tax.type_tax_use == "sale":
+                if tax.type_tax_use == "sale":
                     self._set_debit_lines(tax, debit_line_ids, statement)
                 elif tax.type_tax_use == "purchase":
                     self._set_credit_lines(tax, credit_line_ids, statement)

--- a/account_vat_period_end_statement/report/vat_statement.py
+++ b/account_vat_period_end_statement/report/vat_statement.py
@@ -58,21 +58,6 @@ class VatPeriodEndStatementReport(models.AbstractModel):
                 }
             )
 
-            if tax.cee_type and tax.parent_tax_ids and len(tax.parent_tax_ids) == 1:
-                # In caso di integrazione iva l'imponibile è solo sulla
-                # padre
-                parent = tax.parent_tax_ids[0]
-
-                tax_data = parent._compute_totals_tax(
-                    {
-                        "from_date": date_range.date_start,
-                        "to_date": date_range.date_end,
-                        "registry_type": registry_type,
-                    }
-                )
-                # return tax_name, base, tax_val, deductible, undeductible
-                base = tax_data[1]
-
             res[tax_name] = {
                 "code": tax_name,
                 "vat": tax_val,

--- a/l10n_it_account/models/account_tax.py
+++ b/l10n_it_account/models/account_tax.py
@@ -6,13 +6,7 @@ from odoo import api, fields, models
 class AccountTax(models.Model):
     _inherit = "account.tax"
 
-    cee_type = fields.Selection(
-        [("sale", "Sale"), ("purchase", "Purchase")],
-        string="Include in VAT register",
-        help="Use in the case of tax with 'VAT integration'. This "
-        "specifies the VAT register (sales / purchases) where the "
-        "tax must be computed.",
-    )
+    # TODO remove?
     parent_tax_ids = fields.Many2many(
         "account.tax",
         "account_tax_filiation_rel",
@@ -186,24 +180,11 @@ class AccountTax(models.Model):
         else:
             # TODO remove?
             base_balance = tax.base_balance
-
             tax_balance = 0
             deductible = 0
             undeductible = 0
             for child in tax.children_tax_ids:
                 child_balance = child.balance
-                if (
-                    data["registry_type"] == "customer" and child.cee_type == "sale"
-                ) or (
-                    data["registry_type"] == "supplier" and child.cee_type == "purchase"
-                ):
-                    # Prendo la parte di competenza di ogni registro e lo
-                    # sommo sempre
-                    child_balance = child_balance
-
-                elif child.cee_type:
-                    continue
-
                 tax_balance += child_balance
                 account_ids = (
                     child.mapped("invoice_repartition_line_ids.account_id")

--- a/l10n_it_vat_registries/models/vat_registry.py
+++ b/l10n_it_vat_registries/models/vat_registry.py
@@ -62,7 +62,6 @@ class ReportRegistroIva(models.AbstractModel):
         res = {}
 
         for move_line in move_lines:
-            set_cee_absolute_value = False
             if not (move_line.tax_line_id or move_line.tax_ids):
                 continue
 
@@ -77,14 +76,6 @@ class ReportRegistroIva(models.AbstractModel):
             else:
                 tax = move_line.tax_line_id
                 is_base = False
-
-            if (registry_type == "customer" and tax.cee_type == "sale") or (
-                registry_type == "supplier" and tax.cee_type == "purchase"
-            ):
-                set_cee_absolute_value = True
-
-            elif tax.cee_type:
-                continue
 
             if tax.parent_tax_ids and len(tax.parent_tax_ids) == 1:
                 # we group by main tax
@@ -101,8 +92,6 @@ class ReportRegistroIva(models.AbstractModel):
                 }
             tax_amount = move_line.debit - move_line.credit
 
-            if set_cee_absolute_value:
-                tax_amount = abs(tax_amount)
             if (
                 "receivable" in move.financial_type
                 or "payable_refund" == move.financial_type

--- a/l10n_it_vat_registries/views/account_view.xml
+++ b/l10n_it_vat_registries/views/account_view.xml
@@ -7,10 +7,6 @@
         <field name="arch" type="xml">
             <field name="type_tax_use" position="after">
                 <field name="exclude_from_registries" />
-                    <field
-                    name="cee_type"
-                    attrs="{'invisible': [('type_tax_use', '!=', 'none')]}"
-                />
             </field>
 
         </field>


### PR DESCRIPTION
In seguito a https://github.com/OCA/l10n-italy/issues/1937 e, di conseguenza, a https://github.com/OCA/l10n-italy/pull/2128, propongo questa semplificazione, sempre che il campo `cee_type` non serva a qualcuno anche su v14




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
