### PR TITLE
[14.0] FIX l10n_it_vat_registries: use consistent order in report summary

### DIFF
--- a/l10n_it_vat_registries/report/report_registro_iva.xml
+++ b/l10n_it_vat_registries/report/report_registro_iva.xml
@@ -223,7 +223,7 @@
                                         </tr>
                                     </thead>
                                     <t
-                                            t-foreach="total_used_taxes"
+                                            t-foreach="total_used_taxes.sorted()"
                                             t-as="total_used_tax"
                                         >
                                         <t


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Nel riepilogo del report, le varie imposte vengono elencate nell'ordine in cui appiaiono nelle singole righe, il che cambia da stampa a stampa.

Comportamento attuale prima di questa PR:
L'ordinamento dipende dalle righe stampate in precedenza.

Comportamento desiderato dopo questa PR:
L'ordinamento è determinato dall'ordine in cui le imposte vengono specificate in configurazione, e non cambia da stampa a stampa.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
