### PR TITLE
[12.0] FIX l10n_it_vat_registries: use consistent order in report summary

### DIFF
--- a/l10n_it_vat_registries/report/report_registro_iva.xml
+++ b/l10n_it_vat_registries/report/report_registro_iva.xml
@@ -144,7 +144,7 @@
                                             <th class="right_without_line_bold">Non-Deductible</th>
                                         </tr>
                                     </thead>
-                                    <t t-foreach="total_used_taxes" t-as="total_used_tax">
+                                    <t t-foreach="total_used_taxes.sorted(key='sequence')" t-as="total_used_tax">
                                         <t t-set="tax_code_tuple" t-value="compute_totals_tax(total_used_tax, data)"/>
                                         <t t-set="tot_base" t-value="tot_base + tax_code_tuple[1]"/>
                                         <t t-set="tot_tax" t-value="tot_tax + tax_code_tuple[2]"/>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Nel riepilogo del report, le varie imposte vengono elencate nell'ordine in cui appiaiono nelle singole righe, il che cambia da stampa a stampa.

Comportamento attuale prima di questa PR:
L'ordinamento dipende dalle righe stampate in precedenza.

Comportamento desiderato dopo questa PR:
L'ordinamento è determinato dall'ordine in cui le imposte vengono specificate in configurazione, e non cambia da stampa a stampa.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
