### PR TITLE
[14.0][FIX] l10n_it_vat_payability: Dipendenza da openupgradelib per pre_init_hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ install:
     ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - pip3 install pdfminer.six # needed by attachment_indexation module
-  - pip3 install git+https://github.com/OCA/openupgradelib.git@master
   - travis_install_nightly
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git
     ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
-  - pip3 install pdfminer.six # needed by attachment_indexation module
   - travis_install_nightly
 
 script:

--- a/l10n_it_vat_payability/__manifest__.py
+++ b/l10n_it_vat_payability/__manifest__.py
@@ -13,6 +13,11 @@
     "depends": [
         "account",
     ],
+    "external_dependencies": {
+        "python": [
+            "openupgradelib",
+        ],
+    },
     "data": [
         "views/account_view.xml",
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@
 asn1crypto
 codicefiscale
 elementpath
+openupgradelib
 unidecode
 xmlschema

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+openupgradelib @ git+https://github.com/OCA/openupgradelib.git@master

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 openupgradelib @ git+https://github.com/OCA/openupgradelib.git@master
+pdfminer.six # needed by attachment_indexation module


### PR DESCRIPTION
Superseding https://github.com/OCA/l10n-italy/pull/2307.

Altrimenti runbot non riesce a installare il modulo, vedi https://runbot2-2.odoo-community.org/runbot/static/build/3486011-2044-a13c83/logs/job_20_test_all.txt:
> 2021-06-01 13:59:25,116 151 [1;37m[1;41mCRITICAL[0m openerp_template odoo.modules.module: Couldn't load module l10n_it_vat_payability 
2021-06-01 13:59:25,116 151 [1;37m[1;41mCRITICAL[0m openerp_template odoo.modules.module: No module named 'openupgradelib' 
2021-06-01 13:59:25,118 151 [1;33m[1;49mWARNING[0m openerp_template odoo.modules.loading: Transient module states were reset 
2021-06-01 13:59:25,119 151 [1;31m[1;49mERROR[0m openerp_template odoo.modules.registry: Failed to load registry 
2021-06-01 13:59:25,119 151 [1;37m[1;41mCRITICAL[0m openerp_template odoo.service.server: Failed to initialize database `openerp_template`. 
Traceback (most recent call last):
  File "/.repo_requirements/odoo/odoo/service/server.py", line 1199, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/.repo_requirements/odoo/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/.repo_requirements/odoo/odoo/modules/loading.py", line 455, in load_modules
    loaded_modules, update_module, models_to_check)
  File "/.repo_requirements/odoo/odoo/modules/loading.py", line 348, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check
  File "/.repo_requirements/odoo/odoo/modules/loading.py", line 178, in load_module_graph
    load_openerp_module(package.name)
  File "/.repo_requirements/odoo/odoo/modules/module.py", line 385, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "/.repo_requirements/virtualenv/python3.6/lib/python3.6/site-packages/odoo/addons/l10n_it_vat_payability/__init__.py", line 6, in <module>
    from openupgradelib import openupgrade
ModuleNotFoundError: No module named 'openupgradelib'

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
