### PR TITLE
[FIX][l10n_it_account_stamp] Fixed method 'action_move_create' to avo…

### DIFF
--- a/l10n_it_account_stamp/models/product.py
+++ b/l10n_it_account_stamp/models/product.py
@@ -24,3 +24,11 @@ class ProductTemplate(models.Model):
         digits=dp.get_precision('Account'))
     is_stamp = fields.Boolean('Is a stamp')
     auto_compute = fields.Boolean('Auto-compute')
+    omit_move_from_missing_payback = fields.Boolean(
+        string="Omit Move From Missing Payback"
+    )
+
+    @api.onchange('is_stamp')
+    def onchange_is_stamp(self):
+        if not self.is_stamp:
+            self.omit_move_from_missing_payback = False

--- a/l10n_it_account_stamp/views/product_view.xml
+++ b/l10n_it_account_stamp/views/product_view.xml
@@ -16,8 +16,8 @@
                             For each invoice, the base amount for each selected tax will be added up and used to determine the application of the account stamp.
                         </p>
                         <field name="stamp_apply_min_total_base" attrs="{'invisible': ['|',('auto_compute', '=', False), ('is_stamp', '=', False)], 'required': [('auto_compute', '=', True)]}"/>
-                        <field name="stamp_apply_tax_ids" attrs="{'invisible': ['|',('auto_compute', '=', False), ('is_stamp', '=', False)]}" widget="many2many_tags">
-                        </field>
+                        <field name="stamp_apply_tax_ids" attrs="{'invisible': ['|',('auto_compute', '=', False), ('is_stamp', '=', False)]}" widget="many2many_tags" />
+                        <field name="omit_move_from_missing_payback" attrs="{'invisible': [('is_stamp', '=', False)]}"/>
                     </group>
                 </group>
 


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Nel caso in cui la fattura sia assoggettata a imposta di bollo e non venga applicata la rivalsa in fattura, Odoo scrive in dare e avere l'importo del bollo all'interno della registrazione.

Comportamento desiderato dopo questa PR:
Viene aggiunto un flag sul prodotto "bollo", modificabile dall'utente, da cui viene definito se tali righe debbano essere o meno omesse nel caso non sia presente la rivalsa in fattura.

porting per issue #1694





--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
