### PR TITLE
[12.0][REM][l10n_it_intrastat] Remove depends on stock

### DIFF
--- a/l10n_it_intrastat/__manifest__.py
+++ b/l10n_it_intrastat/__manifest__.py
@@ -15,8 +15,7 @@
     'depends': [
         'sale_management',
         'product',
-        'stock',
-        'stock_account',
+        'account',
         'uom',
     ],
     'data': [


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Sembra che l10n_it_intrastat abbia una dipendenza non necessaria su stock. Questa PR rimuove questa dipendenza

Comportamento attuale prima di questa PR:
L'installazione di l10n_it_intrastat richiede l'installazione di stock

Comportamento desiderato dopo questa PR:
l10n_it_intrastat può essere installato anche senza il modulo stock


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
