### PR TITLE
[FIX] l10n_it_intrastat_statement: wrong year in section 2 / 4

### DIFF
--- a/l10n_it_intrastat_statement/models/intrastat_statement.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement.py
@@ -641,7 +641,7 @@ class AccountIntrastatStatement(models.Model):
             summary_type = "C"
         rcd += format_x(summary_type, 1)
         # Anno
-        rcd += format_9(str(self.fiscalyear)[2:], 2)
+        rcd += format_9(str(self.fiscalyear)[-2:], 2)
         # Periodicità
         rcd += format_x(self.period_type, 1)
         # Periodo

--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
@@ -306,7 +306,7 @@ class IntrastatStatementPurchaseSection2(models.Model):
         #  Trimestre di riferimento del riepilogo da rettificare
         rcd += format_9(self.quarterly, 1)
         # Anno periodo di ref da modificare
-        year = (self.year_id or 0) // 100
+        year = (self.year_id or 0) % 100
         rcd += format_9(year, 2)
         # Codice dello Stato membro del fornitore
         country_id = self.country_partner_id or self.partner_id.country_id

--- a/l10n_it_intrastat_statement/models/intrastat_statement_sale_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_sale_section.py
@@ -264,7 +264,7 @@ class IntrastatStatementSaleSection2(models.Model):
         #  Trimestre di riferimento del riepilogo da rettificare
         rcd += format_9(self.quarterly, 1)
         # Anno periodo di ref da modificare
-        year = (self.year_id or 0) // 100
+        year = (self.year_id or 0) % 100
         rcd += format_9(year, 2)
         # Codice dello Stato membro dell’acquirente
         country_id = self.country_partner_id or self.partner_id.country_id

--- a/l10n_it_intrastat_statement/readme/CONTRIBUTORS.rst
+++ b/l10n_it_intrastat_statement/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 * Lara Baggio <lbaggio@linkgroup.it>
 * Glauco Prina <gprina@linkgroup.it>
 * Sergio Zanchetta <https://github.com/primes2h>
+* Antonio Maria Vigliotti <antoniomaria.vigliotti@gmail.com>


### PR DESCRIPTION
Attenzione! Questa PR sostituisce integralmente la PR https://github.com/OCA/l10n-italy/pull/2304

Descrizione del problema o della funzionalità:
Quando vengono inserite registrazioni manuali di rettifica in sezioni 2 e 4, durante la generazione del file viene sempre impostato l'anno 20 invece dell'anno 21.
Questo dovuto dal taglio dell'anno, che preleva il dato da sinistra (secolo) invece che a destra.
Nel 2020 l'anno ed il secolo erano identici e quindi l'errore (molto subdolo) non si è evidenziato.


Comportamento attuale prima di questa PR:
La dichiarazione intrastat dei clienti italiani che aggiungono le rettifiche è sbagliata con il rischio di multe a causa di un bug software

Comportamento desiderato dopo questa PR:
La dichiarazione viene emessa correttamente

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
