### PR TITLE
[12.0][FIX] document partner data are no more needed

### DIFF
--- a/l10n_it_dichiarazione_intento/models/account_invoice.py
+++ b/l10n_it_dichiarazione_intento/models/account_invoice.py
@@ -171,14 +171,10 @@ class AccountInvoice(models.Model):
                             if not invoice.comment:
                                 invoice.comment = ''
                             invoice.comment += (
-                                "\n\nVostra dichiarazione d'intento nr %s del %s, "
-                                "nostro protocollo nr %s del %s, "
+                                "\n\nVostra dichiarazione d'intento del %s, "
                                 "protocollo telematico nr %s."
                                 % (
-                                    dichiarazione.partner_document_number,
                                     format_date(
-                                        self.env, dichiarazione.partner_document_date),
-                                    dichiarazione.number, format_date(
                                         self.env, dichiarazione.date),
                                     dichiarazione.telematic_protocol
                                 )

--- a/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
@@ -53,10 +53,10 @@ class DichiarazioneIntento(models.Model):
                                  required=True)
     telematic_protocol = fields.Char(required=True)
     partner_document_number = fields.Char(
-        required=True, string='Document Number',
+        string='Document Number',
         help='Number of partner\'s document')
     partner_document_date = fields.Date(
-        required=True, string='Document Date',
+        string='Document Date',
         help='Date of partner\'s document')
     taxes_ids = fields.Many2many('account.tax', string='Taxes',
                                  required=True)

--- a/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
@@ -13,8 +13,6 @@ class TestDichiarazioneIntento(TransactionCase):
     def _create_dichiarazione(self, partner, type_d):
         return self.env['dichiarazione.intento'].sudo().create({
             'partner_id': partner.id,
-            'partner_document_number': 'PartnerTest%s' % partner.id,
-            'partner_document_date': self.today_date.strftime('%Y-%m-%d'),
             'date': self.today_date.strftime('%Y-%m-%d'),
             'date_start': self.today_date.strftime('%Y-%m-%d'),
             'date_end': self.today_date.strftime('%Y-%m-%d'),


### PR DESCRIPTION
Descrizione del problema o della funzionalità: Il numero e la data del partner non sono più presenti nella dichiarazione d'intento in quanto viene elaborata in formato elettronico.

Comportamento attuale prima di questa PR: è necessario inserire data e numero documento del partner non esistenti.

Comportamento desiderato dopo questa PR: non è necessario inserire tali dati.

https://github.com/OCA/l10n-italy/issues/2329


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing