### PR TITLE
12.0 fix l10n it dichiarazione intento

### DIFF
--- a/l10n_it_dichiarazione_intento/models/account_invoice.py
+++ b/l10n_it_dichiarazione_intento/models/account_invoice.py
@@ -168,17 +168,18 @@ class AccountInvoice(models.Model):
                         invoice.dichiarazione_intento_ids = [
                             (4, dichiarazione.id)]
                         if invoice.type in ("out_invoice", "out_refund"):
-                            if not invoice.comment:
-                                invoice.comment = ''
-                            invoice.comment += (
-                                "\n\nVostra dichiarazione d'intento del %s, "
-                                "protocollo telematico nr %s."
-                                % (
-                                    format_date(
-                                        self.env, dichiarazione.date),
-                                    dichiarazione.telematic_protocol
-                                )
-                            )
+                            cmt = invoice.comment or ""
+                            msg = "Vostra dichiarazione d'intento del %s,"\
+                                  " protocollo telematico nr %s."\
+                                  % (format_date(self.env, dichiarazione.date),
+                                     dichiarazione.telematic_protocol)
+                            # Avoid duplication
+                            if msg not in cmt:
+                                if cmt.strip():
+                                    cmt += "\n\n" + msg
+                                else:
+                                    cmt = msg
+                            invoice.comment = cmt
 
         return res
 

--- a/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
@@ -81,8 +81,7 @@ class DichiarazioneIntento(models.Model):
         #       to create an in declaration
         # Declaration issued by company are "IN"
         if values.get('type', False) == 'in':
-            year = datetime.strptime(
-                values['date_start'], '%Y-%m-%d').strftime('%Y')
+            year = str(fields.Date.to_date(values['date_start']).year)
             plafond = self.env.user.company_id.\
                 dichiarazione_yearly_limit_ids.filtered(
                     lambda r: r.year == year)

--- a/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
@@ -3,7 +3,7 @@
 
 from odoo.tests.common import TransactionCase
 from odoo import fields
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import ValidationError
 from datetime import datetime, timedelta
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 
@@ -216,7 +216,7 @@ class TestDichiarazioneIntento(TransactionCase):
 
     def test_invoice_validation_over_dichiarazione_limit(self):
         self.invoice2.action_invoice_open()
-        with self.assertRaises(UserError):
+        with self.assertRaises(ValidationError):
             self.invoice3.action_invoice_open()
 
     def test_invoice_reopen_with_effect_on_dichiarazione(self):
@@ -246,7 +246,7 @@ class TestDichiarazioneIntento(TransactionCase):
         self.assertEqual(self.dichiarazione1.available_amount, 100)
         self.assertEqual(self.refund1.amount_untaxed, 1000)
         self.assertEqual(self.dichiarazione1.limit_amount, 1000)
-        with self.assertRaises(UserError):
+        with self.assertRaises(ValidationError):
             self.refund1.action_invoice_open()
 
     def test_fiscal_position_no_dichiarazione(self):

--- a/l10n_it_dichiarazione_intento/wizard/manually_declarations.py
+++ b/l10n_it_dichiarazione_intento/wizard/manually_declarations.py
@@ -30,13 +30,10 @@ class SelectManuallyDeclarations(models.TransientModel):
     @api.multi
     def confirm(self):
         self.ensure_one()
-        res = True
-        # ----- Link dichiarazione to invoice
-        invoice_id = self.env.context.get('active_id', False)
+        dec_ids = self.declaration_ids.ids
+        vals = {'dichiarazione_intento_ids': [(6, 0, dec_ids)]}
+        invoice_id = self.env.context.get('active_id')
         if not invoice_id:
-            return res
+            return False
         invoice = self.env['account.invoice'].browse(invoice_id)
-        for declaration in self.declaration_ids:
-            invoice.dichiarazione_intento_ids = [
-                (4, declaration.id)]
-        return True
+        return invoice.exists() and invoice.write(vals)


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
1- la duplicazione delle DI crasha
2- se una fattura viene validata, riportata in bozza, e poi validata di nuovo, il messaggio relativo alla DI nelle note della fattura viene duplicato
3- il wizard di assegnazione manuale delle DI in testata fattura non permette di rimuovere DI
4- se nelle righe di fattura sono collegate più DI ma non sono presenti DI nella testata della fattura, il controllo preventivo degli importi disponibili sulle DI fallisce

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:
1- è possibile duplicare le DI
2- il messaggio relativo alle DI non viene duplicato su fatture ri-validate
3- è ora possibile rimuovere DI assegnate manualmente in testata fattura
4- il calcolo degli importi disponibili è delegato alle DI con una constrain solo dopo che le DI sono effettivamente collegate alle fatture (e viene lanciato errore se gli importi di fatture/note credito sono incoerenti con gli importi delle DI)



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
