### PR TITLE
[14.0] [FIX] l10n_it_split_payment: fix payment lines

### DIFF
--- a/l10n_it_split_payment/models/account.py
+++ b/l10n_it_split_payment/models/account.py
@@ -88,7 +88,9 @@ class AccountMove(models.Model):
                 else:
                     receivable_line_amount = 0
                 line_client.with_context(check_move_validity=False).update(
-                    {"debit": receivable_line_amount}
+                    {
+                        "price_unit": -receivable_line_amount,
+                    }
                 )
         elif self.move_type == "out_refund":
             for line_client in line_client_ids:
@@ -100,7 +102,9 @@ class AccountMove(models.Model):
                 else:
                     receivable_line_amount = 0
                 line_client.with_context(check_move_validity=False).update(
-                    {"credit": receivable_line_amount}
+                    {
+                        "price_unit": -receivable_line_amount,
+                    }
                 )
 
     def _compute_split_payments(self):


### PR DESCRIPTION
Force recompute of all fields instead of just debit/credit.
Fix a failure in l10n_it_fatturapa_out_sp tests.

Descrizione del problema o della funzionalità:
Le righe crediti / debit verso clienti / fornitori vanno modificate in caso di SP. Tuttavia, venivano aggiornati solo credit e debit lasciando inalterati gli altri importi.

Comportamento attuale prima di questa PR:
In una fattura, nelle righe relative ai crediti clienti, veniva modificato solo debit, tutti gli altri campi, in particolare amount_currenty, rimanevano inalterati. l10n_it_fatturapa_out_sp usa "amount_currency or debit" per l'importo della riga e usava il valore non modificato (pre SP).

Comportamento desiderato dopo questa PR:
Aggiornando price_unit della riga, tutti gli altri valori, amount_currency e debit compresi, vengono ricalcolati correttamente.




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
