### PR TITLE
[12.0][IMP] l10n_it_fatturapa_in: improve search of product in supplier_info

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -444,6 +444,11 @@ class WizardImportFatturapa(models.TransientModel):
                 ('product_code', '=', supplier_code),
                 ('name', '=', partner.id)
             ])
+            if not supplier_infos:
+                supplier_name = line.Descrizione
+                supplier_infos = supplier_info.search(
+                    [("product_name", "=", supplier_name), ("name", "=", partner.id)]
+                )
             if supplier_infos:
                 products = supplier_infos.mapped('product_id')
                 if len(products) == 1:


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Pochi fornitori specificano in fattura il CodiceArticolo, per cui in mancanza di quello, cerchiamo il prodotto per Descrizione in fattura, sempre nella supplier_info.

Comportamento attuale prima di questa PR:
Trova prodotto solo se c'è il codice

Comportamento desiderato dopo questa PR:
Trova il prodotto se la Descrizione corrosponde ad una riga in supplier_info

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
