### PR TITLE
[14.0][FIX] l10n_it_fatturapa_in multicompany wrong company

### DIFF
--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -207,7 +207,7 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
     def test_08_xml_import_no_account(self):
         """Check that a useful error message is raised when
         the credit account is missing in purchase journal."""
-        company = self.env.user.company_id
+        company = self.env.company
         journal = self.wizard_model.get_purchase_journal(company)
         journal_account = journal.default_account_id
         journal.default_account_id = False
@@ -830,8 +830,8 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.env["res.partner.bank"].create(
             {
                 "acc_number": "IT59R0100003228000000000622",
-                "company_id": self.env.user.company_id.id,
-                "partner_id": self.env.user.company_id.partner_id.id,
+                "company_id": self.env.company.id,
+                "partner_id": self.env.company.partner_id.id,
             }
         )
         res = self.run_wizard("test48", "IT01234567890_FPR15.xml")

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -927,7 +927,7 @@ class WizardImportFatturapa(models.TransientModel):
             accounts_dict = template.get_product_accounts()
             credit_account = accounts_dict["expense"]
 
-        company = self.env.user.company_id
+        company = self.env.company
         # Search in purchase journal
         journal = self.get_purchase_journal(company)
         if not credit_account:
@@ -1296,7 +1296,7 @@ class WizardImportFatturapa(models.TransientModel):
             if invoice.efatt_rounding != 0:
                 if invoice.efatt_rounding > 0:
                     arrotondamenti_account_id = (
-                        self.env.user.company_id.arrotondamenti_passivi_account_id
+                        self.env.company.arrotondamenti_passivi_account_id
                     )
                     if not arrotondamenti_account_id:
                         raise UserError(
@@ -1305,7 +1305,7 @@ class WizardImportFatturapa(models.TransientModel):
                     name = _("Rounding down")
                 else:
                     arrotondamenti_account_id = (
-                        self.env.user.company_id.arrotondamenti_attivi_account_id
+                        self.env.company.arrotondamenti_attivi_account_id
                     )
                     if not arrotondamenti_account_id:
                         raise UserError(


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Nell'importare una fattura il sistema tenta di usare la company di default dell'utente corrente e non la company selezionata a livello di interfaccia.
Comportamento attuale prima di questa PR:
L'import fallisce perché non trova un registro di tipo 'sale' per la company di default dell'utente.
Comportamento desiderato dopo questa PR:
La fattura viene importata correttamente.

N.B. Idealmente sarebbe da scrivere un test.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
