### PR TITLE
[14.0] [FIX] l10n_it_withholding_tax: fix for #2345 + multicompany

### DIFF
--- a/l10n_it_withholding_tax/models/withholding_tax.py
+++ b/l10n_it_withholding_tax/models/withholding_tax.py
@@ -36,7 +36,9 @@ class WithholdingTax(models.Model):
                 wt.base = rate[1]
 
     def _default_wt_journal(self):
-        misc_journal = self.env["account.journal"].search([("code", "=", _("MISC"))])
+        misc_journal = self.env["account.journal"].search(
+            [("code", "=", _("MISC")), ("company_id", "=", self.env.company.id)]
+        )
         if misc_journal:
             return misc_journal[0].id
         return False
@@ -105,7 +107,7 @@ class WithholdingTax(models.Model):
         if self.env.context.get("currency_id"):
             currency = self.env["res.currency"].browse(self.env.context["currency_id"])
         else:
-            currency = self.env.user.company_id.currency_id
+            currency = self.env.company.currency_id
         prec = currency.decimal_places
         base = round(amount * self.base, prec)
         tax = round(base * ((self.tax or 0.0) / 100.0), prec)


### PR DESCRIPTION
Usa self.env.company invece di self.env.user.company_id. La seconda, l'azienda di default dell'utente collegato, raramente è quella giusta da usare, visto che comunque si opera nel contesto dell'azienda indicata da self.env.company.

Questa fix fa parte di una serie di fix relative alla gestione del multicompany.

Edit: aggiunto anche fix per la #2345 (era #2351)

Edit2: da verificare se dipende da #2352 

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
