### PR TITLE
[14.0][FIX] l10n_it_fatturapa_in: Fixed singleton error on field computation

### DIFF
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -174,7 +174,6 @@ class AccountInvoice(models.Model):
         "invoice_date",
     )
     def _compute_e_invoice_validation_error(self):
-        self.ensure_one()
         self.e_invoice_validation_error = False
         self.e_invoice_validation_message = False
 

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -935,6 +935,12 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.assertEqual(invoice.invoice_line_ids[1].price_unit, 3.52)
         self.assertEqual(invoice.invoice_line_ids[1].quantity, 1.0)
 
+    def test_e_invoice_field_compute(self):
+        """Check successful creation of multiple invoices.
+        See https://github.com/OCA/l10n-italy/issues/2349"""
+        invoices = self.invoice_model.create([{}, {}])
+        self.assertEqual(invoices.mapped("e_invoice_validation_error"), [False, False])
+
 
 class TestFatturaPAEnasarco(FatturapaCommon):
     def setUp(self):


### PR DESCRIPTION
Taking over #2350

Fixes: https://github.com/OCA/l10n-italy/issues/2349

diff from #2350 (due to pre-commit formatting)

```diff --git a/l10n_it_fatturapa_in/models/account.py b/l10n_it_fatturapa_in/models/account.py
index 998191db7..7f7dafc99 100644
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -247,10 +247,12 @@ class AccountInvoice(models.Model):
             bill.e_invoice_validation_message = ",\n".join(error_messages) + "."
             other_account_moves -= bill
 
-        other_account_moves.write({
-            'e_invoice_validation_error': False,
-            'e_invoice_validation_message': False,
-        })
+        other_account_moves.write(
+            {
+                "e_invoice_validation_error": False,
+                "e_invoice_validation_message": False,
+            }
+        )
 
     def name_get(self):
         result = super(AccountInvoice, self).name_get()
```

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
