### PR TITLE
[12.0] l10n_it_dichiarazione_intento: permit to add dichiarazione.intento records that exceeds the limit_amount of dichiarazione.intento.yearly.limit

### DIFF
--- a/l10n_it_dichiarazione_intento/views/company_view.xml
+++ b/l10n_it_dichiarazione_intento/views/company_view.xml
@@ -8,12 +8,13 @@
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
             <xpath expr="//page[last()]" position="after">
-                <page string="Declarations of intent">
+                <page string="Exporter Plafond">
                     <field name="dichiarazione_yearly_limit_ids">
                         <tree editable="top">
                             <field name="year"/>
                             <field name="limit_amount"/>
                             <field name="used_amount"/>
+                            <field name="actual_used_amount"/>
                         </tree>
                     </field>
                 </page>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
PR per venire in contro all'esigenza di poter creare più dichiarazioni d'intento oltre il plafond disponibile

Comportamento attuale prima di questa PR:
il plafond si esaurisce in base a quanto dichiarato.

Comportamento desiderato dopo questa PR:
il plafond si esaurisce in base agli acquisti effettivi
in oltre viene modificata la sctringa nella sezione sulla company a "plafond" e non "dichiarazioni d'intento", in modo che sia chiaro che si riferisce all'importo che io azienda posso usare con i miei fornitori.



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
