### PR TITLE
[12.0] FIX l10n_it_fatturapa_in EmailType pattern constraint violated by value www.example.com / info@yourcompany.example.com

### DIFF
--- a/l10n_it_fatturapa/bindings/binding.py
+++ b/l10n_it_fatturapa/bindings/binding.py
@@ -921,7 +921,7 @@ class EmailType (pyxb.binding.datatypes.normalizedString):
     _Documentation = None
 EmailType._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(256))
 EmailType._CF_pattern = pyxb.binding.facets.CF_pattern()
-EmailType._CF_pattern.addPattern(pattern='([!#-\'*+/-9=?A-Z^-~-]+(\\.[!#-\'*+/-9=?A-Z^-~-]+)*|"(\\[\\]!#-[^-~ \\t]|(\\\\[\\t -~]))+")@([!#-\'*+/-9=?A-Z^-~-]+(\\.[!#-\'*+/-9=?A-Z^-~-]+)*|\\[[\\t -Z^-~]*\\])')
+EmailType._CF_pattern.addPattern(pattern='.+@.+[.]+.+')
 EmailType._InitializeFacetMap(EmailType._CF_maxLength,
    EmailType._CF_pattern)
 Namespace.addCategoryObject('typeBinding', 'EmailType', EmailType)

--- a/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd
+++ b/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd
@@ -1363,7 +1363,7 @@
   <xs:simpleType name="EmailType">
     <xs:restriction base="xs:normalizedString">
       <xs:maxLength value="256" />
-      <xs:pattern value="([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*|&quot;(\[\]!#-[^-~ \t]|(\\[\t -~]))+&quot;)@([!#-'*+/-9=?A-Z^-~-]+(\.[!#-'*+/-9=?A-Z^-~-]+)*|\[[\t -Z^-~]*\])" />
+      <xs:pattern value=".+@.+[.]+.+" />
     </xs:restriction>
   </xs:simpleType>
   <!--________________ NUMBERS ____________________-->

--- a/l10n_it_fatturapa_in/tests/data/IT01234567890_FPR13.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT01234567890_FPR13.xml
@@ -35,7 +35,7 @@
             </Sede>
             <Contatti>
                 <Telefono>06543534343</Telefono>
-                <Email>info@yourcompany.example.com</Email>
+                <Email>www.example.com / info@yourcompany.example.com</Email>
             </Contatti>
         </CedentePrestatore>
         <CessionarioCommittente>


### PR DESCRIPTION
Lo schema
https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.1/Schema_del_file_xml_FatturaPA_versione_1.2.xsd
contiene in effetti `.+@.+[.]+.+`, non so da quando




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
