### PR TITLE
[14.0][FIX] l10n_it_fatturapa_in: _compute method failure

### DIFF
--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -94,6 +94,8 @@ class FatturaPAAttachmentIn(models.Model):
             att.invoices_number = False
             att.invoices_total = False
             att.invoices_date = False
+            if not att.ir_attachment_id.datas:
+                continue
             wiz_obj = self.env["wizard.import.fatturapa"].with_context(
                 from_attachment=att
             )


### PR DESCRIPTION
This fixes the following errors:

File "/home/travis/build/OCA/l10n-italy/setup/l10n_it_fatturapa_in/odoo/addons/l10n_it_fatturapa_in/models/attachment.py", line 100, in _compute_xml_data
fatt = wiz_obj.get_invoice_obj(att)
File "/home/travis/build/OCA/l10n-italy/setup/l10n_it_fatturapa_in/odoo/addons/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 1625, in get_invoice_obj
xml_string = fatturapa_attachment.get_xml_string()
File "/home/travis/build/OCA/l10n-italy/setup/l10n_it_fatturapa_in/odoo/addons/l10n_it_fatturapa_in/models/attachment.py", line 84, in get_xml_string
return self.ir_attachment_id.get_xml_string()
File "/home/travis/build/OCA/l10n-italy/setup/l10n_it_fatturapa/odoo/addons/l10n_it_fatturapa/models/ir_attachment.py", line 76, in get_xml_string
data = base64.b64decode(self.datas)
File "/home/travis/virtualenv/python3.6.7/lib/python3.6/base64.py", line 80, in b64decode
s = _bytes_from_decode_data(s)
File "/home/travis/virtualenv/python3.6.7/lib/python3.6/base64.py", line 46, in _bytes_from_decode_data
"string, not %r" % s.__class__.__name__) from None
TypeError: argument should be a bytes-like object or ASCII string, not 'bool'

The wizard is invoked on an empty model, with no attachment.


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
