### PR TITLE
[12.0] Update l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py: concatenated “sede.numero_civico” to the “sede.indirizzo” field

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -256,7 +256,14 @@ class WizardImportFatturapa(models.TransientModel):
         if partner_id and not no_contact_update:
             partner_company_id = partner_model.browse(partner_id).company_id.id
             vals = {
-                'street': cedPrest.Sede.Indirizzo,
+                "street": " ".join(
+                    map(
+                        str,
+                        filter(
+                            None, (cedPrest.Sede.Indirizzo, cedPrest.Sede.NumeroCivico)
+                        ),
+                    )
+                ),
                 'zip': cedPrest.Sede.CAP,
                 'city': cedPrest.Sede.Comune,
                 'register': cedPrest.DatiAnagrafici.AlboProfessionale or ''


### PR DESCRIPTION
concatenated the XML house number node to the Address field

Descrizione del problema o della funzionalità:
Il modulo coinvolto è l10n_it_fatturapa_in per l’importazione delle fatture passive in Odoo 12 CE. Durante l'importazione di una fattura in cui il numero civico è impostato nell'apposito nodo dell'XML questo viene perso.
La normativa prevede che il numero civico possa essere inserito o nel suo apposito nodo “sede.numero_civico” o all'interno dell'indirizzo, ma solo in questo secondo caso viene mantenuta l'informazione sul numero civico.

Comportamento attuale prima di questa PR:
Attualmente nel caso di fatture elettroniche dove sono valorizzati entrambi i campi XML “sede.indirizzo” che “sede.numero_civico” (del CedentePrestatore) l'informazione del numero civico non viene trattata ai fini dell’assegnamento all’anagrafica del partner da parte della funzione la funzione "getCedPrest"

Comportamento desiderato dopo questa PR:
E' desiderata la visualizzazione del numero civico all'interno dell'indirizzo del partner: concatenare il numero civico (presente nell'apposito nodo dell'XML) al campo Indirizzo in fase di assegnamento al partner Odoo


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
