### PR TITLE
[FIX] l10n_it_reverse_charge 10.0:  Fix singleton error when validating multiple invoices

### DIFF
--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -401,18 +401,18 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def invoice_validate(self):
-        self.ensure_one()
         res = super(AccountInvoice, self).invoice_validate()
-        fp = self.fiscal_position_id
-        rc_type = fp and fp.rc_type_id
-        if rc_type and rc_type.method == 'selfinvoice'\
-                and self.amount_total:
-            if not rc_type.with_supplier_self_invoice:
-                self.generate_self_invoice()
-            else:
-                # See with_supplier_self_invoice field help
-                self.generate_supplier_self_invoice()
-                self.rc_self_purchase_invoice_id.generate_self_invoice()
+        for invoice in self:
+            fp = invoice.fiscal_position_id
+            rc_type = fp and fp.rc_type_id
+            if rc_type and rc_type.method == 'selfinvoice'\
+                    and invoice.amount_total:
+                if not rc_type.with_supplier_self_invoice:
+                    invoice.generate_self_invoice()
+                else:
+                    # See with_supplier_self_invoice field help
+                    invoice.generate_supplier_self_invoice()
+                    invoice.rc_self_purchase_invoice_id.generate_self_invoice()
         return res
 
     def remove_rc_payment(self):


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
In l10n_it_reverse_charge per odoo 10.0, viene lanciato un singleton expected quando si provano a validare più fatture

Comportamento attuale prima di questa PR:
In l10n_it_reverse_charge per odoo 10.0, viene lanciato un singleton expected quando si provano a validare più fatture

Comportamento desiderato dopo questa PR:
Possibilità di validare più fatture



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
