### PR TITLE
[14.0][FIX] l10n_it_withholding_tax: Mantieni RdA alla creazione della fattura

### DIFF
--- a/l10n_it_withholding_tax/views/account.xml
+++ b/l10n_it_withholding_tax/views/account.xml
@@ -31,6 +31,17 @@
                         options="{'no_create': True}"
                     />
                 </xpath>
+                <xpath
+                    expr="//field[@name='line_ids']/tree/field[@name='tax_ids']"
+                    position="after"
+                >
+                    <field
+                        name="invoice_line_tax_wt_ids"
+                        widget="many2many_tags"
+                        options="{'no_create': True}"
+                        invisible="True"
+                    />
+                </xpath>
 
                 <xpath
                     expr="//field[@name='invoice_line_ids']/form//field[@name='tax_ids']"


### PR DESCRIPTION
Fix https://github.com/OCA/l10n-italy/issues/2389

**Descrizione del problema**
1. In Fatturazione > Configurazione > Ritenuta d'acconto, creare una ritenuta
2. In Fatturazione > Fornitori > Fatture fornitore, creare una fattura
3. Nella riga fattura, inserire la ritenuta creata al punto 1.
4. Salvare

**Comportamento attuale prima di questa PR**
La ritenuta sparisce dalla riga:
![Peek 2021-08-13 15-44](https://user-images.githubusercontent.com/32064796/129366469-6018334a-da65-4ccf-be1a-da25e0055780.gif)


**Comportamento desiderato dopo questa PR**
La ritenuta viene mantenuta nella riga

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
