### PR TITLE
[12.0][FIX] l10n_it_account_balance_report error on opening account.move.line

### DIFF
--- a/l10n_it_account_balance_report/report/templates/account_balance_report.xml
+++ b/l10n_it_account_balance_report/report/templates/account_balance_report.xml
@@ -209,8 +209,8 @@
                 <t t-if="line.account_id">
                     <t t-set="domain"
                        t-value="[('account_id', '=', line.account_id.id),
-                                 ('date', '&gt;=', line.date_from),
-                                 ('date', '&lt;=', line.date_to)]"/>
+                                 ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                 ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -222,8 +222,8 @@
                 <t t-elif="line.account_group_id">
                     <t t-set="domain"
                        t-value="[('account_id', 'in', line.compute_account_ids.ids),
-                                 ('date', '&gt;=', line.date_from),
-                                 ('date', '&lt;=', line.date_to)]"/>
+                                 ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                 ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -244,8 +244,8 @@
                         <t t-if="line.account_id">
                             <t t-set="domain"
                                t-value="[('account_id', '=', line.account_id.id),
-                                         ('date', '&gt;=', line.date_from),
-                                         ('date', '&lt;=', line.date_to)]"/>
+                                         ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                         ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                             <span>
                                 <a t-att-data-domain="domain"
                                    t-att-data-res-model="'account.move.line'"
@@ -257,8 +257,8 @@
                         <t t-elif="line.account_group_id">
                             <t t-set="domain"
                                t-value="[('account_id', 'in', line.compute_account_ids.ids),
-                                         ('date', '&gt;=', line.date_from),
-                                         ('date', '&lt;=', line.date_to)]"/>
+                                         ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                         ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                             <span>
                                 <a t-att-data-domain="domain"
                                    t-att-data-res-model="'account.move.line'"
@@ -289,8 +289,8 @@
                     <t t-set="domain"
                        t-value="[('account_id', '=', partner_line.report_section_id.account_id.id),
                                  ('partner_id', '=', partner_line.partner_id.id),
-                                 ('date', '&gt;=', partner_line.date_from),
-                                 ('date', '&lt;=', partner_line.date_to)]"/>
+                                 ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                 ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -306,8 +306,8 @@
                     <t t-set="domain"
                        t-value="[('account_id', '=', partner_line.report_section_id.account_id.id),
                                  ('partner_id', '=', partner_line.partner_id.id),
-                                 ('date', '&gt;=', partner_line.date_from),
-                                 ('date', '&lt;=', partner_line.date_to)]"/>
+                                 ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                 ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -322,8 +322,8 @@
                     <t t-set="domain"
                        t-value="[('account_id', '=', partner_line.report_section_id.account_id.id),
                                  ('partner_id', '=', partner_line.partner_id.id),
-                                 ('date', '&gt;=', partner_line.date_from),
-                                 ('date', '&lt;=', partner_line.date_to)]"/>
+                                 ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                 ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                     <span>
                         <a t-att-data-domain="domain"
                            t-att-data-res-model="'account.move.line'"
@@ -338,8 +338,8 @@
                         <t t-set="domain"
                            t-value="[('account_id', '=', partner_line.report_section_id.account_id.id),
                                      ('partner_id', '=', partner_line.partner_id.id),
-                                     ('date', '&gt;=', partner_line.date_from),
-                                     ('date', '&lt;=', partner_line.date_to)]"/>
+                                     ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                     ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"
@@ -355,8 +355,8 @@
                         <t t-set="domain"
                            t-value="[('account_id', '=', partner_line.report_section_id.account_id.id),
                                      ('partner_id', '=', partner_line.partner_id.id),
-                                     ('date', '&gt;=', partner_line.date_from),
-                                     ('date', '&lt;=', partner_line.date_to)]"/>
+                                     ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                     ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                         <span>
                             <a t-att-data-domain="domain"
                                t-att-data-res-model="'account.move.line'"


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
https://github.com/OCA/l10n-italy/issues/2261
tentando di aprire i movimenti contabili dal report a video del saldo contabile si ottiene un errore js

Comportamento attuale prima di questa PR: non si riescono ad aprire i movimenti contabili

Comportamento desiderato dopo questa PR: i movimenti contabili si aprono

![errore-balance](https://user-images.githubusercontent.com/7657311/130990333-d888c841-03f6-4d7f-97b6-ed508fa822e1.gif)


--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing