### PR TITLE
[14.0][FIX] l10n_it_fatturapa_out: Mostrare stato fattura elettronica nella lista delle fatture

### DIFF
--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -4,7 +4,7 @@
     <record id="view_invoice_fatturapa_out_tree" model="ir.ui.view">
         <field name="name">view.invoice.fatturapa.out.tree</field>
         <field name="model">account.move</field>
-        <field name="inherit_id" ref="account.view_move_tree" />
+        <field name="inherit_id" ref="account.view_out_invoice_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='state']" position="before">
                 <field name="fatturapa_state" />


### PR DESCRIPTION
**Descrizione del problema**
Aprire la lista delle fatture in Fatturazione > Clienti > Fatture cliente.

**Comportamento attuale prima di questa PR**
Il campo "E-invoice State" non è visibile

**Comportamento desiderato dopo questa PR**
Il campo "E-invoice State" è visibile

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
