### PR TITLE
[12.0] issues2406 oca l10n italy

### DIFF
--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -502,6 +502,15 @@ class AccountInvoice(models.Model):
                     else:
                         tax_grouped[key]['tax'] += val['tax']
                         tax_grouped[key]['base'] += val['base']
+                # recompute wt values from total base to avoid round issues
+            for key in tax_grouped:
+                tax_group = tax_grouped[key]
+                wt_tax = self.env['withholding.tax'].browse(
+                    tax_group.get('withholding_tax_id'))
+                res = wt_tax.compute_tax(tax_group.get('base'))
+                tax_group.update({
+                    'tax': res.get('tax', 0)
+                })
         return tax_grouped
 
     @api.one

--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -507,7 +507,11 @@ class AccountInvoice(models.Model):
                 tax_group = tax_grouped[key]
                 wt_tax = self.env['withholding.tax'].browse(
                     tax_group.get('withholding_tax_id'))
-                res = wt_tax.compute_tax(tax_group.get('base'))
+                # rebuild base in case of coeff <>1
+                base = tax_group.get('base')
+                if wt_tax.base:
+                    base = base / wt_tax.base
+                res = wt_tax.compute_tax(base)
                 tax_group.update({
                     'tax': res.get('tax', 0)
                 })


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
La ritenuta di account non viene arrontondata in maniera corretta
https://github.com/OCA/l10n-italy/issues/2406

Comportamento attuale prima di questa PR:
attualmente c'è una differenza di 1 o alcuni centesimi
Comportamento desiderato dopo questa PR:
non c'è più l'errore di calcolo 



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
