### PR TITLE
[14.0][FIX] l10n_it_fatturapa_out: string instead of list in error message

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -69,7 +69,7 @@ class WizardExportFatturapa(models.TransientModel):
             if invoice.partner_id != partner:
                 raise UserError(
                     _("Invoices %s must belong to the same partner.")
-                    % invoices.mapped("number")
+                    % ", ".join(invoices.mapped("number"))
                 )
 
         return partner


### PR DESCRIPTION
Add a missing str.join() in a error message

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
