### PR TITLE
[12.0][FIX] l10n_it_dichiarazione_intento plafond out

### DIFF
--- a/l10n_it_dichiarazione_intento/models/account_invoice.py
+++ b/l10n_it_dichiarazione_intento/models/account_invoice.py
@@ -79,14 +79,25 @@ class AccountInvoice(models.Model):
                         'change fiscal position and verify applied tax'))
                 else:
                     continue
+            available_plafond = 0.0
+            if invoice.type in ['in_invoice', 'in_refund']:
+                plafond = self.env.user.company_id.\
+                    dichiarazione_yearly_limit_ids.filtered(
+                        lambda r: r.year == str(fields.first(dichiarazioni).date_start.year)
+                    )
+                available_plafond = plafond.limit_amount - plafond.actual_used_amount
             sign = 1 if invoice.type in ['out_invoice', 'in_invoice'] else -1
             dichiarazioni_amounts = {}
             for tax_line in invoice.tax_line_ids:
                 amount = sign * tax_line.base
                 for dichiarazione in dichiarazioni:
                     if dichiarazione.id not in dichiarazioni_amounts:
-                        dichiarazioni_amounts[dichiarazione.id] = \
-                            dichiarazione.available_amount
+                        if invoice.type in ['in_invoice', 'in_refund'] and \
+                                dichiarazione.available_amount > available_plafond:
+                            dichiarazioni_amounts[dichiarazione.id] = available_plafond
+                        else:
+                            dichiarazioni_amounts[dichiarazione.id] = \
+                                dichiarazione.available_amount
                     if tax_line.tax_id.id in [t.id for t
                                               in dichiarazione.taxes_ids]:
                         dichiarazioni_amounts[dichiarazione.id] -= amount

--- a/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import datetime
+import datetime as dt
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
 
@@ -102,7 +103,7 @@ class DichiarazioneIntento(models.Model):
                 ])
             actual_limit_total = sum([d.limit_amount for d in dichiarazioni]) \
                 + values['limit_amount']
-            if actual_limit_total > plafond.limit_amount:
+            if actual_limit_total > plafond.limit_amount < plafond.actual_used_amount:
                 raise UserError(
                     _('Total of documents exceed yearly limit'))
         # ----- Assign a number to dichiarazione


### PR DESCRIPTION
Descrizione del problema o della funzionalità: la fatturazione clienti è bloccata dal plafond fornitori

Comportamento attuale prima di questa PR: non si possono emettere fatture clienti con plafond se non impostato e sufficiente il plafond fornitori

Comportamento desiderato dopo questa PR: il plafond fornitori non viene preso in considerazione per le fatture clienti




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing