### PR TITLE
[12.0][FIX] l10n_it_dichiarazione_intento plafond out

### DIFF
--- a/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
@@ -117,10 +117,9 @@ class DichiarazioneIntento(models.Model):
                 ])
             actual_limit_total = sum([d.limit_amount for d in dichiarazioni]) \
                 + values['limit_amount']
-            if actual_limit_total > plafond.limit_amount:
-                if plafond.limit_amount < plafond.actual_used_amount:
-                    raise UserError(
-                        _('Total of documents exceed yearly limit'))
+            if actual_limit_total > plafond.limit_amount < plafond.actual_used_amount:
+                raise UserError(
+                    _('Total of documents exceed yearly limit'))
         # ----- Assign a number to dichiarazione
         if values and not values.get('number', ''):
             values['number'] = self.env['ir.sequence'].next_by_code(


### PR DESCRIPTION
Descrizione del problema o della funzionalità: la fatturazione clienti è bloccata dal plafond fornitori

Comportamento attuale prima di questa PR: non si possono emettere fatture clienti con plafond se non impostato e sufficiente il plafond fornitori

Comportamento desiderato dopo questa PR: il plafond fornitori non viene preso in considerazione per le fatture clienti

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing