### PR TITLE
[12.0][FIX] l10n_it_dichiarazione_intento dt object

### DIFF
--- a/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/models/dichiarazione_intento.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import datetime
+import datetime as dt
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
 
@@ -92,8 +93,11 @@ class DichiarazioneIntento(models.Model):
         #       to create an in declaration
         # Declaration issued by company are "IN"
         if values.get('type', False) == 'in':
-            year = datetime.strptime(
-                values['date_start'], '%Y-%m-%d').strftime('%Y')
+            if isinstance(values['date_start'], dt.date):
+                year = str(values['date_start'].year)
+            else:
+                year = datetime.strptime(
+                    values['date_start'], '%Y-%m-%d').strftime('%Y')
             plafond = self.env.user.company_id.\
                 dichiarazione_yearly_limit_ids.filtered(
                     lambda r: r.year == year)

--- a/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
@@ -259,3 +259,7 @@ class TestDichiarazioneIntento(TransactionCase):
         self.invoice5.action_invoice_open()
         post_used_amount = self.dichiarazione4.used_amount
         self.assertAlmostEqual(post_used_amount, 900.0, 2)
+
+    def test_copy_dichiarazione_in(self):
+        dichiarazione_copy = self.dichiarazione4.copy()
+        self.assertTrue(dichiarazione_copy)


### PR DESCRIPTION
Descrizione del problema o della funzionalità: in caso di duplicazione della dichiarazione d'intento, il valore del campo date_start è un datetime.date, per cui il valore preso come una stringa data risulta in un errore

Comportamento attuale prima di questa PR: la duplicazione non è possibile

Comportamento desiderato dopo questa PR: la duplicazione è possibile




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing