### PR TITLE
[FIX] l10n_it_delivery_note: Wrong module name

### DIFF
--- a/l10n_it_delivery_note/cli/migrate_l10n_it_ddt.py
+++ b/l10n_it_delivery_note/cli/migrate_l10n_it_ddt.py
@@ -213,7 +213,7 @@ class MigrateL10nItDdt(EasyCommand):
         DeliveryNoteType = self.env['stock.delivery.note.type']
 
         old_type = self.env.ref('l10n_it_ddt.ddt_type_ddt')
-        new_type = self.env.ref('l10n_it_delivery_note.delivery_note_type_ddt')
+        new_type = self.env.ref('l10n_it_delivery_note_base.delivery_note_type_ddt')
         new_type.write({'sequence_id': old_type.sequence_id.id})
 
         self.env.cr.execute("""


### PR DESCRIPTION
Correction of following error : ValueError: External ID not found in the system: l10n_it_delivery_note.delivery_note_type_ddt

Descrizione del problema o della funzionalità:

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
