### PR TITLE
[12.0] l10n_it_withholding_tax: Residual Net To Pay in report invoice, now, printed only if there is witholding tax in account move

### DIFF
--- a/l10n_it_withholding_tax/views/report_invoice.xml
+++ b/l10n_it_withholding_tax/views/report_invoice.xml
@@ -48,7 +48,7 @@
         <field name="inherit_id" ref="account.report_invoice_document_with_payments"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@id='total']/div/table" position="inside">
-                <t t-if="o.withholding_tax_in_print and len(payments_vals) > 0">
+                <t t-if="o.withholding_tax_in_print and len(payments_vals) > 0 and o.withholding_tax">
                     <tr class="border-black">
                         <td>
                             <strong>Residual Net To Pay</strong>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
In stampa fattura, viene aggiunto `'Residual Net To Pay'`, nel caso in cui ci sia almeno un pagamento collegato alla fattura.
Viene stampato anche se non c'è ritenuta.
Tra l'altro se abbiamo una fattura in £ e il pagamento in €, il Residual Net To Pay risulta sbagliato.


Comportamento attuale prima di questa PR:
Residual Net To Pay viene stampato anche in fattura cliente e senza ritenuta se c'è un pagamento.

Comportamento desiderato dopo questa PR:
Residual Net To Pay viene stampato solo se sulla fattura c'è ritenuta e almeno un pagamento.





--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
