### PR TITLE
[12.0] ADD dn_supplier_number and dn_supplier_date fields updated from ddt_supplier_number and ddt_supplier_date of l10n_it_ddt module

### DIFF
--- a/l10n_it_delivery_note/cli/migrate_l10n_it_ddt.py
+++ b/l10n_it_delivery_note/cli/migrate_l10n_it_ddt.py
@@ -296,6 +296,12 @@ class MigrateL10nItDdt(EasyCommand):
 
         documents = Document.search([], order='id ASC')
         for document in documents:
+            # align dn_supplier_number and dn_supplier_date fields in picking
+            for picking in document.picking_ids:
+                picking.write({
+                    "dn_supplier_number": picking.ddt_supplier_number,
+                    "dn_supplier_date": picking.ddt_supplier_date,
+                })
             DeliveryNote.create(vals_getter(document))
 
         _logger.info("Documents data successfully migrated.")

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -85,6 +85,8 @@ class StockPicking(models.Model):
     delivery_note_readonly = fields.Boolean(compute='_compute_boolean_flags')
     delivery_note_visible = fields.Boolean(compute='_compute_boolean_flags')
     can_be_invoiced = fields.Boolean(compute='_compute_boolean_flags')
+    dn_supplier_number = fields.Char(string="Supplier DN Number", copy=False)
+    dn_supplier_date = fields.Date(string="Supplier DN Date", copy=False)
 
     @property
     def _delivery_note_fields(self):

--- a/l10n_it_delivery_note/views/stock_picking.xml
+++ b/l10n_it_delivery_note/views/stock_picking.xml
@@ -231,6 +231,12 @@
                                                attrs="{'readonly': [('delivery_note_readonly', '=', True)]}" />
                                     </group>
                                 </group>
+                                <group attrs="{'invisible': [('picking_type_code', 'not in', ('incoming'))]}">
+                                    <group>
+                                        <field name="dn_supplier_number" />
+                                        <field name="dn_supplier_date" />
+                                    </group>
+                                </group>
                                 <group string="Delivery Notes"
                                        attrs="{'invisible': [('delivery_note_exists', '=', False)]}">
                                     <field name="delivery_note_note"
@@ -276,6 +282,7 @@
                 <filter string="No DN" name="no_delivery_note" domain="[('delivery_note_id', '=', False)]"/>
                 <filter string="Draft DN" name="draft_delivery_note" domain="[('delivery_note_state', '=', 'draft')]"/>
                 <filter string="Validated DN" name="validated_delivery_note" domain="[('delivery_note_state', '=', 'confirm')]"/>
+                <field name="dn_supplier_number" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Il modulo l10n_it_ddt introduceva un paio di campi (ddt_supplier_number ed ddt_supplier_date) nel modello stock.picking che non sono stati riportati dal nuovo l10n_it_delivery_note.

Comportamento attuale prima di questa PR:
Assenza dei campi ddt_supplier_number ed ddt_supplier_date

Comportamento desiderato dopo questa PR:
introduzione dei campi dn_supplier_number ed dn_supplier_date (opportunamente rinominati) con aggiornamento dello script di migrazione per valorizzarli con quanto presente in ddt_supplier_number ed ddt_supplier_date.




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
