### PR TITLE
[FIX] l10n_it_fiscal_document_type: license must be AGPL since it depends on AGPL modules

### DIFF
--- a/l10n_it_fiscal_document_type/__manifest__.py
+++ b/l10n_it_fiscal_document_type/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2017 Alessandro Camilli
 # Copyright 2018 Sergio Zanchetta (Associazione PNLUG - Gruppo Odoo)
 # Copyright 2018 Lorenzo Battistini (https://github.com/eLBati)
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
     "name": "ITA - Tipi di documento fiscale per dichiarativi",
@@ -9,7 +9,7 @@
     "category": "Localization/Italy",
     "author": "Link It srl, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-italy",
-    "license": "LGPL-3",
+    "license": "AGPL-3",  # Depends on AGPL modules
     "depends": ["l10n_it_account"],
     "data": [
         "views/fiscal_document_type_view.xml",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1246629/134641951-dc995190-2b48-40bc-9b2a-678933d2d1a1.png)
