### PR TITLE
[FIX][12.0] add ability to remove current selection dichiarazione di intento in invoice

### DIFF
--- a/l10n_it_dichiarazione_intento/wizard/manually_declarations.py
+++ b/l10n_it_dichiarazione_intento/wizard/manually_declarations.py
@@ -36,7 +36,8 @@ class SelectManuallyDeclarations(models.TransientModel):
         if not invoice_id:
             return res
         invoice = self.env['account.invoice'].browse(invoice_id)
-        for declaration in self.declaration_ids:
-            invoice.dichiarazione_intento_ids = [
-                (4, declaration.id)]
+        if self.declaration_ids:
+            invoice.dichiarazione_intento_ids = [(6, 0, self.declaration_ids.ids)]
+        else:
+            invoice.dichiarazione_intento_ids = False
         return True


### PR DESCRIPTION
Descrizione del problema o della funzionalità: non è possibile rimuovere le dichiarazioni d'intento indicate nel campo nel tab Altre informazioni in fattura

Comportamento attuale prima di questa PR: non si possono rimuovere le dichiarazioni, anche se rimosse nel wizard

Comportamento desiderato dopo questa PR: si possono rimuovere le dichiarazioni andando a rimuoverle nel wizard




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing