### PR TITLE
Unidecode>=1.3.0 only supports Python 3.5 or later

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Unidecode>1.3.0 only supports Python 3.5 or later
+unidecode<1.3.0


### PR DESCRIPTION
Si veda https://github.com/OCA/l10n-italy/pull/2416#issuecomment-916194514 per ulteriori info.