### PR TITLE
[10.0][FIX] l10n_it_fatturapa_out: Upper limit for Unidecode version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# Unidecode>1.3.0 only supports Python 3.5 or later
-unidecode<1.3.0

--- a/setup/l10n_it_fatturapa_out/setup.py
+++ b/setup/l10n_it_fatturapa_out/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        'external_dependencies_override': {
+            'python': {
+                'unidecode': 'Unidecode<1.3.0',
+            },
+        },
+    },
 )


### PR DESCRIPTION
**Descrizione del problema**
1. Creare un nuovo virtualenv con python2
    ```
    virtualenv -p python2 prova
    ```
2. Fissare la versione di `pip` a `18.1` (la stessa utilizzata da Travis):
    ```
    pip install pip==18.1
    ```
2. Installare nel virtualenv il modulo `odoo10-addon-l10n-it-fatturapa-out` con pip:
    ```
    pip install odoo10-addon-l10n-it-fatturapa-out
    ```

**Comportamento attuale prima di questa PR**
Errore perché viene installato Unidecode alla versione più recente (al momento 1.3.1):
> Collecting odoo10-addon-l10n-it-fatturapa-out
  Using cached https://files.pythonhosted.org/packages/62/fc/c5c113a4db4bd78d00567e72ca5607422e7b64f33e537a6ea5ed0270a8e0/odoo10_addon_l10n_it_fatturapa_out-10.0.2.0.0-py2-none-any.whl
Collecting unidecode (from odoo10-addon-l10n-it-fatturapa-out)
  Using cached https://files.pythonhosted.org/packages/df/11/60a304d3bfa84173f0bfb64f81e26ac5b0bff4c657d8fb6c26ff89ab8240/Unidecode-1.3.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-2i_AHB/unidecode/setup.py", line 17, in <module>
        long_description=get_long_description(),
      File "/tmp/pip-install-2i_AHB/unidecode/setup.py", line 9, in get_long_description
        with open(os.path.join(os.path.dirname(__file__), "README.rst"), encoding='utf-8') as fp:
    TypeError: 'encoding' is an invalid keyword argument for this function
>    
>    ----------------------------------------
>Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-2i_AHB/unidecode/

**Comportamento desiderato dopo questa PR**
Scelta di Unidecode compatibile con Python2: versione < 1.3.0.
Unidecode non supporta più Python2 da https://github.com/avian2/unidecode/commit/00bb678f090648bd1eb583d056e31b949198a746.

**Note**
La versione di `pip` in Travis è per qualche motivo fissata a `18.1`, per chiarire il motivo ho aperto https://github.com/OCA/maintainer-quality-tools/issues/696.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
