### PR TITLE
[12.0][FIX] l10n_it_ricevute_bancarie do not group riba with cig cup

### DIFF
--- a/l10n_it_ricevute_bancarie/tests/test_riba.py
+++ b/l10n_it_ricevute_bancarie/tests/test_riba.py
@@ -430,6 +430,50 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
             )],
         })
         invoice1.action_invoice_open()
+        # invoice with same cig-cup to be grouped
+        invoice2 = self.env['account.invoice'].create({
+            'date_invoice': recent_date,
+            'journal_id': self.sale_journal.id,
+            'partner_id': self.partner.id,
+            'payment_term_id': self.account_payment_term_riba.id,
+            'account_id': self.account_rec1_id.id,
+            'invoice_line_ids': [(
+                0, 0, {
+                    'name': 'product1',
+                    'product_id': self.product1.id,
+                    'quantity': 1.0,
+                    'price_unit': 450.00,
+                    'account_id': self.sale_account.id
+                }
+            )],
+            'related_documents': [(
+                0, 0, {
+                    'type': 'order',
+                    'name': 'SO1232',
+                    'cig': '7987210EG5',
+                    'cup': 'H71N17000690125',
+                }
+            )],
+        })
+        invoice2.action_invoice_open()
+        # invoice without related documents to be left alone
+        invoice3 = self.env['account.invoice'].create({
+            'date_invoice': recent_date,
+            'journal_id': self.sale_journal.id,
+            'partner_id': self.partner.id,
+            'payment_term_id': self.account_payment_term_riba.id,
+            'account_id': self.account_rec1_id.id,
+            'invoice_line_ids': [(
+                0, 0, {
+                    'name': 'product1',
+                    'product_id': self.product1.id,
+                    'quantity': 1.0,
+                    'price_unit': 450.00,
+                    'account_id': self.sale_account.id
+                }
+            )],
+        })
+        invoice3.action_invoice_open()
         # issue wizard
         riba_move_line_id = invoice.move_id.line_ids.filtered(
             lambda x: x.account_id == self.account_rec1_id

--- a/l10n_it_ricevute_bancarie/wizard/wizard_riba_issue.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_riba_issue.py
@@ -56,8 +56,16 @@ class RibaIssue(models.TransientModel):
         move_lines = move_line_obj.search(
             [('id', 'in', self._context['active_ids'])])
         do_group_riba = True
-        if len(set(['%s%s' % (x.cig, x.cup) for x in
-               move_lines.mapped('invoice_id.related_documents')])) > 1:
+        cig_cup_list = []
+        for move_line in move_lines:
+            if move_line.invoice_id.related_documents:
+                cig_cup_list.append('%s%s' % (
+                    move_line.mapped('invoice_id.related_documents.cig'),
+                    move_line.mapped('invoice_id.related_documents.cup'),
+                ))
+            else:
+                cig_cup_list.append('')
+        if len(set(cig_cup_list)) > 1:
             do_group_riba = False
         if do_group_riba:
             for move_line in move_lines:


### PR DESCRIPTION
Descrizione del problema o della funzionalità: le riba con cig cup non devono essere raggruppate con quelle senza

Comportamento attuale prima di questa PR: le riba vengono separate solo se con cig e cup diversi

Comportamento desiderato dopo questa PR: le riba vengono separate anche se con cig e cup e senza




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing