### PR TITLE
[12.0][IMP] l10n_it_account_stamp: Usabilità per il bollo in fattura

### DIFF
--- a/l10n_it_account_stamp/models/invoice.py
+++ b/l10n_it_account_stamp/models/invoice.py
@@ -159,7 +159,7 @@ class AccountInvoice(models.Model):
                     raise exceptions.Warning(
                         _('Missing tax stamp product in company settings!')
                     )
-                income_vals, expense_vals = self._build_tax_stamp_lines(
+                income_vals, expense_vals = inv._build_tax_stamp_lines(
                     stamp_product_id)
                 income_vals['move_id'] = inv.move_id.id
                 expense_vals['move_id'] = inv.move_id.id

--- a/l10n_it_account_stamp/models/invoice.py
+++ b/l10n_it_account_stamp/models/invoice.py
@@ -6,8 +6,16 @@ from odoo import fields, api, models, exceptions, _
 class AccountInvoice(models.Model):
     _inherit = 'account.invoice'
     tax_stamp = fields.Boolean(
-        "Tax Stamp", readonly=False,
-        compute="_compute_tax_stamp", store=True)
+        string="Tax Stamp",
+        help="Tax stamp is applied to this invoice.",
+        readonly=False,
+        compute="_compute_tax_stamp",
+        store=True,
+    )
+    tax_stamp_line_present = fields.Boolean(
+        string="Stamp line is present in invoice",
+        compute='_compute_tax_stamp_line_present',
+    )
     auto_compute_stamp = fields.Boolean(
         related='company_id.tax_stamp_product_id.auto_compute')
     manually_apply_tax_stamp = fields.Boolean("Apply tax stamp")
@@ -82,10 +90,21 @@ class AccountInvoice(models.Model):
             inv.compute_taxes()
 
     def is_tax_stamp_line_present(self):
+        self.ensure_one()
         for l in self.invoice_line_ids:
             if l.product_id and l.product_id.is_stamp:
                 return True
         return False
+
+    @api.multi
+    @api.depends(
+        'invoice_line_ids',
+        'invoice_line_ids.product_id',
+        'invoice_line_ids.product_id.is_stamp',
+    )
+    def _compute_tax_stamp_line_present(self):
+        for invoice in self:
+            invoice.tax_stamp_line_present = invoice.is_tax_stamp_line_present()
 
     def _build_tax_stamp_lines(self, product):
         if (

--- a/l10n_it_account_stamp/views/invoice_view.xml
+++ b/l10n_it_account_stamp/views/invoice_view.xml
@@ -21,13 +21,25 @@
                     <field name="auto_compute_stamp" invisible="1"/>
                     <field name="tax_stamp" string="Tax stamp" invisible="1"/>
                     <field name="manually_apply_tax_stamp"  attrs="{'invisible': [('auto_compute_stamp', '=', True)]}"/>
+                    <field name="tax_stamp_line_present" invisible="1"/>
                 </field>
 
                 <field name="invoice_line_ids" position="after">
-                    <img src="/l10n_it_account_stamp/static/description/icon.png" alt="Tax stamp"
-                         attrs="{'invisible': [('tax_stamp', '=', False)]}"/>
-                    <button class="oe_edit_only" type="object" string="Add tax stamp line"
-                            name="add_tax_stamp_line" attrs="{'invisible': ['|',('tax_stamp', '=', False),('state', 'not in', 'draft')]}"/>
+                    <div name="stamp_applicability" attrs="{'invisible': [('tax_stamp', '=', False)]}">
+                        <img src="/l10n_it_account_stamp/static/description/icon.png" alt="Tax stamp"/>
+                        <span attrs="{'invisible': [('tax_stamp_line_present', '=', True)]}">
+                            <span attrs="{'invisible': [('state', 'not in', 'draft')]}">
+                                <button type="object" string="Charge stamp to customer"
+                                        name="add_tax_stamp_line"/>
+                            </span>
+                            <span attrs="{'invisible': [('state', '=', 'draft')]}">
+                                Stamp can only be charged to customer when invoice is in draft state
+                            </span>
+                        </span>
+                        <span attrs="{'invisible': [('tax_stamp_line_present', '=', False)]}">
+                            Stamp charged to customer
+                        </span>
+                    </div>
                 </field>
 
             </field>


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/2447 per `12.0`

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
