### PR TITLE
[14.0][FIX] mass validation picking with Advanced DN Features

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -314,55 +314,50 @@ class StockPicking(models.Model):
         return True
 
     def button_validate(self):
-        if not self.delivery_note_id:
+        delivery_note_to_create = self._must_create_delivery_note()
+        if not self.delivery_note_id and delivery_note_to_create:
             self._check_delivery_note_consistency()
-
         res = super().button_validate()
-
-        if not self.delivery_note_id:
-            if self._must_create_delivery_note():
-                partners = self._get_partners()
-
-                type_id = self.env["stock.delivery.note.type"].search(
-                    [("code", "=", self.picking_type_code)], limit=1
-                )
-
-                delivery_note = self.env["stock.delivery.note"].create(
-                    {
-                        "partner_sender_id": partners[0].id,
-                        "partner_id": partners[1].id,
-                        "partner_shipping_id": partners[1].id,
-                        "type_id": type_id.id,
-                        "date": self.date_done,
-                        "delivery_method_id": (
-                            self.partner_id.property_delivery_carrier_id.id
-                        ),
-                        "transport_condition_id": (
-                            self.sale_id.default_transport_condition_id.id
-                            or partners[1].default_transport_condition_id.id
-                            or type_id.default_transport_condition_id.id
-                        ),
-                        "goods_appearance_id": (
-                            self.sale_id.default_goods_appearance_id.id
-                            or partners[1].default_goods_appearance_id.id
-                            or type_id.default_goods_appearance_id.id
-                        ),
-                        "transport_reason_id": (
-                            self.sale_id.default_transport_reason_id.id
-                            or partners[1].default_transport_reason_id.id
-                            or type_id.default_transport_reason_id.id
-                        ),
-                        "transport_method_id": (
-                            self.sale_id.default_transport_method_id.id
-                            or partners[1].default_transport_method_id.id
-                            or type_id.default_transport_method_id.id
-                        ),
-                    }
-                )
-
-                self.write({"delivery_note_id": delivery_note.id})
-
+        if delivery_note_to_create and not self.delivery_note_id:
+            delivery_note = self._create_delivery_note()
+            self.write({"delivery_note_id": delivery_note.id})
         return res
+
+    def _create_delivery_note(self):
+        partners = self._get_partners()
+        type_id = self.env["stock.delivery.note.type"].search(
+            [("code", "=", self.picking_type_code)], limit=1
+        )
+        return self.env["stock.delivery.note"].create(
+            {
+                "partner_sender_id": partners[0].id,
+                "partner_id": partners[1].id,
+                "partner_shipping_id": partners[1].id,
+                "type_id": type_id.id,
+                "date": self.date_done,
+                "delivery_method_id": self.partner_id.property_delivery_carrier_id.id,
+                "transport_condition_id": (
+                    self.sale_id.default_transport_condition_id.id
+                    or partners[1].default_transport_condition_id.id
+                    or type_id.default_transport_condition_id.id
+                ),
+                "goods_appearance_id": (
+                    self.sale_id.default_goods_appearance_id.id
+                    or partners[1].default_goods_appearance_id.id
+                    or type_id.default_goods_appearance_id.id
+                ),
+                "transport_reason_id": (
+                    self.sale_id.default_transport_reason_id.id
+                    or partners[1].default_transport_reason_id.id
+                    or type_id.default_transport_reason_id.id
+                ),
+                "transport_method_id": (
+                    self.sale_id.default_transport_method_id.id
+                    or partners[1].default_transport_method_id.id
+                    or type_id.default_transport_method_id.id
+                ),
+            }
+        )
 
     def delivery_note_update_transport_datetime(self):
         self.delivery_note_id.update_transport_datetime()


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
Fix error in mass validation picking: the module did a check on the uniqueness of selected picking's partner also if automatic creation of DN are disabled.
Now, this check is done only when automatic DN will be created;


Comportamento attuale prima di questa PR:
Non è possibile validare più picking con partner diversi

Comportamento desiderato dopo questa PR:
Posso validare più picking con partner diversi




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
