### PR TITLE
[14.0] [FIX] l10n_it_fatturapa_out: minor porting leftover

### DIFF
--- a/l10n_it_fatturapa_out/models/account.py
+++ b/l10n_it_fatturapa_out/models/account.py
@@ -92,7 +92,7 @@ class AccountInvoice(models.Model):
                         "Invoice %s has XML and can't be canceled. "
                         "Delete the XML before."
                     )
-                    % invoice.number
+                    % invoice.name
                 )
         res = super(AccountInvoice, self).action_invoice_cancel()
         return res


### PR DESCRIPTION
Era rimasto in giro un invoice.number che sarebbe dovuto diventare invoice.name. L'errore si vede quanto si cerca di cancellare una fattura con XML collegato.