### PR TITLE
[14.0][FIX] l10n_it_delivery_note: select wizard fails to get picking state after core updates

### DIFF
--- a/l10n_it_delivery_note/wizard/delivery_note_select.xml
+++ b/l10n_it_delivery_note/wizard/delivery_note_select.xml
@@ -13,7 +13,12 @@
                 <div attrs="{'invisible': [('error_message', '=', False)]}">
                     <field name="error_message" />
                 </div>
-                <field name="selected_picking_ids" invisible="True" />
+                <field name="selected_picking_ids" invisible="True">
+                    <!-- force cache usage avoiding to call stock.picking._compute_state method -->
+                    <tree>
+                        <field name="state" />
+                    </tree>
+                </field>
                 <div
                     class="oe_title"
                     attrs="{'invisible': [('error_message', '!=', False)]}"
@@ -56,7 +61,7 @@
                                 <field name="scheduled_date" />
                                 <field name="origin" />
                                 <field name="backorder_id" />
-                                <field name="state" />
+                                <field name="state" invisible="True" />
                             </tree>
                         </field>
                     </page>


### PR DESCRIPTION
le modifiche apportate al metodo `_compute_state` (https://github.com/odoo/odoo/commit/dca7119f6fe4f9e66c3ecc58f204420e2ad805cd#diff-79cbc763115661182c02285c07320098510f5686700359ddee67443b4893dc30) da parte del core portano ad un fallimento nel tentativo di assegnare un delivery note esistente ad un picking in stato 'done'.
in pratica:
![image](https://user-images.githubusercontent.com/70569899/139447274-f0442454-1a28-4e72-976d-e3dc7c4df009.png)

questo accade perchè il dato ('state') non risulta in cache.

questa PR per forzare l'inserimento in cache di tale dato evitando quindi la chiamata al metodo `_compute_state`