### PR TITLE
[14.0][FIX] l10n_it_fatturapa_out: do not relay on invoice line having taxes

### DIFF
--- a/l10n_it_fatturapa_out/data/invoice_it_template.xml
+++ b/l10n_it_fatturapa_out/data/invoice_it_template.xml
@@ -136,7 +136,7 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
         </template>
 
         <template id="account_invoice_line_it_FatturaPA">
-            <t t-set="tax_ids" t-value="line.tax_ids[0]" />
+            <t t-set="tax_ids" t-value="line.tax_ids and line.tax_ids[0]" />
             <DettaglioLinee>
                 <NumeroLinea t-esc="line_counter" />
                 <!--                <TipoCessionePrestazione t-esc=""/>-->

--- a/l10n_it_fatturapa_out/models/account.py
+++ b/l10n_it_fatturapa_out/models/account.py
@@ -54,6 +54,7 @@ class AccountInvoice(models.Model):
                     _("Impossible to generate XML: not a customer invoice: %s")
                     % invoice.name
                 )
+
             if (
                 invoice.invoice_payment_term_id
                 and invoice.invoice_payment_term_id.fatturapa_pt_id.code is False
@@ -78,6 +79,11 @@ class AccountInvoice(models.Model):
                         invoice.name,
                         invoice.invoice_payment_term_id.name,
                     )
+                )
+
+            if not all(aml.tax_ids for aml in invoice.invoice_line_ids):
+                raise UserError(
+                    _("Invoice %s contains product lines w/o taxes") % invoice.name
                 )
         return
 


### PR DESCRIPTION
Product lines must have taxes, so we perform an explicit check.

Fix for #2463