### PR TITLE
[12.0][fix] fiscal_epos_print: null order in lottery_get_button_color method

### DIFF
--- a/fiscal_epos_print/static/src/js/screens.js
+++ b/fiscal_epos_print/static/src/js/screens.js
@@ -219,7 +219,7 @@ odoo.define("fiscal_epos_print.screens", function (require) {
         lottery_get_button_color: function() {
             var order = this.pos.get_order();
             var color = '#e2e2e2';
-            if (order.lottery_code) {
+            if (order && order.lottery_code) {
                 color = 'lightgreen';
             }
             return color;


### PR DESCRIPTION
configurando il servizio POS di tipo bar/ristorante con Gestione tavoli, ie:
![image](https://user-images.githubusercontent.com/70569899/140522765-a110bf14-3154-4ce8-8bae-940b11118e9b.png)

il `pos.ui `non viene caricato.

questo accade per https://github.com/odoo/odoo/blob/da6cd70e8bc436cb4cc625266ae6763442e65965/addons/pos_restaurant/static/src/js/floors.js#L831

che quindi fa saltare l'errore in https://github.com/OCA/l10n-italy/blob/a6a57a0dceccc0b74153766d79247227b77db5d7/fiscal_epos_print/static/src/js/screens.js#L222

