### PR TITLE
[14.0][fix] l10n_it_delivery_note: unable to set delivery note to draft in case invoice created before delivery note creation/association

### DIFF
--- a/l10n_it_delivery_note/wizard/delivery_note_create.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_create.py
@@ -100,6 +100,7 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
         )
 
         self.selected_picking_ids.write({"delivery_note_id": delivery_note.id})
+        sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids)
 
         if self.user_has_groups("l10n_it_delivery_note.use_advanced_delivery_notes"):
             return delivery_note.goto()

--- a/l10n_it_delivery_note/wizard/delivery_note_select.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_select.py
@@ -47,5 +47,9 @@ class StockDeliveryNoteSelectWizard(models.TransientModel):
         self.check_compliance(self.picking_ids)
         self.selected_picking_ids.write({"delivery_note_id": self.delivery_note_id.id})
 
+        sale_order_ids = self.selected_picking_ids.sale_id
+        sale_order_id = sale_order_ids and sale_order_ids[0] or False
+        sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids)
+
         if self.user_has_groups("l10n_it_delivery_note.use_advanced_delivery_notes"):
             return self.delivery_note_id.goto()


### PR DESCRIPTION
passi per riprodurre:

- creare e convalidare SO
- confermare picking
- creare fattura
- creare/associare DdT al picking e validare
- cancellare il DdT e portare in draft

lo stato rimane in "invoiced"
