### PR TITLE
[14.0][FIX] l10n_it_account_stamp: Descrizione righe fattura resettate quando viene aggiunto il bollo

### DIFF
--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -87,6 +87,12 @@ class AccountMove(models.Model):
             }
             inv.write({"invoice_line_ids": [(0, 0, invoice_line_vals)]})
 
+    def _move_autocomplete_invoice_lines_values(self):
+        # Load line names in cache,
+        # otherwise they are reset to the default value
+        self.line_ids.mapped("name")
+        return super()._move_autocomplete_invoice_lines_values()
+
     def is_tax_stamp_line_present(self):
         for line in self.line_ids:
             if line.is_stamp_line:


### PR DESCRIPTION
Corregge https://github.com/OCA/l10n-italy/issues/2498 per v14

Ammetto che la modifica è un work-around pure brutto, la soluzione corretta sarebbe secondo me https://github.com/odoo/odoo/pull/79662 ma chissà se verrà mai accetata.