### PR TITLE
Nuova versione di `black` per correggere "undefined symbol: _PyUnicode_DecodeUnicodeEscape"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
           - --remove-duplicate-keys
           - --remove-unused-variables
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.10b0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/l10n_it_account/models/account_group.py
+++ b/l10n_it_account/models/account_group.py
@@ -73,7 +73,7 @@ class AccountGroup(models.Model):
         return 1
 
     def get_group_accounts(self):
-        """ Retrieves every account from `self` and `self`'s subgroups. """
+        """Retrieves every account from `self` and `self`'s subgroups."""
         return (self + self.get_group_subgroups()).mapped("account_ids")
 
     def get_group_progenitor(self):
@@ -97,6 +97,6 @@ class AccountGroup(models.Model):
         return self.browse(parent_ids)
 
     def get_group_subgroups(self):
-        """ Retrieves every subgroup for groups `self`. """
+        """Retrieves every subgroup for groups `self`."""
         subgroups_ids = self.search([("id", "child_of", self.ids)])
         return subgroups_ids


### PR DESCRIPTION
L'errore è
```
ImportError: /home/runner/.cache/pre-commit/repob3mj_5qk/py_env-python3/lib/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_DecodeUnicodeEscape
```
La issue originale è https://github.com/python/typed_ast/issues/169