### PR TITLE
[12.0][IMP] Add conflicts module for l10n_it_fatturapa_sale

### DIFF
--- a/l10n_it_fatturapa_sale/__manifest__.py
+++ b/l10n_it_fatturapa_sale/__manifest__.py
@@ -16,6 +16,7 @@
         "l10n_it_fatturapa",
         "sale_management",
     ],
+    "excludes": ["sale_order_action_invoice_create_hook"],
     "data": [
         "views/related_document_type_views.xml",
         "views/sale_order_line_views.xml",


### PR DESCRIPTION
Descrizione del problema o della funzionalità: se il modulo sale_order_action_invoice_create_hook è installato, la funzione aggiunta in questo modulo viene bypassata

Comportamento attuale prima di questa PR: il modulo non aggiunge la funzionalità prevista

Comportamento desiderato dopo questa PR: il modulo aggiunge la funzionalità prevista




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing