### PR TITLE
[12.0][IMP] l10n_it_fatturapa_sale add related documents to advance invoice

### DIFF
--- a/l10n_it_fatturapa_sale/__init__.py
+++ b/l10n_it_fatturapa_sale/__init__.py
@@ -1,3 +1,4 @@
 #  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from . import wizard

--- a/l10n_it_fatturapa_sale/wizard/__init__.py
+++ b/l10n_it_fatturapa_sale/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_make_invoice_advance

--- a/l10n_it_fatturapa_sale/wizard/sale_make_invoice_advance.py
+++ b/l10n_it_fatturapa_sale/wizard/sale_make_invoice_advance.py
@@ -1,0 +1,19 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SaleAdvancePaymentInv(models.TransientModel):
+    _inherit = "sale.advance.payment.inv"
+
+    @api.multi
+    def _create_invoice(self, order, so_line, amount):
+        invoice = super()._create_invoice(order, so_line, amount)
+        order = invoice.invoice_line_ids.mapped('sale_line_ids.order_id')
+        sale_documents = order.mapped('related_documents')
+        invoice.update({
+            'related_documents': [
+                (4, sale_document_id)
+                for sale_document_id in sale_documents.ids],
+        })
+        return invoice


### PR DESCRIPTION
Descrizione del problema o della funzionalità: i documenti correlati non vengono riportati n caso di creazione fattura di acconto

Comportamento attuale prima di questa PR: i documenti correlati sono mancanti

Comportamento desiderato dopo questa PR: i documenti correlati sono presenti




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing