### PR TITLE
[FIX][14.0] check lack of taxes only on product lines

### DIFF
--- a/l10n_it_fatturapa_out/models/account.py
+++ b/l10n_it_fatturapa_out/models/account.py
@@ -81,7 +81,9 @@ class AccountInvoice(models.Model):
                     )
                 )
 
-            if not all(aml.tax_ids for aml in invoice.invoice_line_ids):
+            if not all(
+                aml.tax_ids for aml in invoice.invoice_line_ids if aml.product_id
+            ):
                 raise UserError(
                     _("Invoice %s contains product lines w/o taxes") % invoice.name
                 )


### PR DESCRIPTION
Ehm certo che quando uno dice "codice equivalente" deve poi farlo equivalente sul serio...

https://github.com/OCA/l10n-italy/pull/2485#discussion_r747572115

fix per controllo assenza tasse sulle righe fattura, che non deve applicarsi alle note

ad un certo punto le note hanno smesso di avere tasse


@As400it hai modo di testarla al volo, mi pare di capire che ti serve