### PR TITLE
[FIX] l10n_it_split_payment: fix unbalanced lines

### DIFF
--- a/l10n_it_fatturapa_out_sp/tests/data/IT06363391001_00004.xml
+++ b/l10n_it_fatturapa_out_sp/tests/data/IT06363391001_00004.xml
@@ -63,7 +63,7 @@
                 <TipoDocumento>TD01</TipoDocumento>
                 <Divisa>EUR</Divisa>
                 <Data>2016-06-15</Data>
-                <Numero>INV/2016/0016</Numero>
+                <Numero>INV/2016/06/0001</Numero>
                 <ImportoTotaleDocumento>17.08</ImportoTotaleDocumento>
                 <Art73>SI</Art73>
             </DatiGeneraliDocumento>

--- a/l10n_it_split_payment/models/account.py
+++ b/l10n_it_split_payment/models/account.py
@@ -118,6 +118,7 @@ class AccountMove(models.Model):
         write_off_line_vals = self._build_debit_line()
         line_sp = self.line_ids.filtered(lambda l: l.is_split_payment)
         if line_sp:
+            line_sp = line_sp[0].with_context(check_move_validity=False)
             if (
                 self.move_type == "out_invoice"
                 and float_compare(
@@ -127,7 +128,7 @@ class AccountMove(models.Model):
                 )
                 != 0
             ):
-                line_sp.with_context(check_move_validity=False).update(
+                line_sp.update(
                     {
                         "price_unit": 0.0,
                         "amount_currency": 0.0,
@@ -146,7 +147,7 @@ class AccountMove(models.Model):
                 )
                 != 0
             ):
-                line_sp.with_context(check_move_validity=False).update(
+                line_sp.update(
                     {
                         "price_unit": 0.0,
                         "amount_currency": 0.0,

--- a/l10n_it_split_payment/readme/CONTRIBUTORS.rst
+++ b/l10n_it_split_payment/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * Giacomo Grasso <giacomo.grasso.82@gmail.com>
 * Ruben Tonetto <https://github.com/ruben-tonetto>
 * Giuseppe Borruso - Dinamiche Aziendali srl <gborruso@dinamicheaziendali.it>
+* Alex Comba <alex.comba@agilebg.com>

--- a/l10n_it_split_payment/views/account_view.xml
+++ b/l10n_it_split_payment/views/account_view.xml
@@ -13,7 +13,7 @@
         </field>
     </record>
 
-        <record id="account_move_form_sp" model="ir.ui.view">
+    <record id="account_move_form_sp" model="ir.ui.view">
         <field name="name">account.move.form.sp</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
@@ -29,6 +29,12 @@
                     attrs="{'invisible': [('split_payment', '=', False)]}"
                 />
             </field>
+            <xpath
+                expr="//sheet/notebook/page/field[@name='line_ids']/tree"
+                position="inside"
+            >
+                <field name="is_split_payment" optional="hide" />
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Per riprodurre l'errore:
- crea fattura
- aggiungere una riga split payment
- controllare le righe contabili generate (Ok)
- aggiungere nuova riga split payment
- controllare le righe contabili generate (Errate)

Mentre se faccio fattura da ordine e non aggiungo poi righe aggiuntive allora le righe contabili generate sono corrette