### PR TITLE
[14.0][FIX] l10n_it_fiscal_document_type: Keep model attribute in name_search

### DIFF
--- a/l10n_it_fiscal_document_type/models/fiscal_document_type.py
+++ b/l10n_it_fiscal_document_type/models/fiscal_document_type.py
@@ -45,6 +45,7 @@ class FiscalDocumentType(models.Model):
             res.append((doc_type.id, "[%s] %s" % (doc_type.code, doc_type.name)))
         return res
 
+    @api.model
     def name_search(self, name="", args=None, operator="ilike", limit=100):
         if not args:
             args = []


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/2561