### PR TITLE
[14.0][FIX] split_payment: errore su conferma fatture con riga di split payment

### DIFF
--- a/l10n_it_split_payment/migrations/14.0.1.0.0/post-migration.py
+++ b/l10n_it_split_payment/migrations/14.0.1.0.0/post-migration.py
@@ -1,0 +1,32 @@
+#  Copyright 2021 Simone Vanin - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, installed_version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    MoveLine = env["account.move.line"]
+    Translations = env["ir.translation"]
+    source = "Split Payment Write Off"
+    text_vals = {source}
+    langs = Translations._get_languages()
+    for lang, _lang_name in langs:
+        text_val = env["ir.translation"]._get_source(
+            False, "code", lang=lang, source=source
+        )
+        text_vals.add(text_val)
+    text_vals = list(text_vals)
+    line_ids = MoveLine.search([("name", "in", text_vals)]).ids
+    openupgrade.logged_query(
+        cr,
+        """
+update account_move_line
+set is_split_payment = True
+where id in {line_ids}
+    """.format(
+            line_ids=tuple(line_ids)
+        ),
+    )

--- a/l10n_it_split_payment/models/account.py
+++ b/l10n_it_split_payment/models/account.py
@@ -109,9 +109,7 @@ class AccountMove(models.Model):
 
     def _compute_split_payments(self):
         write_off_line_vals = self._build_debit_line()
-        line_sp = self.line_ids.filtered(
-            lambda l: l.is_split_payment or l.name == _("Split Payment Write Off")
-        )
+        line_sp = self.line_ids.filtered(lambda l: l.is_split_payment)
         if line_sp:
             if self.move_type == "out_invoice" and float_compare(
                 line_sp[0].debit,


### PR DESCRIPTION
Questo errore è capitato su un database migrato alla 14.0 avente una fattura in bozza con la riga di split payment.

Provando a confermare la fattura esce l'errore:
```
Impossibile creare movimenti contabili non bilanciati. ID: [xxxx]
Differenze dare - avere: [xx.x]
```

Sullo stesso db, aggiungi un pagamento a una fattura confermata:
```
Impossibile effettuare questa modifica su una registrazione riconciliata, sono modificabili solo alcuni campi non legali. Annullare prima la riconciliazione.
Registrazione contabile (ID): Fattura (xxxx)
```
Questo accade perché, non essendo valorizzato il campo `is_split_payment`, cerca la riga di movimento tramite `name == _("Split Payment Write Off")`, ma se la lingua dell'utente è diversa dalla lingua nella quale è stata tradotta la scritta, non la trova e conta l'importo dello split payment come da riconciliare.