### PR TITLE
[14.0][FIX] l10n_it_delivery_note: unable to create DN without sale order

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -321,6 +321,8 @@ class StockPicking(models.Model):
         if delivery_note_to_create and not self.delivery_note_id:
             delivery_note = self._create_delivery_note()
             self.write({"delivery_note_id": delivery_note.id})
+            if self.sale_id:
+                self.sale_id._assign_delivery_notes_invoices(self.sale_id.invoice_ids)
         return res
 
     def _create_delivery_note(self):

--- a/l10n_it_delivery_note/wizard/delivery_note_create.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_create.py
@@ -70,7 +70,7 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
         self.check_compliance(self.selected_picking_ids)
 
         sale_order_ids = self.mapped("selected_picking_ids.sale_id")
-        sale_order_id = sale_order_ids and sale_order_ids[0] or False
+        sale_order_id = sale_order_ids and sale_order_ids[0] or self.env["sale.order"]
 
         delivery_note = self.env["stock.delivery.note"].create(
             {
@@ -100,7 +100,8 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
         )
 
         self.selected_picking_ids.write({"delivery_note_id": delivery_note.id})
-        sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids)
+        if sale_order_id:
+            sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids)
 
         if self.user_has_groups("l10n_it_delivery_note.use_advanced_delivery_notes"):
             return delivery_note.goto()

--- a/l10n_it_delivery_note/wizard/delivery_note_select.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_select.py
@@ -48,8 +48,9 @@ class StockDeliveryNoteSelectWizard(models.TransientModel):
         self.selected_picking_ids.write({"delivery_note_id": self.delivery_note_id.id})
 
         sale_order_ids = self.selected_picking_ids.sale_id
-        sale_order_id = sale_order_ids and sale_order_ids[0] or False
-        sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids)
+        sale_order_id = sale_order_ids and sale_order_ids[0] or self.env["sale.order"]
+        if sale_order_id:
+            sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids)
 
         if self.user_has_groups("l10n_it_delivery_note.use_advanced_delivery_notes"):
             return self.delivery_note_id.goto()


### PR DESCRIPTION
Per riprodurre l'errore:
fare un picking senza passare da ordine e creare il DDT

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing