### PR TITLE
[14.0][FIX] l10n_it_fatturapa_in: remove limit parameter from browse

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -398,7 +398,7 @@ class WizardImportFatturapa(models.TransientModel):
         )
         def_purchase_tax = False
         if supplier_taxes_ids:
-            def_purchase_tax = account_tax_model.browse(supplier_taxes_ids, limit=1)
+            def_purchase_tax = account_tax_model.browse(supplier_taxes_ids)[0]
         if float(AliquotaIVA) == 0.0 and Natura:
             account_taxes = account_tax_model.search(
                 [


### PR DESCRIPTION
Otherwise it raises the following error:

File "/srv/odoo-14-customer14-test/customer14/odoo/lib/python3.6/site-packages/odoo/addons/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 1725, in importFatturaPA
    fatt, fatturapa_attachment, fattura, partner_id
  File "/srv/odoo-14-customer14-test/customer14/odoo/lib/python3.6/site-packages/odoo/addons/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 1045, in invoiceCreate
    FatturaBody, credit_account.id, partner, wt_founds, invoice
  File "/srv/odoo-14-customer14-test/customer14/odoo/lib/python3.6/site-packages/odoo/addons/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 1586, in set_invoice_line_ids
    credit_account_id, line, wt_founds
  File "/srv/odoo-14-customer14-test/customer14/odoo/lib/python3.6/site-packages/odoo/addons/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 536, in _prepareInvoiceLine
    retLine = self._prepare_generic_line_data(line)
  File "/srv/odoo-14-customer14-test/customer14/odoo/lib/python3.6/site-packages/odoo/addons/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 378, in _prepare_generic_line_data
    account_taxes = self.get_account_taxes(line.AliquotaIVA, line.Natura)
  File "/srv/odoo-14-customer14-test/customer14/odoo/lib/python3.6/site-packages/odoo/addons/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 393, in get_account_taxes
    def_purchase_tax = account_tax_model.browse(supplier_taxes_ids, limit=1)
Exception
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/srv/odoo-14-customer14-test/customer14/odoo/lib/python3.6/site-packages/odoo/http.py", line 640, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/srv/odoo-14-customer14-test/customer14/odoo/lib/python3.6/site-packages/odoo/http.py", line 316, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: browse() got an unexpected keyword argument 'limit'