### PR TITLE
[14.0][FIX] l10n_it_account_stamp: force invoice currency in tax stamp lines

### DIFF
--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -126,6 +126,7 @@ class AccountMove(models.Model):
             "debit": 0,
             "credit": product.list_price,
             "exclude_from_invoice_tab": True,
+            "currency_id": self.currency_id.id,
         }
         if self.move_type == "out_refund":
             income_vals["debit"] = product.list_price
@@ -141,6 +142,7 @@ class AccountMove(models.Model):
             "debit": product.list_price,
             "credit": 0,
             "exclude_from_invoice_tab": True,
+            "currency_id": self.currency_id.id,
         }
         if self.move_type == "out_refund":
             income_vals["debit"] = 0

--- a/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
+++ b/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
@@ -84,3 +84,16 @@ class InvoicingTest(TestAccountInvoiceReport):
         # Add stamp and check that edited description is kept
         invoice.add_tax_stamp_line()
         self.assertEqual(invoice.invoice_line_ids[0].name, edited_descr)
+
+    def test_amount_total_changing_currency(self):
+        """Modify invoice currency and check that amount_total does not change after
+        action_post"""
+        self.env.company.tax_stamp_product_id.auto_compute = False
+        invoice = self.invoices.filtered(lambda inv: inv.move_type == "out_invoice")
+        invoice_form = Form(invoice)
+        invoice_form.manually_apply_tax_stamp = False
+        invoice_form.currency_id = self.env.ref("base.USD")
+        invoice = invoice_form.save()
+        total = invoice.amount_total
+        invoice.action_post()
+        self.assertEqual(total, invoice.amount_total)


### PR DESCRIPTION
Come riprodurre il bug:
creare una fattura con `currency_id` diversa da quella di defualt e settare il campo `manually_apply_tax_stamp`

dopo la conferma della fattura l'`amount_total` risulta calcolato in currency_id di defualt.

questa PR forza l'utilizzo della `currency_id` della fattura nella creazione delle `account.move.line` da parte di questo modulo in fase di conferma.