### PR TITLE
[14.0][FIX] l10n_it_fatturapa_out: allow to write related_documents field when l10n_it_fatturapa_in is installed after l10n_it_fatturapa_out

### DIFF
--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -16,6 +16,7 @@
         <field name="name">account.invoice.fatturapa</field>
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
+        <field name="priority" eval="20" />
         <field name="arch" type="xml">
             <button name="preview_invoice" position="before">
                 <button


### PR DESCRIPTION
This change fixes the following scenario:

- install l10n_it_fatturapa_out
- install l10n_it_fatturapa_in
- tick the flag *Enable electronic invoicing* on a partner
- create an invoice for the previous partner
- add some lines in Related Documents
- related documents are not saved

This is due to the order in which `account.view_move_form` inherited views are loaded (ref. https://github.com/odoo/odoo/blob/293f54336fe18b41579604a20969534006437460/odoo/addons/base/models/ir_ui_view.py#L595)