### PR TITLE
[12.0][FIX] enable sale user with no access to related_documents to delete a sale line

### DIFF
--- a/l10n_it_fatturapa_sale/models/sale_order.py
+++ b/l10n_it_fatturapa_sale/models/sale_order.py
@@ -33,7 +33,6 @@ class SaleOrder (models.Model):
 
     @api.multi
     def unlink(self):
-        related_documents = self.mapped('related_documents')
-        res = super().unlink()
+        related_documents = self.sudo().mapped('related_documents')
         related_documents.check_unlink().unlink()
-        return res
+        return super().unlink()

--- a/l10n_it_fatturapa_sale/models/sale_order_line.py
+++ b/l10n_it_fatturapa_sale/models/sale_order_line.py
@@ -50,7 +50,6 @@ class SaleOrderLine(models.Model):
 
     @api.multi
     def unlink(self):
-        related_documents = self.mapped('related_documents')
-        res = super().unlink()
+        related_documents = self.sudo().mapped('related_documents')
         related_documents.check_unlink().unlink()
-        return res
+        return super().unlink()


### PR DESCRIPTION
Descrizione del problema o della funzionalità: un utente dell'app vendite non può eliminare una riga di ordine di vendita o un ordine di vendita, anche senza related documents

Comportamento attuale prima di questa PR: l'utente non riesce ad eliminare righe o ordini

Comportamento desiderato dopo questa PR: l'utente riesce ad eliminare righe ed ordini




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing