### PR TITLE
[12.0][FIX] fiscal_epos_print: Validazione massiva imposte

### DIFF
--- a/fiscal_epos_print/models/account.py
+++ b/fiscal_epos_print/models/account.py
@@ -15,5 +15,6 @@ class AccountTax(models.Model):
 
     @api.constrains('fpdeptax')
     def _validate_fpdeptax(self):
-        if not re.search(regex, self.fpdeptax):
-            raise ValidationError("Department ID number range [1 - 99]")
+        for tax in self:
+            if not re.search(regex, tax.fpdeptax):
+                raise ValidationError("Department ID number range [1 - 99]")


### PR DESCRIPTION
Prima di questa PR, all'installazione del modulo eseguita con un comando tipo:
```
/opt/odoo-venv/bin/odoo -d <db_name> -i fiscal_epos_print
```
viene sollevato l'errore:
```
odoo.exceptions.ValidationError: ('Error while validating constraint\n\nExpected singleton: account.tax(19, 20)', None)
```
vedi ad esempio https://runboat.odoo-community.org/api/v1/builds/b7166404f-0d25-4a9e-9481-7146d60930fe/init-log