### PR TITLE
[14.0][fix] l10n_it_reverse_charge: unable to set payment to draft

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -354,7 +354,7 @@ class AccountMove(models.Model):
     def button_draft(self):
         new_self = self.with_context(rc_set_to_draft=True)
         invoice_model = new_self.env["account.move"]
-        for inv in new_self:
+        for inv in new_self.filtered(lambda i: i != i.payment_id.move_id):
             # remove payments without deleting self invoice
             inv.remove_rc_payment(delete_self_invoice=False)
             inv.remove_invoice_payment()


### PR DESCRIPTION
come riprodurre:

- creo fattura cliente/fornitore
- registro pagamento
- dal pagamento faccio `REIMPOSTA A BOZZA`

si osserva il seguente messaggio:
`errore "Il record non esiste o è stato eliminato. (Record: account.move(73279,), Utente: 2)"`

questo accade perche la chiamata al metodo `button_draft` esteso dal modulo `l10n_it_reverse_charge` non tiene conto del fatto che si sta eseguendo a partire da `account.payment`, o per meglio dire si aspetta che la move da riportare in bozza non coincida con `payment_id.move_id`

questa PR filtra le move in modo da escludere quelle che coincidono con `payment_id.move_id`

