### PR TITLE
[10.0][fix] l10n_it_dichiarazione_intento: exception creating invoice with partner already associated to a declaration of intent

### DIFF
--- a/l10n_it_dichiarazione_intento/models/account_invoice.py
+++ b/l10n_it_dichiarazione_intento/models/account_invoice.py
@@ -25,8 +25,8 @@ class AccountInvoice(models.Model):
                     )
                 if not all_dichiarazioni:
                     return
-                valid_date = fields.Date.from_string(invoice.date_invoice) \
-                    or fields.Date.context_today(invoice)
+                valid_date = invoice.date_invoice or fields.Date.context_today(invoice)
+                valid_date = fields.Date.from_string(valid_date)
 
                 dichiarazioni_valide = all_dichiarazioni.filtered(
                     lambda d:

--- a/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
+++ b/l10n_it_dichiarazione_intento/tests/test_dichiarazione_intento.py
@@ -26,7 +26,7 @@ class TestDichiarazioneIntento(TransactionCase):
             'telematic_protocol': '08060120341234567-000001',
             })
 
-    def _create_invoice(self, partner, tax=False, date=False):
+    def _create_invoice(self, partner, tax=False, date=False, with_date_invoice=True):
         invoice_date = date if date else self.today_date
         payment_term = self.env.ref('account.account_payment_term_advance')
         invoice_line_data = [(0, 0, {
@@ -39,7 +39,7 @@ class TestDichiarazioneIntento(TransactionCase):
             })]
         return self.env['account.invoice'].sudo().create({
             'partner_id': partner.id,
-            'date_invoice': invoice_date,
+            'date_invoice': with_date_invoice and invoice_date,
             'type': 'out_invoice',
             'name': 'Test Invoice for Dichiarazione',
             'payment_term_id': payment_term.id,
@@ -237,3 +237,6 @@ class TestDichiarazioneIntento(TransactionCase):
     def test_fiscal_position_no_dichiarazione(self):
         self.invoice4._onchange_date_invoice()
         self.assertEqual(self.invoice4.fiscal_position_id.id, self.fiscal_position2.id)
+
+    def test_invoice_creation_without_date_invoice(self):
+        self._create_invoice(self.partner1, with_date_invoice=False)


### PR DESCRIPTION
come riprodurre il problema:

- creare una dichiarazione intento con partner X
- creare una fattura con partner X

risultato attuale:
eccezione: TypeError: can't compare datetime.date to str

questo è causato da un errata assegnazione qui https://github.com/OCA/l10n-italy/blob/2ef523248b485e7e300b2455370f001768d07344/l10n_it_dichiarazione_intento/models/account_invoice.py#L28-L29 dato che `fields.Date.context_today` ritornando una stringa fa saltare l'eccezione in questo punto https://github.com/OCA/l10n-italy/blob/2ef523248b485e7e300b2455370f001768d07344/l10n_it_dichiarazione_intento/models/account_invoice.py#L33-L34


questa PR per fixare il problema descritto.