### PR TITLE
Spostare menu RiBa in modo da renderlo visibile anche nella versione Enterprise

### DIFF
--- a/l10n_it_ricevute_bancarie/models/__init__.py
+++ b/l10n_it_ricevute_bancarie/models/__init__.py
@@ -9,6 +9,7 @@
 from . import account
 from . import account_config
 from . import bank_statement
+from . import ir_ui_menu
 from . import partner
 from . import riba
 from . import riba_config

--- a/l10n_it_ricevute_bancarie/models/ir_ui_menu.py
+++ b/l10n_it_ricevute_bancarie/models/ir_ui_menu.py
@@ -1,0 +1,26 @@
+#  Copyright 2022 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class IrUiMenu(models.Model):
+    _inherit = "ir.ui.menu"
+
+    def write(self, vals):
+        old_parent = self.parent_id
+        new_parent_id = vals.get("parent_id")
+
+        res = super().write(vals)
+
+        if new_parent_id:
+            # Move the RiBa menu if any of
+            # its siblings (menu having same parent before write)
+            # is moved (parent changes).
+            # This happens when account_accountant (enterprise)
+            # is installed or uninstalled.
+            root_riba_menu = self.env.ref("l10n_it_ricevute_bancarie.menu_riba")
+            parent_riba_menu = root_riba_menu.parent_id
+            if old_parent == parent_riba_menu and new_parent_id != old_parent.id:
+                root_riba_menu.parent_id = new_parent_id
+        return res

--- a/l10n_it_ricevute_bancarie/tests/__init__.py
+++ b/l10n_it_ricevute_bancarie/tests/__init__.py
@@ -4,5 +4,6 @@
 #
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from . import test_menu
 from . import test_riba
 from . import riba_common

--- a/l10n_it_ricevute_bancarie/tests/test_menu.py
+++ b/l10n_it_ricevute_bancarie/tests/test_menu.py
@@ -1,0 +1,50 @@
+#  Copyright 2022 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import common
+
+
+class TestRiBaCommon(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.menu_model = self.env["ir.ui.menu"]
+        self.root_riba_menu = self.browse_ref("l10n_it_ricevute_bancarie.menu_riba")
+        self.new_parent = self.browse_ref("base.menu_custom")
+
+    def test_sibling_moved(self):
+        """Check that RiBa menu is moved when a sibling changes parent."""
+        root_riba_parent_menu = self.root_riba_menu.parent_id
+        sibling_menu = self.menu_model.search(
+            [
+                ("parent_id", "=", root_riba_parent_menu.id),
+            ],
+            limit=1,
+        )
+        # pre-condition: menus have same parent
+        self.assertEqual(root_riba_parent_menu, sibling_menu.parent_id)
+
+        # Change sibling's parent
+        sibling_menu.parent_id = self.new_parent
+
+        # Check that RiBa menu's parent has changed according to its sibling
+        self.assertEqual(self.root_riba_menu.parent_id, sibling_menu.parent_id)
+        self.assertNotEqual(self.root_riba_menu.parent_id, root_riba_parent_menu)
+
+    def test_not_sibling_not_moved(self):
+        """Check that RiBa menu is not moved when a menu
+        that is not a sibling changes parent."""
+        root_riba_parent_menu = self.root_riba_menu.parent_id
+        not_sibling_menu = self.menu_model.search(
+            [
+                ("parent_id", "!=", root_riba_parent_menu.id),
+            ],
+            limit=1,
+        )
+        # pre-condition: menus have different parent
+        self.assertNotEqual(root_riba_parent_menu, not_sibling_menu.parent_id)
+
+        # Change not-sibling menu's parent
+        not_sibling_menu.parent_id = self.new_parent
+
+        # Check RiBa menu's parent is not changed
+        self.assertEqual(self.root_riba_menu.parent_id, root_riba_parent_menu)


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/2526 per `14.0`.

Sostituisce https://github.com/OCA/l10n-italy/pull/2139.