### PR TITLE
[REF] l10n_it_withholding_tax: Bump version

### DIFF
--- a/l10n_it_withholding_tax/__manifest__.py
+++ b/l10n_it_withholding_tax/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "ITA - Ritenute d'acconto",
-    "version": "14.0.1.1.2",
+    "version": "14.0.1.1.3",
     "category": "Account",
     "author": "Openforce, Odoo Italia Network, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-italy",


### PR DESCRIPTION
Currently in OCA wheelhouse modules for `l10n_it_withholding_tax` there is this situation:
![image](https://user-images.githubusercontent.com/32064796/151775576-d35cf97e-6db5-47ec-8946-a5e82be6cad8.png)
(from https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-l10n-it-withholding-tax/)

The problem is that the most advanced version is [14.0.1.1.2.dev1](https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-l10n-it-withholding-tax/odoo14_addon_l10n_it_withholding_tax-14.0.1.1.2.dev1-py3-none-any.whl) but it is not the newest: it has been generated in November and does not include the latest merged changes for the module (https://github.com/OCA/l10n-italy/pull/2617).
These changes are instead contained in [14.0.1.1.2](https://wheelhouse.odoo-community.org/oca-simple/odoo14-addon-l10n-it-withholding-tax/odoo14_addon_l10n_it_withholding_tax-14.0.1.1.2-py3-none-any.whl).

As a solution, in this PR I am simply bumping the module version, but before marking as "Ready for merge" it might be worth to investigate the issue further, @sbidoul could you please have a look?