### PR TITLE
[12.O][IMP] add support to dropshipping to l10n_it_delivery_note

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -294,6 +294,8 @@ class StockPicking(models.Model):
 
         if not src_partner_id:
             src_partner_id = partner_id
+            if not dest_partner_id:
+                dest_partner_id = self.mapped('move_lines.partner_id')
 
             if not dest_partner_id:
                 raise ValueError(


### PR DESCRIPTION
Descrizione del problema o della funzionalità: il ddt non può essere emesso se è impostato il dropshipping

Comportamento attuale prima di questa PR: viene segnalato un errore

Comportamento desiderato dopo questa PR: il ddt viene creato correttamente




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing