### PR TITLE
[14.0][FIX] failure in test due to changes in note handling in core

### DIFF
--- a/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
@@ -541,6 +541,7 @@ class TestFatturaPAXMLValidation(FatturaPACommon):
                             "display_type": "line_note",
                             "name": "Notes",
                             "tax_ids": [(6, 0, {self.tax_22.id})],
+                            "currency_id": self.EUR.id,
                         },
                     ),
                 ],


### PR DESCRIPTION
See:
https://github.com/odoo/odoo/pull/83889
https://github.com/odoo/odoo/commit/571e4d7006e30966435f4b5c3998bf943147a447

Provoca questo errore: https://github.com/OCA/l10n-italy/runs/5064729584?check_suite_focus=true#step:8:500

In sostanza, adesso le righe note vengono ignorate (nel core) in un serie di ricalcoli.  Come effetto, gli veniva assegnata una currency.  La cosa non impatta, a meno che non stai creando una riga note con delle tasse specifiche. In tal caso, adesso, va specificata anche la currency.

Il test10 di fatturapa_out fa proprio quello, pertanto ogni PR è bloccata perché i test (di fatturapa_out) falliscono.