### PR TITLE
[12.0][IMP] aggiunta possibilità di impostare il numero DDT direttamente nel wizard in fase di creazione

### DIFF
--- a/l10n_it_delivery_note/wizard/delivery_note_create.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_create.py
@@ -33,6 +33,7 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
     type_id = fields.Many2one('stock.delivery.note.type',
                               default=_default_type,
                               required=True)
+    name = fields.Char()
 
     @api.model
     def check_compliance(self, pickings):
@@ -50,7 +51,7 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
         sale_order_ids = self.mapped('selected_picking_ids.sale_id')
         sale_order_id = sale_order_ids and sale_order_ids[0] or False
 
-        delivery_note = self.env['stock.delivery.note'].create({
+        values = {
             'partner_sender_id': self.partner_sender_id.id,
             'partner_id': self.partner_id.id,
             'partner_shipping_id': self.partner_shipping_id.id,
@@ -79,7 +80,10 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
                 sale_order_id.default_transport_method_id.id or
                 self.partner_id.default_transport_method_id.id or
                 self.type_id.default_transport_method_id.id
-        })
+        }
+        if self.name:
+            values.update({'name': self.name})
+        delivery_note = self.env['stock.delivery.note'].create(values)
 
         self.selected_picking_ids.write({'delivery_note_id': delivery_note.id})
 

--- a/l10n_it_delivery_note/wizard/delivery_note_create.xml
+++ b/l10n_it_delivery_note/wizard/delivery_note_create.xml
@@ -24,6 +24,7 @@
                     <group>
                         <field name="type_id" options="{'no_open': True, 'no_create': True}" />
                         <field name="date" />
+                        <field name="name" groups="l10n_it_delivery_note.can_change_number"/>
                     </group>
                 </group>
                 <notebook attrs="{'invisible': [('error_message', '!=', False)]}">


### PR DESCRIPTION
Descrizione del problema o della funzionalità: per cambiare numero DDT attualmente è necessaria validarlo e poi rimetterlo in bozza, modificarlo e validarlo nuovamente, correggendo in seguito la sequenza

Comportamento attuale prima di questa PR: non è possibile creare direttamente un DDT con un numero inserito manualmente

Comportamento desiderato dopo questa PR: è possibile creare direttamente un DDT con un numero inserito manualmente




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing