### PR TITLE
[IMP] l10n_it_fatturapa_sale: e_invoice group visibility adding a new note or section on sale order lines

### DIFF
--- a/l10n_it_fatturapa_sale/views/sale_order_views.xml
+++ b/l10n_it_fatturapa_sale/views/sale_order_views.xml
@@ -17,6 +17,7 @@
                     name="e_invoice"
                     string="Electronic Invoice"
                     groups="account.group_account_user"
+                    attrs="{'invisible': [('display_type', '!=', False)]}"
                 >
                     <field name="admin_ref" />
                     <field name="related_documents" />


### PR DESCRIPTION
In this way the group is hidden when you add a note or a section from sale order lines