### PR TITLE
[14.0][FIX] l10n_it_delivery_note: force currency in DN line_note

### DIFF
--- a/l10n_it_delivery_note/models/account_invoice.py
+++ b/l10n_it_delivery_note/models/account_invoice.py
@@ -122,6 +122,7 @@ class AccountInvoice(models.Model):
                                     ),
                                     "delivery_note_id": note_line.delivery_note_id.id,
                                     "quantity": 0,
+                                    "currency_id": line.currency_id.id,
                                 },
                             )
                         )


### PR DESCRIPTION
Come riprodurre il bug:
creare a partire dal DN una fattura con `currency_id` diversa da quella di defualt 

la creazione dal DB aggiunge di una riga (line_note)
questa aggiunta porta al ricalcolo del `amount_total` della fatutra ed essendoci più righe fattura con `currency_id` diversa viene usata quella di defualt.

questa PR forza l'utilizzo della `currency_id` della riga fattura generante la DN line_note .