### PR TITLE
[12.0] FIX l10n_it_fatturapa_pec when e-invoice sent file name is in wrong format

### DIFF
--- a/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
+++ b/l10n_it_fatturapa_pec/models/fatturapa_attachment_out.py
@@ -97,6 +97,14 @@ class FatturaPAAttachmentOut(models.Model):
         attachments = [x for x in message_dict['attachments']
                        if regex.match(x.fname)]
 
+        if not attachments:
+            raise UserError(_(
+                "PEC message \"%s\" is coming from SDI but attachments do not "
+                "match SDI response format. Please check."
+            ) % (
+                message_dict['subject']
+            ))
+
         for attachment in attachments:
             response_name = attachment.fname
             message_type = response_name.split('_')[2]


### PR DESCRIPTION

SDI response can't be linked to original file, as RESPONSE_MAIL_REGEX does not match