### PR TITLE
[14.0][FIX] l10n_italy_delivery_note_order_link enabled without use_advanced_delivery_note flag

### DIFF
--- a/l10n_it_delivery_note_order_link/views/purchase_order.xml
+++ b/l10n_it_delivery_note_order_link/views/purchase_order.xml
@@ -21,7 +21,6 @@
                     name="goto_delivery_notes"
                     icon="fa-pencil-square-o"
                     attrs="{'invisible': [('delivery_note_count', '=', 0)]}"
-                    groups="l10n_it_delivery_note.use_advanced_delivery_notes"
                 >
                     <field
                         name="delivery_note_count"

--- a/l10n_it_delivery_note_order_link/views/sale_order.xml
+++ b/l10n_it_delivery_note_order_link/views/sale_order.xml
@@ -18,7 +18,6 @@
                     name="goto_delivery_notes"
                     icon="fa-pencil-square-o"
                     attrs="{'invisible': [('delivery_note_count', '=', 0)]}"
-                    groups="l10n_it_delivery_note.use_advanced_delivery_notes"
                 >
                     <field
                         name="delivery_note_count"


### PR DESCRIPTION
Descrizione del problema o della funzionalità:
la funzionalità è disponibile solo con flag use_advanced_delivery_notes settato.

Comportamento attuale prima di questa PR:
i pulsanti per il link ai ddt nelle viste ordine non sono visibili se non è settato il flag use_advanced_delivery_notes in configurazione magazzino.

Comportamento desiderato dopo questa PR:
i pulsanti per i link ai ddt nelle viste ordine sono visibili anche con flag use_advanced_delivery_notes non settato.
