### PR TITLE
[FIX] l10n_it_intrastat_statement: Allineamento colonne report modelli intra bis

### DIFF
--- a/l10n_it_intrastat_statement/report/intrastat_mod1_bis.xml
+++ b/l10n_it_intrastat_statement/report/intrastat_mod1_bis.xml
@@ -67,6 +67,7 @@
                                             <th></th>
                                             <th></th>
                                             <th></th>
+                                            <th></th>
                                         </tr>
                                         <tr>
                                             <th class="text-center">PROGR.</th>
@@ -74,6 +75,7 @@
                                             <th class="text-center">CODICE IVA</th>
                                             <th class="text-center">AMMONTARE DELLE OPERAZIONI IN EURO</th>
                                             <th class="text-center">NATURA TRANS.</th>
+                                            <th class="text-center">NATURA TRANS. B</th>
                                             <th class="text-center">NOMENCLATURA COMBINATA</th>
                                             <th class="text-center">MASSA NETTA</th>
                                             <th class="text-center">UNITA' SUPPLEMENTARE</th>
@@ -99,6 +101,7 @@
                                             <td>11</td>
                                             <td>12</td>
                                             <td>13</td>
+                                            <td>14</td>
                                         </tr>
                                         <t t-set="total" t-value="0"/>
                                         <tr t-foreach="o.sale_section1_ids" t-as="l">

--- a/l10n_it_intrastat_statement/report/report_intrastat_mod2_bis.xml
+++ b/l10n_it_intrastat_statement/report/report_intrastat_mod2_bis.xml
@@ -69,6 +69,7 @@
                                         <th></th>
                                         <th></th>
                                         <th></th>
+                                        <th></th>
                                     </tr>
                                     <tr>
                                         <!-- <th class="text-center">PROGR.</th> -->
@@ -77,6 +78,7 @@
                                         <th class="text-center">AMMONTARE DELLE OPERAZIONI IN EURO</th>
                                         <th class="text-center">AMMONTARE DELLE OPERAZIONI IN VALUTA</th>
                                         <th class="text-center">NATURA TRANS.</th>
+                                        <th class="text-center">NATURA TRANS. B</th>
                                         <th class="text-center">NOMENCLATURA COMBINATA</th>
                                         <th class="text-center">MASSA NETTA</th>
                                         <th class="text-center">UNITA' SUPPLEMENTARE</th>
@@ -104,7 +106,7 @@
                                         <td>12</td>
                                         <td>13</td>
                                         <td>14</td>
-                                        <!-- <td>15</td> -->
+                                        <td>15</td>
                                     </tr>
                                     <t t-set="total" t-value="0"/>
                                     <tr t-foreach="o.purchase_section1_ids" t-as="l">


### PR DESCRIPTION
Corregge https://github.com/OCA/l10n-italy/issues/2718 per `12.0`.

Essendo una fix, sarebbe bello avere un test ma penso che implementare un test per controllare l'allineamento di righe/colonne di un report sia troppo complicato rispetto all'entità della fix.