### PR TITLE
[14.0][FIX] l10n_it_withholding_tax: allow to record payments by selecting vendor bills from Bills tree view

### DIFF
--- a/l10n_it_withholding_tax/models/withholding_tax.py
+++ b/l10n_it_withholding_tax/models/withholding_tax.py
@@ -437,7 +437,11 @@ class WithholdingTaxMove(models.Model):
             move_lines.append((0, 0, ml_vals))
 
         move_vals["line_ids"] = move_lines
-        move = self.env["account.move"].create(move_vals)
+        move = (
+            self.env["account.move"]
+            .with_context(default_move_type="entry")
+            .create(move_vals)
+        )
         move.action_post()
 
         # Save move in the wt move


### PR DESCRIPTION
Steps to reproduce the behavior:

* create and confirm a bill invoice with withholding tax
* select it from the Bills tree view
* click on Register Payment button
* click on Create Payment button

The following error is raised:
```
Traceback (most recent call last):
  File "/home/tafaru/dev/envs/odoo14/l10n-italy/l10n_it_withholding_tax/tests/test_withholding_tax.py", line 305, in test_create_payments
    payment_register.with_context(default_move_type="in_invoice").action_create_payments()
  File "/home/tafaru/dev/envs/odoo14/odoo/addons/account/wizard/account_payment_register.py", line 668, in action_create_payments
    payments = self._create_payments()
  File "/home/tafaru/dev/envs/odoo14/odoo/addons/account/wizard/account_payment_register.py", line 664, in _create_payments
    self._reconcile_payments(to_process, edit_mode=edit_mode)
  File "/home/tafaru/dev/envs/odoo14/odoo/addons/account/wizard/account_payment_register.py", line 627, in _reconcile_payments
    .filtered_domain([('account_id', '=', account.id), ('reconciled', '=', False)])\
  File "/home/tafaru/dev/envs/odoo14/odoo/addons/account_edi/models/account_move.py", line 427, in reconcile
    res = super().reconcile()
  File "/home/tafaru/dev/envs/odoo14/odoo/addons/account/models/account_move.py", line 4838, in reconcile
    partials = self.env['account.partial.reconcile'].create(sorted_lines._prepare_reconciliation_partials())
  File "<decorator-gen-188>", line 2, in create
  File "/home/tafaru/dev/envs/odoo14/odoo/odoo/api.py", line 329, in _model_create_single
    return self.browse().concat(*(create(self, vals) for vals in arg))
  File "/home/tafaru/dev/envs/odoo14/odoo/odoo/api.py", line 329, in <genexpr>
    return self.browse().concat(*(create(self, vals) for vals in arg))
  File "/home/tafaru/dev/envs/odoo14/l10n-italy/l10n_it_withholding_tax/models/account.py", line 100, in create
    reconcile.generate_wt_moves()
  File "/home/tafaru/dev/envs/odoo14/l10n-italy/l10n_it_withholding_tax/models/account.py", line 162, in generate_wt_moves
    wt_move.generate_account_move()
  File "/home/tafaru/dev/envs/odoo14/l10n-italy/l10n_it_withholding_tax/models/withholding_tax.py", line 440, in generate_account_move
    move = self.env["account.move"].create(move_vals)
  File "<decorator-gen-167>", line 2, in create
  File "/home/tafaru/dev/envs/odoo14/odoo/odoo/api.py", line 347, in _model_create_multi
    return create(self, [arg])
  File "/home/tafaru/dev/envs/odoo14/odoo/addons/account/models/account_move.py", line 1978, in create
    vals_list = self._move_autocomplete_invoice_lines_create(vals_list)
  File "/home/tafaru/dev/envs/odoo14/odoo/addons/account/models/account_move.py", line 1914, in _move_autocomplete_invoice_lines_create
    vals = self_ctx._add_missing_default_values(vals)
  File "/home/tafaru/dev/envs/odoo14/odoo/odoo/models.py", line 1854, in _add_missing_default_values
    defaults = self.default_get(list(missing_defaults))
  File "/home/tafaru/dev/envs/odoo14/odoo/odoo/models.py", line 1309, in default_get
    defaults[name] = field.default(self)
  File "/home/tafaru/dev/envs/odoo14/odoo/addons/account/models/account_move.py", line 124, in _get_default_currency
    journal = self._get_default_journal()
  File "/home/tafaru/dev/envs/odoo14/odoo/addons/account/models/account_move.py", line 108, in _get_default_journal
    journal_type=journal.type,
odoo.exceptions.UserError: Cannot create an invoice of type in_invoice with a journal having general as type.
```