### PR TITLE
[14.0][l10n_it_pos_fiscalcode] Fix fiscal code usage on POS

### DIFF
--- a/l10n_it_pos_fiscalcode/readme/CONTRIBUTORS.rst
+++ b/l10n_it_pos_fiscalcode/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Lorenzo Battistini <https://github.com/eLBati>
+* Roberto Fichera <https://github.com/Robyf70>

--- a/l10n_it_pos_fiscalcode/static/description/index.html
+++ b/l10n_it_pos_fiscalcode/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>ITA - POS - Codice fiscale</title>
 <style type="text/css">
 
@@ -399,6 +399,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#id3">Contributors</a></h2>
 <ul class="simple">
 <li>Lorenzo Battistini &lt;<a class="reference external" href="https://github.com/eLBati">https://github.com/eLBati</a>&gt;</li>
+<li>Roberto Fichera &lt;<a class="reference external" href="https://github.com/Robyf70">https://github.com/Robyf70</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_it_pos_fiscalcode/static/src/js/models.js
+++ b/l10n_it_pos_fiscalcode/static/src/js/models.js
@@ -2,5 +2,5 @@ odoo.define("l10n_it_pos_fiscalcode.fiscalcode_field", function (require) {
     "use strict";
 
     var pos_models = require("point_of_sale.models");
-    pos_models.load_fields("res.partner", "fiscalcode");
+    pos_models.load_fields("res.partner", ["fiscalcode"]);
 });

--- a/l10n_it_pos_fiscalcode/static/src/js/screens.js
+++ b/l10n_it_pos_fiscalcode/static/src/js/screens.js
@@ -1,0 +1,53 @@
+odoo.define("l10n_it_pos_fiscalcode.ClientDetailsEdit", function (require) {
+    "use strict";
+
+    const ClientDetailsEdit = require("point_of_sale.ClientDetailsEdit");
+    const Registries = require("point_of_sale.Registries");
+    const {_t} = require("web.core");
+
+    const PosClientDetailsEdit = (ClientDetailsEdit) =>
+        class extends ClientDetailsEdit {
+            _validFiscalCode(fcins) {
+                const fc = fcins.toUpperCase();
+                const fcReg = /^[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]$/;
+                if (!fcReg.test(fc)) {
+                    return false;
+                }
+
+                const set1 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+                const set2 = "ABCDEFGHIJABCDEFGHIJKLMNOPQRSTUVWXYZ";
+                const seteven = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+                const setodd = "BAKPLCQDREVOSFTGUHMINJWZYX";
+                let s = 0;
+
+                for (let i = 1; i <= 13; i += 2)
+                    s += seteven.indexOf(set2.charAt(set1.indexOf(fc.charAt(i))));
+                for (let i = 0; i <= 14; i += 2)
+                    s += setodd.indexOf(set2.charAt(set1.indexOf(fc.charAt(i))));
+                if (s % 26 !== fc.charCodeAt(15) - "A".charCodeAt(0)) return false;
+                return true;
+            }
+            saveChanges() {
+                const processedChanges = {};
+                for (const [key, value] of Object.entries(this.changes)) {
+                    if (this.intFields.includes(key)) {
+                        processedChanges[key] = parseInt(value) || false;
+                    } else {
+                        processedChanges[key] = value;
+                    }
+                }
+                if (processedChanges.fiscalcode && processedChanges.fiscalcode !== "") {
+                    if (!this._validFiscalCode(processedChanges.fiscalcode)) {
+                        return this.showPopup("ErrorPopup", {
+                            title: _t("The Fiscal code doesn't seem to be correct"),
+                        });
+                    }
+                }
+                super.saveChanges();
+            }
+        };
+
+    Registries.Component.extend(ClientDetailsEdit, PosClientDetailsEdit);
+
+    return ClientDetailsEdit;
+});

--- a/l10n_it_pos_fiscalcode/static/src/xml/pos.xml
+++ b/l10n_it_pos_fiscalcode/static/src/xml/pos.xml
@@ -1,31 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
 
-    <t t-extend="ClientDetails">
-        <t t-jquery=".client-details-right" t-operation="append">
-            <div class='client-detail'>
-                <span class='label'>F.C.</span>
-                <t t-if='partner.fiscalcode'>
-                    <span class='detail fiscalcode'><t
-                            t-esc='partner.fiscalcode'
-                        /></span>
-                </t>
-                <t t-if='!partner.fiscalcode'>
-                    <span class='detail fiscalcode empty'>N/A</span>
-                </t>
-            </div>
-        </t>
-    </t>
-    <t t-extend="ClientDetailsEdit">
-        <t t-jquery=".client-details-right" t-operation="append">
+    <t
+        t-name="ClientDetailsEdit"
+        t-inherit="point_of_sale.ClientDetailsEdit"
+        t-inherit-mode="extension"
+        owl="1"
+    >
+        <xpath expr="//div[hasclass('client-details-right')]" t-operation="inside">
             <div class='client-detail'>
                 <span class='label'>F.C.</span>
                 <input
                     class='detail fiscalcode'
                     name='fiscalcode'
-                    t-att-value='partner.fiscalcode || ""'
+                    t-att-value='props.partner.fiscalcode || ""'
+                    t-on-change="captureChange"
                 />
             </div>
-        </t>
+        </xpath>
     </t>
+
 </templates>

--- a/l10n_it_pos_fiscalcode/views/assets.xml
+++ b/l10n_it_pos_fiscalcode/views/assets.xml
@@ -7,6 +7,10 @@
                 type="text/javascript"
                 src="/l10n_it_pos_fiscalcode/static/src/js/models.js"
             />
+            <script
+                type="text/javascript"
+                src="/l10n_it_pos_fiscalcode/static/src/js/screens.js"
+            />
         </xpath>
 
     </template>


### PR DESCRIPTION
Sulla v14 le estensioni POS devono usare OWL. La PR corrente risolve il problema di visibilità del codice fiscale nella view di edit del contatto sul POS.