### PR TITLE
[FIX] fiscal_epos_print: Impedire stampa scontrini diversi per la stampante fiscale, ma contenenti gli stessi dati

### DIFF
--- a/fiscal_epos_print/__manifest__.py
+++ b/fiscal_epos_print/__manifest__.py
@@ -2,11 +2,12 @@
 # © 2016 Alessio Gerace - Agile Business Group
 # © 2018-2020 Lorenzo Battistini
 # © 2019-2020 Roberto Fichera - Level Prime Srl
+# Copyright 2022 Simone Rubino - TAKOBI
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'ITA - Driver per stampanti fiscali compatibili ePOS-Print XML',
-    'version': '12.0.1.3.6',
+    'version': '12.0.2.0.0',
     'category': 'Point Of Sale',
     'summary': 'ePOS-Print XML Fiscal Printer Driver - Stampanti Epson compatibili: '
                'FP81II, FP90III',

--- a/fiscal_epos_print/migrations/12.0.2.0.0/post-fiscal_epos_disable_reprint.py
+++ b/fiscal_epos_print/migrations/12.0.2.0.0/post-fiscal_epos_disable_reprint.py
@@ -1,0 +1,16 @@
+#  Copyright 2022 Simone Rubino - TAKOBI
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, installed_version):
+    """Disable frontend reprint for existing fiscal printer configurations."""
+    pos_configs = env['pos.config'].search([
+        ('printer_ip', '!=', False),
+        ('iface_reprint_done_order', '=', True),
+    ])
+    pos_configs.update({
+        'iface_reprint_done_order': False,
+    })

--- a/fiscal_epos_print/models/point_of_sale.py
+++ b/fiscal_epos_print/models/point_of_sale.py
@@ -1,4 +1,7 @@
-from odoo import fields, models
+#  Copyright 2022 Simone Rubino - TAKOBI
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models, exceptions
 
 
 class PosConfig(models.Model):
@@ -18,3 +21,17 @@ class PosConfig(models.Model):
     fiscal_printer_serial = fields.Char(string='Fiscal Printer Serial')
 
     fiscal_cashdrawer = fields.Boolean(string='Fiscal Printer Open CashDrawer')
+
+    @api.constrains('printer_ip', 'iface_reprint_done_order')
+    def _check_fiscal_epos_reprint(self):
+        """If an order has been printed by the fiscal printer,
+        the core reprint functionality has to be avoided
+        because it would create another fiscal document.
+        """
+        for config in self:
+            if config.printer_ip and config.iface_reprint_done_order:
+                raise exceptions.ValidationError(
+                    _("Reprint cannot be done for a fiscal printer yet.\n"
+                      "Please disable 'Reprint Orders' "
+                      "or unset 'Printer IP Address'.")
+                )

--- a/fiscal_epos_print/readme/CONTRIBUTORS.rst
+++ b/fiscal_epos_print/readme/CONTRIBUTORS.rst
@@ -3,6 +3,7 @@
 * `TAKOBI <https://takobi.online>`_:
 
   * Lorenzo Battistini
+  * Simone Rubino <sir@takobi.online>
 
 * Alessio Gerace
 * Roberto Fichera

--- a/fiscal_epos_print/readme/ROADMAP.rst
+++ b/fiscal_epos_print/readme/ROADMAP.rst
@@ -1,3 +1,4 @@
 * Resi:
    - Aggiungere controllo "rendibilità"
    - Stampare sullo scontrino un barcode identificativo, in modo da generare il reso facendone la scansione
+* Use fiscal printer's reprint functionality


### PR DESCRIPTION
Corregge https://github.com/OCA/l10n-italy/issues/2751 per `12.0`.