### PR TITLE
[IMP] l10n_it_fatturapa_out: Fixed PyXB version

### DIFF
--- a/setup/l10n_it_fatturapa_out/setup.py
+++ b/setup/l10n_it_fatturapa_out/setup.py
@@ -5,6 +5,7 @@ setuptools.setup(
     odoo_addon={
         'external_dependencies_override': {
             'python': {
+                'pyxb': 'PyXB==1.2.6',
                 'unidecode': 'Unidecode<1.3.0',
             },
         },


### PR DESCRIPTION
Fix error:
ERROR: Double requirement given: PyXB==1.2.6 (from -r test-requirements.txt (line 17)) (already in pyxb (from -r test-requirements.txt (line 16)), name='PyXB')
during setuptools-odoo external dependencies retrieval