### PR TITLE
[12.0][FIX] shipping address

### DIFF
--- a/l10n_it_delivery_note/README.rst
+++ b/l10n_it_delivery_note/README.rst
@@ -187,6 +187,7 @@ Contributors
 * Andrea Piovesana <andrea.m.piovesana@gmail.com>
 * Giovanni Serra <giovanni@gslab.it>
 * Alex Comba <alex.comba@agilebg.com>
+* Sergio Corato <https://github.com/sergiocorato>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -252,7 +252,7 @@ class StockPicking(models.Model):
         return self.env['stock.delivery.note'].create({
             'partner_sender_id': partners[0].id,
             'partner_id': partners[1].id,
-            'partner_shipping_id': partners[1].id
+            'partner_shipping_id': partners[2].id
         })
 
     def delivery_note_update_transport_datetime(self):
@@ -305,7 +305,17 @@ class StockPicking(models.Model):
         elif not dest_partner_id:
             dest_partner_id = partner_id
 
-        return (src_partner_id, dest_partner_id)
+        if self.mapped('sale_id'):
+            partner_ids = self.mapped('sale_id.partner_invoice_id')
+            if len(partner_ids) > 1:
+                raise ValueError(
+                    "Multiple partner found for sale order linked to pickings!"
+                )
+            partner_id = partner_ids[0]
+        else:
+            partner_id = dest_partner_id.commercial_partner_id
+
+        return (src_partner_id, partner_id, dest_partner_id)
 
     def goto(self, **kwargs):
         self.ensure_one()

--- a/l10n_it_delivery_note/readme/CONTRIBUTORS.rst
+++ b/l10n_it_delivery_note/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
 * Andrea Piovesana <andrea.m.piovesana@gmail.com>
 * Giovanni Serra <giovanni@gslab.it>
 * Alex Comba <alex.comba@agilebg.com>
+* Sergio Corato <https://github.com/sergiocorato>

--- a/l10n_it_delivery_note/static/description/index.html
+++ b/l10n_it_delivery_note/static/description/index.html
@@ -514,6 +514,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Andrea Piovesana &lt;<a class="reference external" href="mailto:andrea.m.piovesana&#64;gmail.com">andrea.m.piovesana&#64;gmail.com</a>&gt;</li>
 <li>Giovanni Serra &lt;<a class="reference external" href="mailto:giovanni&#64;gslab.it">giovanni&#64;gslab.it</a>&gt;</li>
 <li>Alex Comba &lt;<a class="reference external" href="mailto:alex.comba&#64;agilebg.com">alex.comba&#64;agilebg.com</a>&gt;</li>
+<li>Sergio Corato &lt;<a class="reference external" href="https://github.com/sergiocorato">https://github.com/sergiocorato</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note.py
@@ -6,6 +6,15 @@ from .delivery_note_common import StockDeliveryNoteCommon
 
 class StockDeliveryNote(StockDeliveryNoteCommon):
 
+    def setUp(self):
+        super().setUp()
+        self.partner_shipping = self.create_partner(
+            'Shipping Address')
+        self.partner_shipping.write({
+            'parent_id': self.recipient.id,
+            'type': 'delivery',
+        })
+
     # ⇒ "Ordine singolo: consegna parziale"
     def test_partial_delivering_single_so(self):
         #
@@ -48,3 +57,43 @@ class StockDeliveryNote(StockDeliveryNoteCommon):
         picking_backorder.move_lines[0].quantity_done = 1
         picking_backorder.button_validate()
         self.assertTrue(picking_backorder.delivery_note_id)
+
+    # ⇒ "Ordine singolo: consegna a indirizzo diverso"
+    def test_partner_shipping_delivering_single_so(self):
+        use_adv_notes_group_id = self.env.ref(
+            "l10n_it_delivery_note.use_advanced_delivery_notes").id
+        self.env.user.write({'groups_id': [(3, use_adv_notes_group_id)]})
+
+        StockPicking = self.env["stock.picking"]
+        StockBackorderConfirmationWizard = self.env['stock.backorder.confirmation']
+        sales_order = self.create_sales_order(
+            [
+                self.large_desk_line,  # 1
+                self.desk_combination_line,  # 1
+            ],
+        )
+        self.assertEqual(len(sales_order.order_line), 2)
+        sales_order.action_confirm()
+        self.assertEqual(len(sales_order.picking_ids), 1)
+        picking = sales_order.picking_ids
+        self.assertEqual(len(picking.move_lines), 2)
+
+        # deliver only the first product
+        picking.move_lines[0].quantity_done = 1
+
+        backorder_wiz_id = picking.button_validate()['res_id']
+        backorder_wiz = StockBackorderConfirmationWizard.browse(backorder_wiz_id)
+        backorder_wiz.process()
+        self.assertTrue(picking.delivery_note_id)
+        self.assertEqual(picking.delivery_note_id.partner_id, self.recipient)
+        self.assertEqual(picking.delivery_note_id.partner_shipping_id,
+                         self.partner_shipping)
+        picking_backorder = StockPicking.search([("backorder_id", "=", picking.id)])
+        self.assertEqual(len(picking_backorder.move_lines), 1)
+        picking_backorder.move_lines[0].quantity_done = 1
+        picking_backorder.button_validate()
+        self.assertTrue(picking_backorder.delivery_note_id)
+        self.assertEqual(picking_backorder.delivery_note_id.partner_id,
+                         self.recipient)
+        self.assertEqual(picking_backorder.delivery_note_id.partner_shipping_id,
+                         self.partner_shipping)


### PR DESCRIPTION
Descrizione del problema o della funzionalità: in caso l'out sia stato generato da un SO con consegna ad un indirizzo diverso, il destinatario del DDT non deve essere l'indirizzo di destinazione

Comportamento attuale prima di questa PR: gli indirizzi di destinazione e il destinatario coincidono

Comportamento desiderato dopo questa PR: gli indirizzi sono come da SO




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing