### PR TITLE
[12.0] FIX l10n_it_fatturapa_in, Setting Italian timezone by default, otherwise e_invoice_received_date could be set the day before of the actual date

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1015,11 +1015,21 @@ class WizardImportFatturapa(models.TransientModel):
             for rel_doc in causLst:
                 comment += rel_doc + '\n'
 
+        if (
+            not fatturapa_attachment.env.context.get("tz")
+            and not fatturapa_attachment.env.user.tz
+        ):
+            # Setting Italian timezone, otherwise e_invoice_received_date
+            # could be set the day before of the actual date.
+            fatturapa_attachment = fatturapa_attachment.with_context(tz="Europe/Rome")
         if fatturapa_attachment.e_invoice_received_date:
-            e_invoice_received_date = fatturapa_attachment.\
-                e_invoice_received_date.date()
+            e_invoice_received_date = fields.Datetime.context_timestamp(
+                fatturapa_attachment, fatturapa_attachment.e_invoice_received_date
+            ).date()
         else:
-            e_invoice_received_date = fatturapa_attachment.create_date.date()
+            e_invoice_received_date = fields.Datetime.context_timestamp(
+                fatturapa_attachment, fatturapa_attachment.create_date
+            ).date()
         e_invoice_date = FatturaBody.DatiGenerali.DatiGeneraliDocumento.Data.date()
 
         invoice_data = {


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/2778

Example:
receiving date = 2022-04-01 00:16
saved in DB, UTC format, as 2022-03-31 22:16:03
converted to date = 2022-03-31

In this case, the invoice would be registered in the wrong period (month)