### PR TITLE
[FIX] l10n_it_reverse_charge: wrong string from tuple when move_vals[inv] contains only one ID

### DIFF
--- a/l10n_it_reverse_charge/migrations/13.0.1.0.0/pre-migration.py
+++ b/l10n_it_reverse_charge/migrations/13.0.1.0.0/pre-migration.py
@@ -162,14 +162,14 @@ def migrate(env, version):
             )
             payment_id = cr.fetchone()[0]
 
-            line_ids = tuple(move_vals[inv])
+            line_ids = ",".join([str(line_id) for line_id in move_vals[inv]])
             openupgrade.logged_query(
                 cr,
                 """
                 update account_move_line
                 set move_id = {move_id},
                     payment_id = {payment_id}
-                where id in {line_ids};
+                where id in ({line_ids});
                 """.format(
                     move_id=move_id, payment_id=payment_id, line_ids=line_ids
                 ),


### PR DESCRIPTION
la conversione da `list` a `tuple` per un solo elemento porta ad avere una virgola inaspettata [qui](https://github.com/OCA/l10n-italy/blob/dcd4b527a5d5cc7ca07c497ee407e0a8d0c7b829/l10n_it_reverse_charge/migrations/13.0.1.0.0/pre-migration.py#L172)

in pratica:
```
str(tuple([1]))
'(1,)'
```


