### PR TITLE
[IMP] l10n_it_fatturapa_in: Gestire errori di parsing XML

### DIFF
--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -87,38 +87,31 @@ class FatturaPAAttachmentIn(models.Model):
     @api.depends('ir_attachment_id.datas')
     def _compute_xml_data(self):
         for att in self:
-            if not att.registered:
-                wiz_obj = self.env['wizard.import.fatturapa'] \
-                    .with_context(from_attachment=att)
-                fatt = wiz_obj.get_invoice_obj(att)
-                cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore
-                partner_id = wiz_obj.getCedPrest(cedentePrestatore)
-                att.xml_supplier_id = partner_id
-                att.invoices_number = len(fatt.FatturaElettronicaBody)
-                att.invoices_total = 0
-                att.is_self_invoice = False
-                invoices_date = []
-                for invoice_body in fatt.FatturaElettronicaBody:
-                    att.invoices_total += float(
-                        invoice_body.DatiGenerali.DatiGeneraliDocumento.
-                        ImportoTotaleDocumento or 0
-                    )
-                    invoice_date = format_date(
-                        att.with_context(
-                            lang=att.env.user.lang).env, fields.Date.from_string(
-                                invoice_body.DatiGenerali.DatiGeneraliDocumento.Data))
-                    if invoice_date not in invoices_date:
-                        invoices_date.append(invoice_date)
-                    if invoice_body.DatiGenerali.DatiGeneraliDocumento.TipoDocumento \
-                            in SELF_INVOICE_TYPES:
-                        att.is_self_invoice = True
-                att.invoices_date = ' '.join(invoices_date)
-            else:
-                att.xml_supplier_id = False
-                att.invoices_number = 0
-                att.invoices_total = 0
-                att.is_self_invoice = False
-                att.invoices_date = False
+            wiz_obj = self.env['wizard.import.fatturapa'] \
+                .with_context(from_attachment=att)
+            fatt = wiz_obj.get_invoice_obj(att)
+            cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore
+            partner_id = wiz_obj.getCedPrest(cedentePrestatore)
+            att.xml_supplier_id = partner_id
+            att.invoices_number = len(fatt.FatturaElettronicaBody)
+            att.invoices_total = 0
+            att.is_self_invoice = False
+            invoices_date = []
+            for invoice_body in fatt.FatturaElettronicaBody:
+                att.invoices_total += float(
+                    invoice_body.DatiGenerali.DatiGeneraliDocumento.
+                    ImportoTotaleDocumento or 0
+                )
+                invoice_date = format_date(
+                    att.with_context(
+                        lang=att.env.user.lang).env, fields.Date.from_string(
+                            invoice_body.DatiGenerali.DatiGeneraliDocumento.Data))
+                if invoice_date not in invoices_date:
+                    invoices_date.append(invoice_date)
+                if invoice_body.DatiGenerali.DatiGeneraliDocumento.TipoDocumento \
+                        in SELF_INVOICE_TYPES:
+                    att.is_self_invoice = True
+            att.invoices_date = ' '.join(invoices_date)
 
     @api.multi
     @api.depends('in_invoice_ids')

--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -1,7 +1,10 @@
 
 import base64
+import logging
 from odoo import fields, models, api, _
 from odoo.tools import format_date
+
+_logger = logging.getLogger(__name__)
 
 SELF_INVOICE_TYPES = ("TD16", "TD17", "TD18", "TD19", "TD20", "TD21")
 
@@ -87,31 +90,42 @@ class FatturaPAAttachmentIn(models.Model):
     @api.depends('ir_attachment_id.datas')
     def _compute_xml_data(self):
         for att in self:
+            att.xml_supplier_id = False
+            att.invoices_number = 0
+            att.invoices_total = 0
+            att.invoices_date = False
+            att.is_self_invoice = False
             wiz_obj = self.env['wizard.import.fatturapa'] \
                 .with_context(from_attachment=att)
-            fatt = wiz_obj.get_invoice_obj(att)
-            cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore
-            partner_id = wiz_obj.getCedPrest(cedentePrestatore)
-            att.xml_supplier_id = partner_id
-            att.invoices_number = len(fatt.FatturaElettronicaBody)
-            att.invoices_total = 0
-            att.is_self_invoice = False
-            invoices_date = []
-            for invoice_body in fatt.FatturaElettronicaBody:
-                att.invoices_total += float(
-                    invoice_body.DatiGenerali.DatiGeneraliDocumento.
-                    ImportoTotaleDocumento or 0
+            try:
+                fatt = wiz_obj.get_invoice_obj(att)
+                cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore
+                partner_id = wiz_obj.getCedPrest(cedentePrestatore)
+                att.xml_supplier_id = partner_id
+                att.invoices_number = len(fatt.FatturaElettronicaBody)
+                att.invoices_total = 0
+                att.is_self_invoice = False
+                invoices_date = []
+                for invoice_body in fatt.FatturaElettronicaBody:
+                    att.invoices_total += float(
+                        invoice_body.DatiGenerali.DatiGeneraliDocumento.
+                        ImportoTotaleDocumento or 0
+                    )
+                    invoice_date = format_date(
+                        att.with_context(
+                            lang=att.env.user.lang).env, fields.Date.from_string(
+                                invoice_body.DatiGenerali.DatiGeneraliDocumento.Data))
+                    if invoice_date not in invoices_date:
+                        invoices_date.append(invoice_date)
+                    if invoice_body.DatiGenerali.DatiGeneraliDocumento.TipoDocumento \
+                            in SELF_INVOICE_TYPES:
+                        att.is_self_invoice = True
+                att.invoices_date = ' '.join(invoices_date)
+            except Exception as e:
+                _logger.error(
+                    _("Impossible to execute _compute_xml_data for %s: %s")
+                    % (att.display_name, e)
                 )
-                invoice_date = format_date(
-                    att.with_context(
-                        lang=att.env.user.lang).env, fields.Date.from_string(
-                            invoice_body.DatiGenerali.DatiGeneraliDocumento.Data))
-                if invoice_date not in invoices_date:
-                    invoices_date.append(invoice_date)
-                if invoice_body.DatiGenerali.DatiGeneraliDocumento.TipoDocumento \
-                        in SELF_INVOICE_TYPES:
-                    att.is_self_invoice = True
-            att.invoices_date = ' '.join(invoices_date)
 
     @api.multi
     @api.depends('in_invoice_ids')

--- a/l10n_it_fatturapa_in/tests/data/ZGEXQROO37831_anonimizzata.xml
+++ b/l10n_it_fatturapa_in/tests/data/ZGEXQROO37831_anonimizzata.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FatturaElettronica xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12" xmlns="http://ivaservizi.agenziaentrate.gov.it/ docs/xsd/fatture/v1.2">
+    <FatturaElettronicaHeader xmlns="">
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>12345670017</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>0006299335</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>0000000</CodiceDestinatario>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>12345670017</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>Pippolo S.p.A.</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Tal dei tali</Indirizzo>
+                <CAP>20123</CAP>
+                <Comune>Milano</Comune>
+                <Provincia>MI</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>11531111117</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>11531111117</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>Mkt s.r.l.</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via talaltri</Indirizzo>
+                <CAP>20145</CAP>
+                <Comune>Milano</Comune>
+                <Provincia>MI</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+        <TerzoIntermediarioOSoggettoEmittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>03331111116</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>03331111116</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>RossiDati Srl</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+        </TerzoIntermediarioOSoggettoEmittente>
+        <SoggettoEmittente>TZ</SoggettoEmittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody xmlns="">
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2022-03-10</Data>
+                <Numero>17606</Numero>
+                <ImportoTotaleDocumento>109.80</ImportoTotaleDocumento>
+                <Causale>DA PAGARE</Causale>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>Op. 3367462 - Canone annuo F@X IN Periodo: 2022-03-05 / 2023-03-05
+Numero: 0114121701</Descrizione>
+                <Quantita>1.00000000</Quantita>
+                <PrezzoUnitario>30.00000000</PrezzoUnitario>
+                <PrezzoTotale>30.00000000</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>2</NumeroLinea>
+                <Descrizione>Op. 3368479 - Canone annuo F@X IN Periodo: 2022-03-01 / 2023-03-01
+Numero: 03311570073</Descrizione>
+                <Quantita>1.00000000</Quantita>
+                <PrezzoUnitario>30.00000000</PrezzoUnitario>
+                <PrezzoTotale>30.00000000</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>3</NumeroLinea>
+                <Descrizione>Op. 3369124 - Canone annuo F@X IN Periodo: 2022-02-27 / 2023-02-27
+Numero: 0293650722</Descrizione>
+                <Quantita>1.00000000</Quantita>
+                <PrezzoUnitario>30.00000000</PrezzoUnitario>
+                <PrezzoTotale>30.00000000</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>90.00</ImponibileImporto>
+                <Imposta>19.80</Imposta>
+                <EsigibilitaIVA>I</EsigibilitaIVA>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2022-03-10</DataScadenzaPagamento>
+                <ImportoPagamento>109.80</ImportoPagamento>
+                <IstitutoFinanziario>Banca Sella Via Vincenzo Monti, 33 Milano</IstitutoFinanziario>
+                <IBAN>IT90B0326801602111111111111</IBAN>
+                <ABI>03268</ABI>
+                <CAB>01602</CAB>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/fatturapa_common.py
+++ b/l10n_it_fatturapa_in/tests/fatturapa_common.py
@@ -107,18 +107,30 @@ class FatturapaCommon(SingleTransactionCase):
             'bic': 'BCITITMM',
         })
 
+    def create_attachment(self, name, file_name,
+                          datas_fname=None, module_name=None):
+        if module_name is None:
+            module_name = 'l10n_it_fatturapa_in'
+        if datas_fname is None:
+            datas_fname = file_name
+        attach = self.attach_model.create(
+            {
+                'name': name,
+                'datas': self.getFile(file_name, module_name=module_name)[1],
+                'datas_fname': datas_fname
+            })
+        return attach
+
     def run_wizard(self, name, file_name, datas_fname=None,
                    mode='import', wiz_values=None, module_name=None):
         if module_name is None:
             module_name = 'l10n_it_fatturapa_in'
         if datas_fname is None:
             datas_fname = file_name
-        attach_id = self.attach_model.create(
-            {
-                'name': name,
-                'datas': self.getFile(file_name, module_name=module_name)[1],
-                'datas_fname': datas_fname
-            }).id
+        attach = self.create_attachment(name, file_name,
+                                        datas_fname=datas_fname,
+                                        module_name=module_name)
+        attach_id = attach.id
         if mode == 'import':
             wizard = self.wizard_model.with_context(
                 active_ids=[attach_id], active_model='fatturapa.attachment.in'

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -1,7 +1,26 @@
+from psycopg2 import IntegrityError
+
 from datetime import date
 
+from odoo.tools import mute_logger
 from .fatturapa_common import FatturapaCommon
 from odoo.exceptions import UserError
+
+
+class TestDuplicatedAttachment(FatturapaCommon):
+
+    def test_duplicated_attachment(self):
+        """Attachment name must be unique"""
+        # This test breaks the current transaction
+        # and every test executed after this in the
+        # same transaction would fail.
+        # Note that all the tests in TestFatturaPAXMLValidation
+        # are executed in the same transaction.
+        self.run_wizard('test_duplicated', 'IT02780790107_11005.xml')
+        with self.assertRaises(IntegrityError) as ie:
+            with mute_logger('odoo.sql_db'):
+                self.run_wizard('test_duplicated', 'IT02780790107_11005.xml')
+        self.assertEqual(ie.exception.pgcode, '23505')
 
 
 class TestFatturaPAXMLValidation(FatturapaCommon):
@@ -156,11 +175,11 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         # File not exist Exception
         self.assertRaises(
             Exception, self.run_wizard, 'test6_Exception', '')
-        # fake Signed file is passed , generate orm_exception
-        self.assertRaises(
-            UserError, self.run_wizard, 'test6_orm_exception',
-            'IT05979361218_fake.xml.p7m'
-        )
+        # fake Signed file is passed , generate parsing error
+        with mute_logger('odoo.addons.l10n_it_fatturapa_in.models.attachment'):
+            attachment = self.create_attachment(
+                'test6_orm_exception', 'IT05979361218_fake.xml.p7m')
+        self.assertIn('Invalid xml', attachment.e_invoice_parsing_error)
 
     def test_07_xml_import(self):
         # 2 lines with quantity != 1 and discounts
@@ -754,6 +773,20 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         invoice_ids = res.get("domain")[0][2]
         invoice = self.invoice_model.browse(invoice_ids)
         self.assertTrue(invoice.fatturapa_attachment_in_id.is_self_invoice)
+
+    def test_52_xml_import(self):
+        """
+        Check that an XML with syntax error is created,
+        but it shows a parsing error.
+        """
+        with mute_logger('odoo.addons.l10n_it_fatturapa_in.models.attachment'):
+            attachment = self.create_attachment(
+                "test52",
+                "ZGEXQROO37831_anonimizzata.xml",
+            )
+        self.assertIn('http://ivaservizi.agenziaentrate.gov.it/ '
+                      'has no category elementBinding',
+                      attachment.e_invoice_parsing_error)
 
     def test_01_xml_link(self):
         """

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -1,26 +1,7 @@
-from psycopg2 import IntegrityError
-
 from datetime import date
 
-from odoo.tools import mute_logger
 from .fatturapa_common import FatturapaCommon
 from odoo.exceptions import UserError
-
-
-class TestDuplicatedAttachment(FatturapaCommon):
-
-    def test_duplicated_attachment(self):
-        """Attachment name must be unique"""
-        # This test breaks the current transaction
-        # and every test executed after this in the
-        # same transaction would fail.
-        # Note that all the tests in TestFatturaPAXMLValidation
-        # are executed in the same transaction.
-        self.run_wizard('test_duplicated', 'IT02780790107_11005.xml')
-        with self.assertRaises(IntegrityError) as ie:
-            with mute_logger('odoo.sql_db'):
-                self.run_wizard('test_duplicated', 'IT02780790107_11005.xml')
-        self.assertEqual(ie.exception.pgcode, '23505')
 
 
 class TestFatturaPAXMLValidation(FatturapaCommon):

--- a/l10n_it_fatturapa_in/views/account_view.xml
+++ b/l10n_it_fatturapa_in/views/account_view.xml
@@ -9,6 +9,9 @@
                 <div class="alert alert-info" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('e_invoice_validation_error','=',False)]}">
                      <bold><field name="e_invoice_validation_message" nolabel="1"/></bold>
                 </div>
+                <div class="alert alert-warning" role="alert" style="margin-bottom:0px;" attrs="{'invisible': [('e_invoice_parsing_error','=',False)]}">
+                     <bold><field name="e_invoice_parsing_error" nolabel="1"/></bold>
+                </div>
                 <field name="e_invoice_validation_error" invisible="1"/>
                 <div>
                     <group>

--- a/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.py
+++ b/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.py
@@ -2,12 +2,6 @@
 from odoo import models, api, fields
 from odoo.tools.translate import _
 from odoo.exceptions import UserError
-from odoo.addons.l10n_it_fatturapa.bindings import fatturapa
-
-
-def get_invoice_obj(fatturapa_attachment):
-    xml_string = fatturapa_attachment.get_xml_string()
-    return fatturapa.CreateFromDocument(xml_string)
 
 
 class WizardLinkToInvoiceLine(models.TransientModel):
@@ -42,7 +36,12 @@ class WizardLinkToInvoiceLine(models.TransientModel):
             .new({
                 'e_invoice_detail_level': '2',
             })
-        fatt = get_invoice_obj(fatturapa_attachment)
+        fatt = fatturapa_attachment.get_invoice_obj()
+        if not fatt:
+            raise UserError(
+                _("Cannot link an attachment that could not be parsed.\n"
+                  "Please fix the parsing error first, then try again."))
+
         FatturaBody = fatt.FatturaElettronicaBody[self.e_invoice_nbr]
         cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore
 
@@ -88,7 +87,12 @@ class WizardLinkToInvoice(models.TransientModel):
 
     @api.model
     def _get_default_lines_vals(self, attachment):
-        fatt = get_invoice_obj(attachment)
+        fatt = attachment.get_invoice_obj()
+        if not fatt:
+            raise UserError(
+                _("Cannot link an attachment that could not be parsed.\n"
+                  "Please fix the parsing error first, then try again."))
+
         invoice_model = self.env['account.invoice']
         line_vals = list()
         descr_template = _("Bill number {bill_nbr} of {bill_date}.\n"

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -6,7 +6,6 @@ from odoo.tools import float_is_zero
 from odoo.tools.translate import _
 from odoo.exceptions import UserError
 
-from odoo.addons.l10n_it_fatturapa.bindings import fatturapa
 from odoo.addons.base_iban.models.res_partner_bank import pretty_iban
 
 _logger = logging.getLogger(__name__)
@@ -1556,10 +1555,6 @@ class WizardImportFatturapa(models.TransientModel):
                     % (invoice.amount_untaxed, amount_untaxed)
                 )
 
-    def get_invoice_obj(self, fatturapa_attachment):
-        xml_string = fatturapa_attachment.get_xml_string()
-        return fatturapa.CreateFromDocument(xml_string)
-
     def _set_decimal_precision(self, precision_name, field_name):
         precision = self.env["decimal.precision"].search([
             ("name", "=", precision_name)], limit=1)
@@ -1616,7 +1611,13 @@ class WizardImportFatturapa(models.TransientModel):
             if fatturapa_attachment.in_invoice_ids:
                 raise UserError(
                     _("File is linked to bills yet."))
-            fatt = self.get_invoice_obj(fatturapa_attachment)
+
+            fatt = fatturapa_attachment.get_invoice_obj()
+            if not fatt:
+                raise UserError(
+                    _("Cannot import an attachment that could not be parsed.\n"
+                      "Please fix the parsing error first, then try again."))
+
             cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore
             # 1.2
             partner_id = self.getCedPrest(cedentePrestatore)

--- a/l10n_it_fatturapa_pec/models/mail_thread.py
+++ b/l10n_it_fatturapa_pec/models/mail_thread.py
@@ -192,6 +192,7 @@ class MailThread(models.AbstractModel):
         if e_invoice_user_id:
             fatturapa_attachment_in = fatturapa_attachment_in.sudo(
                 e_invoice_user_id)
+        fatturapa_attachment = fatturapa_attachment_in.browse()
         if attachment.mimetype == 'application/zip':
             with zipfile.ZipFile(io.BytesIO(decoded)) as zf:
                 for file_name in zf.namelist():
@@ -205,7 +206,7 @@ class MailThread(models.AbstractModel):
                             _logger.info("In invoice %s already processed"
                                          % fatturapa_atts.mapped('name'))
                         else:
-                            fatturapa_attachment_in.create({
+                            fatturapa_attachment = fatturapa_attachment_in.create({
                                 'name': file_name,
                                 'datas_fname': file_name,
                                 'datas': base64.encodestring(inv_file.read()),
@@ -220,8 +221,13 @@ class MailThread(models.AbstractModel):
                     "Invoice xml already processed in %s"
                     % fatturapa_atts.mapped('name'))
             else:
-                fatturapa_attachment_in.create({
+                fatturapa_attachment = fatturapa_attachment_in.create({
                     'ir_attachment_id': attachment.id,
                     'company_id': company_id,
                     'e_invoice_received_date': received_date,
                 })
+        # Notify if there was an error
+        # during automatic import of invoices from PEC.
+        parsing_error = fatturapa_attachment.e_invoice_parsing_error
+        if parsing_error:
+            raise Exception(parsing_error)

--- a/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
+++ b/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
@@ -128,6 +128,7 @@ class TestEInvoiceResponse(EInvoiceCommon):
             instance.retr.return_value = ('', [incoming_mail], '')
 
             with mute_logger(
+                    'odoo.addons.l10n_it_fatturapa_in.models.attachment',
                     'odoo.addons.l10n_it_fatturapa_pec.models.fetchmail'):
                 self.PEC_server.fetch_mail()
 


### PR DESCRIPTION
Sostituisce https://github.com/OCA/l10n-italy/pull/2748.

~~Non riesco ad aggiungere un test perché l'errore si presenta solo al ricalcolo di fatture già presenti a DB.
La creazione di una nuova fattura con questo tipo di errori viene bloccata perché viene sollevato errore in https://github.com/OCA/l10n-italy/blob/cfbc2bcf3f3e06311b06bea8c2ea1356c4f6ba75/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py#L1609.~~

Test aggiunto separando la creazione della fattura elettronica dall'importazione