### PR TITLE
[FIX][l10n_it_ricevute_bancarie] fix compute of tax

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account.py
+++ b/l10n_it_ricevute_bancarie/models/account.py
@@ -179,7 +179,7 @@ class AccountMove(models.Model):
                     }
                     # ---- Update Line Value with tax if is set on product
                     if invoice.company_id.due_cost_service_id.taxes_id:
-                        tax = invoice.company_id.due_cost_service_id.taxes_id
+                        tax = invoice.fiscal_position_id.map_tax(service_prod.taxes_id)
                         line_vals.update({"tax_ids": [(4, tax.id)]})
                     invoice.write({"invoice_line_ids": [(0, 0, line_vals)]})
                     # ---- recompute invoice taxes


### PR DESCRIPTION
When on an invoice add a line for collecting expenses or bank receipts, set the tax value of that line as defined on the invoice fiscal position tax mapping

Issue #2793 