### PR TITLE
[FIX] - fix tax_exigibility

### DIFF
--- a/l10n_it_account/models/account_tax.py
+++ b/l10n_it_account/models/account_tax.py
@@ -205,7 +205,7 @@ class AccountTax(models.Model):
                     continue
 
                 tax_balance += child_balance
-                if child.account_id:
+                if child.tax_exigibility == "on_invoice":
                     deductible += child_balance
                 else:
                     undeductible += child_balance


### PR DESCRIPTION
Ci siamo accorti che se provo a generare il report della Liquidazione IVA con periodo fiscale avente un'imposta che ha delle imposte figlie con a loro volta il campo vat_statement_account_id impostato, viene fuori un errore a causa della mancanza di account_id all'interno del modello account.tax.
Con il passaggio alla versione 13.0 il campo account_id di account.tax è stato rimosso. Seguendo le linee guida dettate dalla migrazione alla versione 13.0 di OCA/OpenUpgrade abbiamo risolto il problema facendo il controllo, precedente fatto su account_id, sul campo tax_exigibility.  

Documentazione seguita:
https://github.com/OCA/OpenUpgrade/blob/420ac0f79fa0cc216500d73df60741b4618a304b/addons/account/migrations/13.0.1.1/openupgrade_analysis_work.txt#L455-L461
