### PR TITLE
[12.0][FIX] l10n_it_fatturapa_out Python 3.8 PyXB Date error

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -85,7 +85,7 @@ class FatturapaBDS(domutils.BindingDOMSupport):
             # instead of letting PyXB edit it
             return str(value)
         
-        if IGNORE_PYXB_DATE and isinstance(value, pyxb_date) and False:
+        if IGNORE_PYXB_DATE and isinstance(value, pyxb_date):
             # PyXB with python 3.8 breaks datetime conversion,
             #  giving an TypeError on pyxb/binding/datatypes.py line 686
             return value.strftime(DT)


### PR DESCRIPTION
Quando si prova ad esportare una fattura elettronica utilizzando Python3.8 si riceve il seguente errore:
TypeError: function takes 3 arguments plus optional tzinfo (8 given) 
Alla riga python3.8/site-packages/pyxb/binding/datatypes.py", line 686, in __new__  raise TypeError('function takes %d arguments plus optional tzinfo (%d given)' % (len(cls._ValidFields), len(args)))

L'errore è dovuto ad una errata conversione di un campo Date in Datetime del modulo PyXB.
Sebbene il modulo sia in dismissione, con questo Fix è comunque possibile esportare le fatture elettroniche usando Python3.8.