### PR TITLE
[14.0][REF] l10n_it_ricevute_bancarie: update domain c/o issue

### DIFF
--- a/l10n_it_ricevute_bancarie/views/account_view.xml
+++ b/l10n_it_ricevute_bancarie/views/account_view.xml
@@ -131,7 +131,7 @@
         <field name="search_view_id" ref="riba_filter" />
         <field
             name="domain"
-        >['&amp;','|',('riba','=','True'),('unsolved_invoice_ids','!=',False),('account_id.internal_type','=','receivable')]</field>
+        >['&amp;','&amp;',('riba','=','True'),'|',('unsolved_invoice_ids','!=',False),('account_id.internal_type','=','receivable'),('move_id.move_type','!=','out_refund')]</field>
         <field
             name="context"
         >{'search_default_da_emettere':1, 'search_default_to_reconcile':1}</field>


### PR DESCRIPTION
Descrizione del problema o della funzionalità:

rimovere dalle riba da emettere i movimenti contabili che non hanno il flag riba impostato e tolto note di credito

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing