### PR TITLE
[12.0][IMP] l10n_it_split_payment refactoring

### DIFF
--- a/l10n_it_split_payment/models/account.py
+++ b/l10n_it_split_payment/models/account.py
@@ -59,7 +59,6 @@ class AccountInvoice(models.Model):
                 raise UserError(_("Can't handle supplier invoices with split payment"))
 
             sign = 1 if self.type == 'out_invoice' else -1
-
             amount_sp = sign * self.amount_sp
             total -= amount_sp
 

--- a/l10n_it_split_payment/models/account.py
+++ b/l10n_it_split_payment/models/account.py
@@ -51,7 +51,8 @@ class AccountInvoice(models.Model):
     @api.multi
     def compute_invoice_totals(self, company_currency, invoice_move_lines):
         total, total_currency, iml = \
-            super(AccountInvoice, self).compute_invoice_totals(company_currency, invoice_move_lines)
+            super(AccountInvoice, self).compute_invoice_totals(
+                company_currency, invoice_move_lines)
 
         if self.split_payment:
             if self.type in ['in_invoice', 'in_refund']:
@@ -64,7 +65,8 @@ class AccountInvoice(models.Model):
 
             diff_currency = self.currency_id != company_currency
             amount_sp_currency = company_currency._convert(
-                amount_sp, self.currency_id, self.company_id, self._get_currency_rate_date() or fields.Date.today())
+                amount_sp, self.currency_id, self.company_id, 
+                self._get_currency_rate_date() or fields.Date.today())
 
             iml.append({
                 'type': 'dest',
@@ -77,4 +79,4 @@ class AccountInvoice(models.Model):
                 'invoice_id': self.id
             })
 
-        return total, total_currency, iml    
+        return total, total_currency, iml

--- a/l10n_it_split_payment/models/account.py
+++ b/l10n_it_split_payment/models/account.py
@@ -41,25 +41,6 @@ class AccountInvoice(models.Model):
             self.amount_total -= self.amount_tax
             self.amount_tax = 0
 
-    def _build_debit_line(self):
-        if not self.company_id.sp_account_id:
-            raise UserError(
-                _("Please set 'Split Payment Write-off Account' field in"
-                  " accounting configuration"))
-        vals = {
-            'name': _('Split Payment Write Off'),
-            'partner_id': self.partner_id.id,
-            'account_id': self.company_id.sp_account_id.id,
-            'journal_id': self.journal_id.id,
-            'date': self.date_invoice,
-            'debit': self.amount_sp,
-            'credit': 0,
-            }
-        if self.type == 'out_refund':
-            vals['debit'] = 0
-            vals['credit'] = self.amount_sp
-        return vals
-
     @api.multi
     def get_receivable_line_ids(self):
         # return the move line ids with the same account as the invoice self
@@ -68,53 +49,32 @@ class AccountInvoice(models.Model):
             lambda r: r.account_id.id == self.account_id.id).ids
 
     @api.multi
-    def _compute_split_payments(self):
-        for invoice in self:
-            receivable_line_ids = invoice.get_receivable_line_ids()
-            move_line_pool = self.env['account.move.line']
-            for receivable_line in move_line_pool.browse(receivable_line_ids):
-                inv_total = invoice.amount_sp + invoice.amount_total
-                if invoice.type == 'out_invoice':
-                    if inv_total:
-                        receivable_line_amount = (
-                            invoice.amount_total * receivable_line.debit
-                            ) / inv_total
-                    else:
-                        receivable_line_amount = 0
-                    receivable_line.with_context(
-                        check_move_validity=False
-                    ).write(
-                        {'debit': receivable_line_amount})
-                elif invoice.type == 'out_refund':
-                    if inv_total:
-                        receivable_line_amount = (
-                            invoice.amount_total * receivable_line.credit
-                            ) / inv_total
-                    else:
-                        receivable_line_amount = 0
-                    receivable_line.with_context(
-                        check_move_validity=False
-                    ).write(
-                        {'credit': receivable_line_amount})
+    def compute_invoice_totals(self, company_currency, invoice_move_lines):
+        total, total_currency, iml = \
+            super(AccountInvoice, self).compute_invoice_totals(company_currency, invoice_move_lines)
 
-    @api.multi
-    def action_move_create(self):
-        res = super(AccountInvoice, self).action_move_create()
-        for invoice in self:
-            if invoice.split_payment:
-                if invoice.type in ['in_invoice', 'in_refund']:
-                    raise UserError(
-                        _("Can't handle supplier invoices with split payment"))
-                if invoice.move_id.state == 'posted':
-                    posted = True
-                    invoice.move_id.state = 'draft'
-                self._compute_split_payments()
-                line_model = self.env['account.move.line']
-                write_off_line_vals = invoice._build_debit_line()
-                write_off_line_vals['move_id'] = invoice.move_id.id
-                line_model.with_context(
-                    check_move_validity=False
-                ).create(write_off_line_vals)
-                if posted:
-                    invoice.move_id.state = 'posted'
-        return res
+        if self.split_payment:
+            if self.type in ['in_invoice', 'in_refund']:
+                raise UserError(_("Can't handle supplier invoices with split payment"))
+
+            sign = 1 if self.type == 'out_invoice' else -1
+
+            amount_sp = sign * self.amount_sp
+            total -= amount_sp
+
+            diff_currency = self.currency_id != company_currency
+            amount_sp_currency = company_currency._convert(
+                amount_sp, self.currency_id, self.company_id, self._get_currency_rate_date() or fields.Date.today())
+
+            iml.append({
+                'type': 'dest',
+                'name': _('Split Payment Write Off'),
+                'price': amount_sp,
+                'account_id': self.company_id.sp_account_id.id,
+                'date_maturity': self.date_invoice,
+                'amount_currency': diff_currency and amount_sp_currency,
+                'currency_id': diff_currency and self.currency_id.id,
+                'invoice_id': self.id
+            })
+
+        return total, total_currency, iml    


### PR DESCRIPTION
Propongo una revisione della sezione del modulo split payment. 
Invece di agganciarci all'azione di creazione della registrazione contabile della fattura e modificarla a posteriori, sarebbe preferibile modificare il metodo compute_invoice_totals dove si va a decurtare dal totale fattura l'importo in split payment (ove presente) e nelle righe della registrazione contabile che si andrà a creare aggiungere la registrazione di contropartita per quadrare la registrazione.

In questo modo si evita di "sbloccare" e successivamente "bloccare" la registrazione contabile della fattura modificando semplicemente il campo state (invece di usare i metodi post e button_cancel) e si lascia al sistema di calcolare le scadenze di pagamento a partire dal reale netto a pagare (invece in precedenza il sistema calcola le scadenze in base al totale fattura e poi decurta in modo proporzionale l'importo dell'iva in split payment).

Lascio il meotodo get_receivable_line_ids in quanto utilizzato nei moduli di fatturapa (anche se a questo punto nel modulo l10n_it_split_payment è inutile).