### PR TITLE
[12.0][FIX] l10n_it_fatturapa_in: sconto applicato due volte

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -664,6 +664,9 @@ class WizardImportFatturapa(models.TransientModel):
             self.e_invoice_detail_level == '2'
         ):
             invoice = self.env['account.invoice'].browse(invoice_id)
+            if invoice.amount_total == float(DatiGeneraliDocumento.ImportoTotaleDocumento):
+                return True
+            
             for DiscRise in DatiGeneraliDocumento.ScontoMaggiorazione:
                 if DiscRise.Percentuale:
                     amount = (


### PR DESCRIPTION
**Comportamento attuale:** importando una fattura fornitore con livello di dettaglio massimo, sconto globale definito nella sezione DatiGeneraliDocumento e lo sconto nelle righe applicato in modo esplicito (quindi ogni riga ha la sezione sconto/maggiorazione), odoo importa correttamente tutte le righe con lo sconto ma aggiunge anche una riga di sconto globale. Il totale della fattura importata quindi non combacia con il totale fattura (in quanto lo sconto viene considerato due volte).

Come specificato nel documento attuale dei controlli dello SDI (https://www.fatturapa.gov.it/export/documenti/Elenco-Controlli-versione-1.7.pdf) la sezione ScontoMaggiorazione presente nella sezione DatiGeneraliDocumento è solo riepilogativa e non impatta nel calcolo del totale imponibile fattura. Pertanto sarebbe preferibile evitare l'inserimento della riga aggiuntiva se le righe fattura già definiscono in modo corretto tutti gli imponibili.

La mia modifica evita la creazione della riga aggiuntiva quando le righe fatture già compilano gli imponibili correttamente, ma a mio avviso andrebbe completamente rimosso il metodo o rivisto in toto, magari utilizzandolo quando si importa la fattura con un dettaglio minimo.