### PR TITLE
[12.0][FIX] l10n_fatturapa_out_wt: fix indentation to enable tests

### DIFF
--- a/l10n_it_fatturapa_out_wt/tests/test_fatturapa_wt.py
+++ b/l10n_it_fatturapa_out_wt/tests/test_fatturapa_wt.py
@@ -245,7 +245,7 @@ class TestInvoiceWT(FatturaPACommon):
             module_name='l10n_it_fatturapa_out_wt')
 
 
-def test_e_invoice_wt_inps_0(self):
+    def test_e_invoice_wt_inps_0(self):
         self.set_sequences(17, '2019-01-07')
         invoice = self.invoice_model.create({
             'date_invoice': '2019-01-07',
@@ -285,7 +285,7 @@ def test_e_invoice_wt_inps_0(self):
             module_name='l10n_it_fatturapa_out_wt')
 
 
-def test_e_invoice_wt_inps_1(self):
+    def test_e_invoice_wt_inps_1(self):
         """
         Fill DatiCassaPrevidenziale with INPS data
         """
@@ -330,7 +330,7 @@ def test_e_invoice_wt_inps_1(self):
             module_name='l10n_it_fatturapa_out_wt')
 
 
-def test_e_invoice_wt_inps_2(self):
+    def test_e_invoice_wt_inps_2(self):
         """
         Fill DatiCassaPrevidenziale with INPS data,
         when DatiRiepilogo already has 0 VAT


### PR DESCRIPTION
Alcuni test non venivano eseguiti per errori di indentazione. 

NOTA: al primo giro non sto correggendo i test (modificando gli XML). L'ho già fatto in #2848 ma qui preferisco che la correzione sia suggerita esplicitamente da qualcun altro, per vedere se ho interpretato correttamente.

- [ ] 12.0 #2866 
- [ ] 14.0 #2848 