### PR TITLE
[12.0] FIX l10n_it_fatturapa_out_rc - AttributeError: 'DatiPagamentoType' object has no attribute 'ImportoPagamento'

### DIFF
--- a/l10n_it_fatturapa_out_rc/wizard/wizard_export_e_invoice.py
+++ b/l10n_it_fatturapa_out_rc/wizard/wizard_export_e_invoice.py
@@ -192,8 +192,11 @@ class WizardExportFatturapa(models.TransientModel):
     def setDatiPagamento(self, invoice, body):
         super(WizardExportFatturapa, self).setDatiPagamento(invoice, body)
         for DatiPagamento in body.DatiPagamento:
-            if invoice.type in ['out_refund', 'in_refund'] \
-                    and invoice.fiscal_document_type_id.code not in ['TD04', 'TD08']\
-                    and DatiPagamento.ImportoPagamento:
-                DatiPagamento.ImportoPagamento = - DatiPagamento.ImportoPagamento
+            for dettaglio in DatiPagamento.DettaglioPagamento:
+                if (
+                    invoice.type in ['out_refund', 'in_refund']
+                    and invoice.fiscal_document_type_id.code not in ['TD04', 'TD08']
+                    and dettaglio.ImportoPagamento
+                ):
+                    dettaglio.ImportoPagamento = - dettaglio.ImportoPagamento
         return True


### PR DESCRIPTION
l10n_it_fatturapa_out_rc/wizard/wizard_export_e_invoice.py", line 197, in setDatiPagamento
    and DatiPagamento.ImportoPagamento:
AttributeError: 'DatiPagamentoType' object has no attribute 'ImportoPagamento'