### PR TITLE
[FIX][l10n_it_fatturapa_in] change from log.erro fo to log.info to av…

### DIFF
--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -124,7 +124,7 @@ class FatturaPAAttachmentIn(models.Model):
                     att_name=self.display_name,
                     error_msg=e,
                 )
-            _logger.error(error_msg)
+            _logger.warning(error_msg)
             self.e_invoice_parsing_error = error_msg
         else:
             self.e_invoice_parsing_error = False

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -176,9 +176,8 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.assertRaises(
             Exception, self.run_wizard, 'test6_Exception', '')
         # fake Signed file is passed , generate parsing error
-        with mute_logger('odoo.addons.l10n_it_fatturapa_in.models.attachment'):
-            attachment = self.create_attachment(
-                'test6_orm_exception', 'IT05979361218_fake.xml.p7m')
+        attachment = self.create_attachment(
+            'test6_orm_exception', 'IT05979361218_fake.xml.p7m')
         self.assertIn('Invalid xml', attachment.e_invoice_parsing_error)
 
     def test_07_xml_import(self):
@@ -779,11 +778,10 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         Check that an XML with syntax error is created,
         but it shows a parsing error.
         """
-        with mute_logger('odoo.addons.l10n_it_fatturapa_in.models.attachment'):
-            attachment = self.create_attachment(
-                "test52",
-                "ZGEXQROO37831_anonimizzata.xml",
-            )
+        attachment = self.create_attachment(
+            "test52",
+            "ZGEXQROO37831_anonimizzata.xml",
+        )
         self.assertIn('http://ivaservizi.agenziaentrate.gov.it/ '
                       'has no category elementBinding',
                       attachment.e_invoice_parsing_error)

--- a/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
+++ b/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
@@ -128,7 +128,6 @@ class TestEInvoiceResponse(EInvoiceCommon):
             instance.retr.return_value = ('', [incoming_mail], '')
 
             with mute_logger(
-                    'odoo.addons.l10n_it_fatturapa_in.models.attachment',
                     'odoo.addons.l10n_it_fatturapa_pec.models.fetchmail'):
                 self.PEC_server.fetch_mail()
 


### PR DESCRIPTION
Attualmente avendo nel log .error odoo.sh blocca l'aggiornamento interpretandolo come un errore bloccante, quando invece è solo un errore di parsing.

Inoltre una volta buildato in staging e e se si prova a fare un update all passa tranquillamente, è solo perchè scatta il ricalolo del nuovo metodo messo qui  https://github.com/OCA/l10n-italy/pull/2788/files#diff-48ce31dcb7cd2814e3c9553a3c77c1b5b20fd8dbfbaca55333591842ec7435c7R117-R120 dalla PR https://github.com/OCA/l10n-italy/pull/2788