### PR TITLE
[14.0][FIX] l10n_it_reverse_charge: porting mistake

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -97,7 +97,7 @@ class AccountMove(models.Model):
             "date": self.date,
             "invoice_origin": self.sequence_number,
             "rc_purchase_invoice_id": self.id,
-            "name": rc_type.self_invoice_text,
+            "ref": rc_type.self_invoice_text,
             "currency_id": currency.id,
             "fiscal_position_id": False,
             "invoice_payment_term_id": False,


### PR DESCRIPTION
'name' is now what 'number' used to be. We should use 'ref'.

Fixes: #2846 