### PR TITLE
[14.0] [IMP] l10n_it_account_stamp: add receipt info in readme

### DIFF
--- a/l10n_it_account_stamp/README.rst
+++ b/l10n_it_account_stamp/README.rst
@@ -27,11 +27,11 @@ ITA - Imposta di bollo
 
 **Italiano**
 
-Questo modulo aggiunge il supporto all'imposta di bollo italiana nelle fatture.
+Questo modulo aggiunge il supporto all'imposta di bollo italiana nelle fatture e nelle ricevute.
 
 **English**
 
-This module adds Italian Tax Stamp support in invoices.
+This module adds Italian Tax Stamp support in invoices and receipts.
 
 **Table of contents**
 
@@ -47,20 +47,20 @@ Per modificare le impostazioni sul prodotto "Imposta di bollo 2 euro" è necessa
 
 1. Impostazioni -> Utenti e aziende -> Utenti
 2. Selezionare l'utente per il quale si vuole abilitare la funzionalità
-3. Abilitare: Mostrare funzionalità contabili complete
+3. Abilitare l'opzione "Mostrare funzionalità contabili complete"
 
 
 Modalità automatica:
 
 - andare sul prodotto "Imposta di bollo 2 euro" e configurare "Imposte marca da bollo" (Imposte in esenzione).
 
-- per ciascuna fattura, l'applicabilità dell'imposta di bollo verrà calcolata in modo automatico in base alla somma degli imponibili relativi alle imposte selezionate.
+- per ciascuna fattura o ricevuta, l'applicabilità dell'imposta di bollo verrà calcolata in modo automatico in base alla somma degli imponibili relativi alle imposte selezionate.
 
 Modalità manuale:
 
 - andare sul prodotto "Imposta di bollo 2 euro" e deselezionare la casella "Calcolo automatico".
 
-- per ciascuna fattura, abilitare manualmente la casella di selezione "Imposta di bollo". L'applicabilità dell'imposta di bollo verrà calcolata in base alla somma degli imponibili relativi alle imposte selezionate.
+- per ciascuna fattura o ricevuta, abilitare manualmente la casella di selezione "Imposta di bollo". L'applicabilità dell'imposta di bollo verrà calcolata in base alla somma degli imponibili relativi alle imposte selezionate.
 
 Impostare i conti di ricavo/costo nella scheda "Contabilità", generalmente ricavo="Debiti per bolli" e costo="Valori bollati".
 
@@ -70,19 +70,19 @@ In order to change Tax Stamp 2 euro product settings, enable full accounting fea
 
 1. Settings -> Users & Companies -> Users
 2. Click on the user you want to enable feature
-3. Enable: Show Full Accounting Features
+3. Enable 'Show Full Accounting Features' option
 
 Automatic mode:
 
 - Go to 'Tax Stamp 2 euro' product and configure 'Stamp taxes' (exemption taxes).
 
-- For each invoice, the base amount for each selected tax will be added up and used to determine the application of the account stamp.
+- For each invoice or receipt, the base amount for each selected tax will be added up and used to determine the application of the account stamp.
 
 Manual mode:
 
 - Go to 'Tax Stamp 2 euro' product and deselect 'Auto-compute' checkbox.
 
-- For each invoice, manually enable 'Tax Stamp' checkbox.
+- For each invoice or receipt, manually enable 'Tax Stamp' checkbox.
 
 Also set income/expense accounts, typically income = 'Debiti per bolli' and expense = 'Valori bollati'.
 
@@ -91,13 +91,13 @@ Usage
 
 **Italiano**
 
-Se nella fattura è previsto l'addebito dell'imposta di bollo al cliente, fare clic sul pulsante "Aggiungi riga bollo" per aggiungere una riga relativa all'imposta di bollo.
+Se nella fattura o ricevuta è previsto l'addebito dell'imposta di bollo al cliente, fare clic sul pulsante "Aggiungi riga bollo" per aggiungere una riga relativa all'imposta di bollo.
 
 In caso contrario, l'imposta di bollo verrà comunque considerata ma non verrà addebitata al cliente.
 
 **English**
 
-In invoice form, when applicable, click 'Add tax stamp line' button to add tax stamp as invoice line, thus charging customer.
+In invoice or receipt form, when applicable, click 'Add tax stamp line' button to add tax stamp as invoice line, thus charging customer.
 
 Otherwise, tax stamp will be anyway accounted, without charging customer.
 

--- a/l10n_it_account_stamp/readme/CONFIGURE.rst
+++ b/l10n_it_account_stamp/readme/CONFIGURE.rst
@@ -4,20 +4,20 @@ Per modificare le impostazioni sul prodotto "Imposta di bollo 2 euro" è necessa
 
 1. Impostazioni -> Utenti e aziende -> Utenti
 2. Selezionare l'utente per il quale si vuole abilitare la funzionalità
-3. Abilitare: Mostrare funzionalità contabili complete
+3. Abilitare l'opzione "Mostrare funzionalità contabili complete"
 
 
 Modalità automatica:
 
 - andare sul prodotto "Imposta di bollo 2 euro" e configurare "Imposte marca da bollo" (Imposte in esenzione).
 
-- per ciascuna fattura, l'applicabilità dell'imposta di bollo verrà calcolata in modo automatico in base alla somma degli imponibili relativi alle imposte selezionate.
+- per ciascuna fattura o ricevuta, l'applicabilità dell'imposta di bollo verrà calcolata in modo automatico in base alla somma degli imponibili relativi alle imposte selezionate.
 
 Modalità manuale:
 
 - andare sul prodotto "Imposta di bollo 2 euro" e deselezionare la casella "Calcolo automatico".
 
-- per ciascuna fattura, abilitare manualmente la casella di selezione "Imposta di bollo". L'applicabilità dell'imposta di bollo verrà calcolata in base alla somma degli imponibili relativi alle imposte selezionate.
+- per ciascuna fattura o ricevuta, abilitare manualmente la casella di selezione "Imposta di bollo". L'applicabilità dell'imposta di bollo verrà calcolata in base alla somma degli imponibili relativi alle imposte selezionate.
 
 Impostare i conti di ricavo/costo nella scheda "Contabilità", generalmente ricavo="Debiti per bolli" e costo="Valori bollati".
 
@@ -27,18 +27,18 @@ In order to change Tax Stamp 2 euro product settings, enable full accounting fea
 
 1. Settings -> Users & Companies -> Users
 2. Click on the user you want to enable feature
-3. Enable: Show Full Accounting Features
+3. Enable 'Show Full Accounting Features' option
 
 Automatic mode:
 
 - Go to 'Tax Stamp 2 euro' product and configure 'Stamp taxes' (exemption taxes).
 
-- For each invoice, the base amount for each selected tax will be added up and used to determine the application of the account stamp.
+- For each invoice or receipt, the base amount for each selected tax will be added up and used to determine the application of the account stamp.
 
 Manual mode:
 
 - Go to 'Tax Stamp 2 euro' product and deselect 'Auto-compute' checkbox.
 
-- For each invoice, manually enable 'Tax Stamp' checkbox.
+- For each invoice or receipt, manually enable 'Tax Stamp' checkbox.
 
 Also set income/expense accounts, typically income = 'Debiti per bolli' and expense = 'Valori bollati'.

--- a/l10n_it_account_stamp/readme/DESCRIPTION.rst
+++ b/l10n_it_account_stamp/readme/DESCRIPTION.rst
@@ -1,7 +1,7 @@
 **Italiano**
 
-Questo modulo aggiunge il supporto all'imposta di bollo italiana nelle fatture.
+Questo modulo aggiunge il supporto all'imposta di bollo italiana nelle fatture e nelle ricevute.
 
 **English**
 
-This module adds Italian Tax Stamp support in invoices.
+This module adds Italian Tax Stamp support in invoices and receipts.

--- a/l10n_it_account_stamp/readme/USAGE.rst
+++ b/l10n_it_account_stamp/readme/USAGE.rst
@@ -1,11 +1,11 @@
 **Italiano**
 
-Se nella fattura è previsto l'addebito dell'imposta di bollo al cliente, fare clic sul pulsante "Aggiungi riga bollo" per aggiungere una riga relativa all'imposta di bollo.
+Se nella fattura o ricevuta è previsto l'addebito dell'imposta di bollo al cliente, fare clic sul pulsante "Aggiungi riga bollo" per aggiungere una riga relativa all'imposta di bollo.
 
 In caso contrario, l'imposta di bollo verrà comunque considerata ma non verrà addebitata al cliente.
 
 **English**
 
-In invoice form, when applicable, click 'Add tax stamp line' button to add tax stamp as invoice line, thus charging customer.
+In invoice or receipt form, when applicable, click 'Add tax stamp line' button to add tax stamp as invoice line, thus charging customer.
 
 Otherwise, tax stamp will be anyway accounted, without charging customer.

--- a/l10n_it_account_stamp/static/description/index.html
+++ b/l10n_it_account_stamp/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>ITA - Imposta di bollo</title>
 <style type="text/css">
 
@@ -369,9 +369,9 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/l10n-italy/tree/14.0/l10n_it_account_stamp"><img alt="OCA/l10n-italy" src="https://img.shields.io/badge/github-OCA%2Fl10n--italy-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/l10n-italy-14-0/l10n-italy-14-0-l10n_it_account_stamp"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/122/14.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
 <p><strong>Italiano</strong></p>
-<p>Questo modulo aggiunge il supporto all’imposta di bollo italiana nelle fatture.</p>
+<p>Questo modulo aggiunge il supporto all’imposta di bollo italiana nelle fatture e nelle ricevute.</p>
 <p><strong>English</strong></p>
-<p>This module adds Italian Tax Stamp support in invoices.</p>
+<p>This module adds Italian Tax Stamp support in invoices and receipts.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -393,17 +393,17 @@ ul.auto-toc {
 <ol class="arabic simple">
 <li>Impostazioni -&gt; Utenti e aziende -&gt; Utenti</li>
 <li>Selezionare l’utente per il quale si vuole abilitare la funzionalità</li>
-<li>Abilitare: Mostrare funzionalità contabili complete</li>
+<li>Abilitare l’opzione “Mostrare funzionalità contabili complete”</li>
 </ol>
 <p>Modalità automatica:</p>
 <ul class="simple">
 <li>andare sul prodotto “Imposta di bollo 2 euro” e configurare “Imposte marca da bollo” (Imposte in esenzione).</li>
-<li>per ciascuna fattura, l’applicabilità dell’imposta di bollo verrà calcolata in modo automatico in base alla somma degli imponibili relativi alle imposte selezionate.</li>
+<li>per ciascuna fattura o ricevuta, l’applicabilità dell’imposta di bollo verrà calcolata in modo automatico in base alla somma degli imponibili relativi alle imposte selezionate.</li>
 </ul>
 <p>Modalità manuale:</p>
 <ul class="simple">
 <li>andare sul prodotto “Imposta di bollo 2 euro” e deselezionare la casella “Calcolo automatico”.</li>
-<li>per ciascuna fattura, abilitare manualmente la casella di selezione “Imposta di bollo”. L’applicabilità dell’imposta di bollo verrà calcolata in base alla somma degli imponibili relativi alle imposte selezionate.</li>
+<li>per ciascuna fattura o ricevuta, abilitare manualmente la casella di selezione “Imposta di bollo”. L’applicabilità dell’imposta di bollo verrà calcolata in base alla somma degli imponibili relativi alle imposte selezionate.</li>
 </ul>
 <p>Impostare i conti di ricavo/costo nella scheda “Contabilità”, generalmente ricavo=”Debiti per bolli” e costo=”Valori bollati”.</p>
 <p><strong>English</strong></p>
@@ -411,27 +411,27 @@ ul.auto-toc {
 <ol class="arabic simple">
 <li>Settings -&gt; Users &amp; Companies -&gt; Users</li>
 <li>Click on the user you want to enable feature</li>
-<li>Enable: Show Full Accounting Features</li>
+<li>Enable ‘Show Full Accounting Features’ option</li>
 </ol>
 <p>Automatic mode:</p>
 <ul class="simple">
 <li>Go to ‘Tax Stamp 2 euro’ product and configure ‘Stamp taxes’ (exemption taxes).</li>
-<li>For each invoice, the base amount for each selected tax will be added up and used to determine the application of the account stamp.</li>
+<li>For each invoice or receipt, the base amount for each selected tax will be added up and used to determine the application of the account stamp.</li>
 </ul>
 <p>Manual mode:</p>
 <ul class="simple">
 <li>Go to ‘Tax Stamp 2 euro’ product and deselect ‘Auto-compute’ checkbox.</li>
-<li>For each invoice, manually enable ‘Tax Stamp’ checkbox.</li>
+<li>For each invoice or receipt, manually enable ‘Tax Stamp’ checkbox.</li>
 </ul>
 <p>Also set income/expense accounts, typically income = ‘Debiti per bolli’ and expense = ‘Valori bollati’.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id2">Usage</a></h1>
 <p><strong>Italiano</strong></p>
-<p>Se nella fattura è previsto l’addebito dell’imposta di bollo al cliente, fare clic sul pulsante “Aggiungi riga bollo” per aggiungere una riga relativa all’imposta di bollo.</p>
+<p>Se nella fattura o ricevuta è previsto l’addebito dell’imposta di bollo al cliente, fare clic sul pulsante “Aggiungi riga bollo” per aggiungere una riga relativa all’imposta di bollo.</p>
 <p>In caso contrario, l’imposta di bollo verrà comunque considerata ma non verrà addebitata al cliente.</p>
 <p><strong>English</strong></p>
-<p>In invoice form, when applicable, click ‘Add tax stamp line’ button to add tax stamp as invoice line, thus charging customer.</p>
+<p>In invoice or receipt form, when applicable, click ‘Add tax stamp line’ button to add tax stamp as invoice line, thus charging customer.</p>
 <p>Otherwise, tax stamp will be anyway accounted, without charging customer.</p>
 </div>
 <div class="section" id="bug-tracker">


### PR DESCRIPTION
Come effetto collaterale della gestione nativa delle ricevute in Odoo 14.0, l'imposta di bollo è supportata in modo automatico anche per tali documenti. La funzionalità però non è indicata nel README.
Questa PR aggiorna il readme per coprire questo caso d'uso piuttosto comune.
