### PR TITLE
[12.0][FIX] l10n_it_fatturapa_sale security

### DIFF
--- a/l10n_it_fatturapa_sale/__manifest__.py
+++ b/l10n_it_fatturapa_sale/__manifest__.py
@@ -18,6 +18,7 @@
     ],
     "excludes": ["sale_order_action_invoice_create_hook"],
     "data": [
+        "security/ir.model.access.csv",
         "views/related_document_type_views.xml",
         "views/sale_order_line_views.xml",
         "views/sale_order_views.xml",

--- a/l10n_it_fatturapa_sale/security/ir.model.access.csv
+++ b/l10n_it_fatturapa_sale/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_fatturapa_related_document_type_sales,access_fatturapa_related_document_type_sales,model_fatturapa_related_document_type,sales_team.group_sale_salesman,1,0,0,0


### PR DESCRIPTION
Descrizione del problema o della funzionalità: il permesso ai manager vendite sul campo related non è presente nelle regole di accesso

Comportamento attuale prima di questa PR: l'utente vendite che non ha permessi sulla fatturazione riceve un errore in accesso all'ordine di vendita

Comportamento desiderato dopo questa PR: l'utente riesce ad accedere




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing