### PR TITLE
14.0 l10n it delivery note fix mark as todo 0.1

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -191,7 +191,7 @@ class StockPicking(models.Model):
             self.delivery_method_id = False
     
     def _compute_show_mark_as_todo(self):
-        #ToDo: decorator needed? Seems to work without it
+        #ToDo: E' necessario rimettere il decoratore api.depends? Funziona lo stesso
         res = super(StockPicking, self)._compute_show_mark_as_todo()
         for picking in self:
             if self.env.context.get('from_delivery_note', False):

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -191,12 +191,12 @@ class StockPicking(models.Model):
             self.delivery_method_id = False
     
     def _compute_show_mark_as_todo(self):
-    #ToDo: decorator needed? Seems to work without it
-    res = super(StockPicking, self)._compute_show_mark_as_todo()
-    for picking in self:
-        if self.env.context.get('from_delivery_note', False):
-            picking.show_mark_as_todo = True
-    return res
+        #ToDo: decorator needed? Seems to work without it
+        res = super(StockPicking, self)._compute_show_mark_as_todo()
+        for picking in self:
+            if self.env.context.get('from_delivery_note', False):
+                picking.show_mark_as_todo = True
+        return res
 
     def _add_delivery_cost_to_so(self):
         self.ensure_one()

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -191,10 +191,10 @@ class StockPicking(models.Model):
             self.delivery_method_id = False
     
     def _compute_show_mark_as_todo(self):
-        #ToDo: E' necessario rimettere il decoratore api.depends? Funziona lo stesso
+        # ToDo: E' necessario rimettere il decoratore api.depends? Funziona lo stesso
         res = super(StockPicking, self)._compute_show_mark_as_todo()
         for picking in self:
-            if self.env.context.get('from_delivery_note', False):
+            if self.env.context.get("from_delivery_note", False):
                 picking.show_mark_as_todo = True
         return res
 

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -189,6 +189,14 @@ class StockPicking(models.Model):
 
         else:
             self.delivery_method_id = False
+    
+    def _compute_show_mark_as_todo(self):
+    #ToDo: decorator needed? Seems to work without it
+    res = super(StockPicking, self)._compute_show_mark_as_todo()
+    for picking in self:
+        if self.env.context.get('from_delivery_note', False):
+            picking.show_mark_as_todo = True
+    return res
 
     def _add_delivery_cost_to_so(self):
         self.ensure_one()

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -189,7 +189,7 @@ class StockPicking(models.Model):
 
         else:
             self.delivery_method_id = False
-    
+
     def _compute_show_mark_as_todo(self):
         # ToDo: E' necessario rimettere il decoratore api.depends? Funziona lo stesso
         res = super(StockPicking, self)._compute_show_mark_as_todo()


### PR DESCRIPTION
Implementa https://github.com/OCA/l10n-italy/issues/2912

Override del metodo _compute_show_mark_as_todo per settare a True il campo show_mark_as_todo qualora il form di creazione picking venga aperto dal DDT (modello stock.delivery.note). Serve per fare apparire il pulsante Mark as To Do in questa modalità e rendere possibile il salvataggio dei nuovi picking creati da DDT.