### PR TITLE
[12.0] FIX l10n_it_sdi_channel - ValueError: Wrong value for ir.attachment.type: 'out_invoice'

### DIFF
--- a/l10n_it_sdi_channel/models/account_invoice.py
+++ b/l10n_it_sdi_channel/models/account_invoice.py
@@ -22,6 +22,9 @@ class AccountInvoice (models.Model):
             .with_context(
                 active_model=self._name,
                 active_ids=self.ids,
+                # Otherwise default_type could be set for invoice ("out_invoice")
+                # and conflict with ir.attachment.type
+                default_type="binary",
             ) \
             .create([{}])
         export_result = export_wizard.exportFatturaPA()


### PR DESCRIPTION

When "Validate, export and send to SdI"