### PR TITLE
Fattura elettronica: Specifiche tecniche versione 1.7.1

### DIFF
--- a/l10n_it_fatturapa/bindings/_ds.diff
+++ b/l10n_it_fatturapa/bindings/_ds.diff
@@ -31,7 +31,7 @@ index ea52682e..d6e5a7ca 100644
 +    _logger.debug(err)
 +
  # Unique identifier for bindings created at the same time
- _GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:7b7e2a22-51cf-11ec-b0cc-ec5c6864f137')
+ _GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0937e7fe-3807-11ed-9890-99c59b328e7e')
 
 @@ -25,9 +34,6 @@ if pyxb.__version__ != _PyXBVersion:
  # inside class definitions where property names may conflict.

--- a/l10n_it_fatturapa/bindings/_ds.py
+++ b/l10n_it_fatturapa/bindings/_ds.py
@@ -1,28 +1,20 @@
-# flake8: noqa
+# ./_ds.py
+# -*- coding: utf-8 -*-
 # PyXB bindings for NM:f1c343a882e7a65fb879f4ee813309f8231f28c8
-# Generated 2021-11-30 12:20:11.883884 by PyXB version 1.2.6 using Python 3.6.9.final.0
+# Generated 2022-09-19 12:37:19.432820 by PyXB version 1.2.6 using Python 3.6.15.final.0
 # Namespace http://www.w3.org/2000/09/xmldsig# [xmlns:ds]
 
 from __future__ import unicode_literals
-import logging
+import pyxb
+import pyxb.binding
+import pyxb.binding.saxer
 import io
-
-_logger = logging.getLogger(__name__)
-
-try:
-    import pyxb
-    import pyxb.binding
-    import pyxb.binding.saxer
-    import pyxb.utils.utility
-    import pyxb.utils.domutils
-    import pyxb.utils.six as _six
-    # Import bindings for namespaces imported into schema
-    import pyxb.binding.datatypes
-except (ImportError) as err:
-    _logger.debug(err)
-
+import pyxb.utils.utility
+import pyxb.utils.domutils
+import sys
+import pyxb.utils.six as _six
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:7b7e2a22-51cf-11ec-b0cc-ec5c6864f137')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0937e7fe-3807-11ed-9890-99c59b328e7e')
 
 # Version of PyXB used to generate the bindings
 _PyXBVersion = '1.2.6'
@@ -33,6 +25,9 @@ if pyxb.__version__ != _PyXBVersion:
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
 _module_typeBindings = pyxb.utils.utility.Object()
+
+# Import bindings for namespaces imported into schema
+import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://www.w3.org/2000/09/xmldsig#', create_if_missing=True)
@@ -128,40 +123,40 @@ class SignatureType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}SignatureValue uses Python identifier SignatureValue
     __SignatureValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignatureValue'), 'SignatureValue', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignatureValue', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 54, 2), )
 
-
+    
     SignatureValue = property(__SignatureValue.value, __SignatureValue.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}SignedInfo uses Python identifier SignedInfo
     __SignedInfo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignedInfo'), 'SignedInfo', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigSignedInfo', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 65, 0), )
 
-
+    
     SignedInfo = property(__SignedInfo.value, __SignedInfo.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}KeyInfo uses Python identifier KeyInfo
     __KeyInfo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'KeyInfo'), 'KeyInfo', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigKeyInfo', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 144, 0), )
 
-
+    
     KeyInfo = property(__KeyInfo.value, __KeyInfo.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Object uses Python identifier Object
     __Object = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Object'), 'Object', '__httpwww_w3_org200009xmldsig_SignatureType_httpwww_w3_org200009xmldsigObject', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 243, 0), )
 
-
+    
     Object = property(__Object.value, __Object.set, None, None)
 
-
+    
     # Attribute Id uses Python identifier Id
     __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignatureType_Id', pyxb.binding.datatypes.ID)
     __Id._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 51, 2)
     __Id._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 51, 2)
-
+    
     Id = property(__Id.value, __Id.set, None, None)
 
     _ElementMap.update({
@@ -188,16 +183,16 @@ class SignatureValueType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.base64Binary
-
+    
     # Attribute Id uses Python identifier Id
     __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignatureValueType_Id', pyxb.binding.datatypes.ID)
     __Id._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 58, 8)
     __Id._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 58, 8)
-
+    
     Id = property(__Id.value, __Id.set, None, None)
 
     _ElementMap.update({
-
+        
     })
     _AttributeMap.update({
         __Id.name() : __Id
@@ -217,33 +212,33 @@ class SignedInfoType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}CanonicalizationMethod uses Python identifier CanonicalizationMethod
     __CanonicalizationMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'CanonicalizationMethod'), 'CanonicalizationMethod', '__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigCanonicalizationMethod', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 75, 2), )
 
-
+    
     CanonicalizationMethod = property(__CanonicalizationMethod.value, __CanonicalizationMethod.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}SignatureMethod uses Python identifier SignatureMethod
     __SignatureMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignatureMethod'), 'SignatureMethod', '__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigSignatureMethod', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 84, 2), )
 
-
+    
     SignatureMethod = property(__SignatureMethod.value, __SignatureMethod.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Reference uses Python identifier Reference
     __Reference = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Reference'), 'Reference', '__httpwww_w3_org200009xmldsig_SignedInfoType_httpwww_w3_org200009xmldsigReference', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 96, 0), )
 
-
+    
     Reference = property(__Reference.value, __Reference.set, None, None)
 
-
+    
     # Attribute Id uses Python identifier Id
     __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignedInfoType_Id', pyxb.binding.datatypes.ID)
     __Id._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 72, 2)
     __Id._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 72, 2)
-
+    
     Id = property(__Id.value, __Id.set, None, None)
 
     _ElementMap.update({
@@ -269,17 +264,17 @@ class CanonicalizationMethodType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Attribute Algorithm uses Python identifier Algorithm
     __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_CanonicalizationMethodType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
     __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 81, 4)
     __Algorithm._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 81, 4)
-
+    
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
     _ElementMap.update({
-
+        
     })
     _AttributeMap.update({
         __Algorithm.name() : __Algorithm
@@ -299,19 +294,19 @@ class SignatureMethodType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}HMACOutputLength uses Python identifier HMACOutputLength
     __HMACOutputLength = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'HMACOutputLength'), 'HMACOutputLength', '__httpwww_w3_org200009xmldsig_SignatureMethodType_httpwww_w3_org200009xmldsigHMACOutputLength', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 87, 6), )
 
-
+    
     HMACOutputLength = property(__HMACOutputLength.value, __HMACOutputLength.set, None, None)
 
-
+    
     # Attribute Algorithm uses Python identifier Algorithm
     __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_SignatureMethodType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
     __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 91, 4)
     __Algorithm._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 91, 4)
-
+    
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
@@ -336,49 +331,49 @@ class ReferenceType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
     __Transforms = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), 'Transforms', '__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigTransforms', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 108, 2), )
 
-
+    
     Transforms = property(__Transforms.value, __Transforms.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}DigestMethod uses Python identifier DigestMethod
     __DigestMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DigestMethod'), 'DigestMethod', '__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestMethod', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 127, 0), )
 
-
+    
     DigestMethod = property(__DigestMethod.value, __DigestMethod.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}DigestValue uses Python identifier DigestValue
     __DigestValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DigestValue'), 'DigestValue', '__httpwww_w3_org200009xmldsig_ReferenceType_httpwww_w3_org200009xmldsigDigestValue', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 135, 0), )
 
-
+    
     DigestValue = property(__DigestValue.value, __DigestValue.set, None, None)
 
-
+    
     # Attribute Id uses Python identifier Id
     __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_ReferenceType_Id', pyxb.binding.datatypes.ID)
     __Id._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 103, 2)
     __Id._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 103, 2)
-
+    
     Id = property(__Id.value, __Id.set, None, None)
 
-
+    
     # Attribute URI uses Python identifier URI
     __URI = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'URI'), 'URI', '__httpwww_w3_org200009xmldsig_ReferenceType_URI', pyxb.binding.datatypes.anyURI)
     __URI._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 104, 2)
     __URI._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 104, 2)
-
+    
     URI = property(__URI.value, __URI.set, None, None)
 
-
+    
     # Attribute Type uses Python identifier Type
     __Type = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Type'), 'Type', '__httpwww_w3_org200009xmldsig_ReferenceType_Type', pyxb.binding.datatypes.anyURI)
     __Type._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 105, 2)
     __Type._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 105, 2)
-
+    
     Type = property(__Type.value, __Type.set, None, None)
 
     _ElementMap.update({
@@ -406,18 +401,18 @@ class TransformsType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Transform uses Python identifier Transform
     __Transform = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Transform'), 'Transform', '__httpwww_w3_org200009xmldsig_TransformsType_httpwww_w3_org200009xmldsigTransform', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 115, 2), )
 
-
+    
     Transform = property(__Transform.value, __Transform.set, None, None)
 
     _ElementMap.update({
         __Transform.name() : __Transform
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.TransformsType = TransformsType
 Namespace.addCategoryObject('typeBinding', 'TransformsType', TransformsType)
@@ -434,19 +429,19 @@ class TransformType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}XPath uses Python identifier XPath
     __XPath = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'XPath'), 'XPath', '__httpwww_w3_org200009xmldsig_TransformType_httpwww_w3_org200009xmldsigXPath', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 120, 6), )
 
-
+    
     XPath = property(__XPath.value, __XPath.set, None, None)
 
-
+    
     # Attribute Algorithm uses Python identifier Algorithm
     __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_TransformType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
     __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 122, 4)
     __Algorithm._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 122, 4)
-
+    
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
@@ -471,17 +466,17 @@ class DigestMethodType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Attribute Algorithm uses Python identifier Algorithm
     __Algorithm = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Algorithm'), 'Algorithm', '__httpwww_w3_org200009xmldsig_DigestMethodType_Algorithm', pyxb.binding.datatypes.anyURI, required=True)
     __Algorithm._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 132, 2)
     __Algorithm._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 132, 2)
-
+    
     Algorithm = property(__Algorithm.value, __Algorithm.set, None, None)
 
     _HasWildcardElement = True
     _ElementMap.update({
-
+        
     })
     _AttributeMap.update({
         __Algorithm.name() : __Algorithm
@@ -501,61 +496,61 @@ class KeyInfoType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}KeyName uses Python identifier KeyName
     __KeyName = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'KeyName'), 'KeyName', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyName', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 160, 2), )
 
-
+    
     KeyName = property(__KeyName.value, __KeyName.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}MgmtData uses Python identifier MgmtData
     __MgmtData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'MgmtData'), 'MgmtData', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigMgmtData', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 161, 2), )
 
-
+    
     MgmtData = property(__MgmtData.value, __MgmtData.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}KeyValue uses Python identifier KeyValue
     __KeyValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'KeyValue'), 'KeyValue', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigKeyValue', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 163, 2), )
 
-
+    
     KeyValue = property(__KeyValue.value, __KeyValue.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}RetrievalMethod uses Python identifier RetrievalMethod
     __RetrievalMethod = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RetrievalMethod'), 'RetrievalMethod', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigRetrievalMethod', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 172, 2), )
 
-
+    
     RetrievalMethod = property(__RetrievalMethod.value, __RetrievalMethod.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509Data uses Python identifier X509Data
     __X509Data = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509Data'), 'X509Data', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigX509Data', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 183, 0), )
 
-
+    
     X509Data = property(__X509Data.value, __X509Data.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}PGPData uses Python identifier PGPData
     __PGPData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PGPData'), 'PGPData', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigPGPData', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 208, 0), )
 
-
+    
     PGPData = property(__PGPData.value, __PGPData.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}SPKIData uses Python identifier SPKIData
     __SPKIData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SPKIData'), 'SPKIData', '__httpwww_w3_org200009xmldsig_KeyInfoType_httpwww_w3_org200009xmldsigSPKIData', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 229, 0), )
 
-
+    
     SPKIData = property(__SPKIData.value, __SPKIData.set, None, None)
 
-
+    
     # Attribute Id uses Python identifier Id
     __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_KeyInfoType_Id', pyxb.binding.datatypes.ID)
     __Id._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 157, 2)
     __Id._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 157, 2)
-
+    
     Id = property(__Id.value, __Id.set, None, None)
 
     _HasWildcardElement = True
@@ -586,18 +581,18 @@ class KeyValueType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}DSAKeyValue uses Python identifier DSAKeyValue
     __DSAKeyValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'DSAKeyValue'), 'DSAKeyValue', '__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigDSAKeyValue', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 289, 0), )
 
-
+    
     DSAKeyValue = property(__DSAKeyValue.value, __DSAKeyValue.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}RSAKeyValue uses Python identifier RSAKeyValue
     __RSAKeyValue = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'RSAKeyValue'), 'RSAKeyValue', '__httpwww_w3_org200009xmldsig_KeyValueType_httpwww_w3_org200009xmldsigRSAKeyValue', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 306, 0), )
 
-
+    
     RSAKeyValue = property(__RSAKeyValue.value, __RSAKeyValue.set, None, None)
 
     _HasWildcardElement = True
@@ -606,7 +601,7 @@ class KeyValueType (pyxb.binding.basis.complexTypeDefinition):
         __RSAKeyValue.name() : __RSAKeyValue
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.KeyValueType = KeyValueType
 Namespace.addCategoryObject('typeBinding', 'KeyValueType', KeyValueType)
@@ -623,27 +618,27 @@ class RetrievalMethodType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Transforms uses Python identifier Transforms
     __Transforms = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Transforms'), 'Transforms', '__httpwww_w3_org200009xmldsig_RetrievalMethodType_httpwww_w3_org200009xmldsigTransforms', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 108, 2), )
 
-
+    
     Transforms = property(__Transforms.value, __Transforms.set, None, None)
 
-
+    
     # Attribute URI uses Python identifier URI
     __URI = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'URI'), 'URI', '__httpwww_w3_org200009xmldsig_RetrievalMethodType_URI', pyxb.binding.datatypes.anyURI)
     __URI._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 177, 4)
     __URI._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 177, 4)
-
+    
     URI = property(__URI.value, __URI.set, None, None)
 
-
+    
     # Attribute Type uses Python identifier Type
     __Type = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Type'), 'Type', '__httpwww_w3_org200009xmldsig_RetrievalMethodType_Type', pyxb.binding.datatypes.anyURI)
     __Type._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 178, 4)
     __Type._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 178, 4)
-
+    
     Type = property(__Type.value, __Type.set, None, None)
 
     _ElementMap.update({
@@ -668,39 +663,39 @@ class X509DataType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerSerial uses Python identifier X509IssuerSerial
     __X509IssuerSerial = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerSerial'), 'X509IssuerSerial', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509IssuerSerial', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 187, 6), )
 
-
+    
     X509IssuerSerial = property(__X509IssuerSerial.value, __X509IssuerSerial.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509SKI uses Python identifier X509SKI
     __X509SKI = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509SKI'), 'X509SKI', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SKI', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 188, 6), )
 
-
+    
     X509SKI = property(__X509SKI.value, __X509SKI.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509SubjectName uses Python identifier X509SubjectName
     __X509SubjectName = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509SubjectName'), 'X509SubjectName', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509SubjectName', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 189, 6), )
 
-
+    
     X509SubjectName = property(__X509SubjectName.value, __X509SubjectName.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509Certificate uses Python identifier X509Certificate
     __X509Certificate = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509Certificate'), 'X509Certificate', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509Certificate', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 190, 6), )
 
-
+    
     X509Certificate = property(__X509Certificate.value, __X509Certificate.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509CRL uses Python identifier X509CRL
     __X509CRL = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509CRL'), 'X509CRL', '__httpwww_w3_org200009xmldsig_X509DataType_httpwww_w3_org200009xmldsigX509CRL', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 191, 6), )
 
-
+    
     X509CRL = property(__X509CRL.value, __X509CRL.set, None, None)
 
     _HasWildcardElement = True
@@ -712,7 +707,7 @@ class X509DataType (pyxb.binding.basis.complexTypeDefinition):
         __X509CRL.name() : __X509CRL
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.X509DataType = X509DataType
 Namespace.addCategoryObject('typeBinding', 'X509DataType', X509DataType)
@@ -729,18 +724,18 @@ class X509IssuerSerialType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509IssuerName uses Python identifier X509IssuerName
     __X509IssuerName = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509IssuerName'), 'X509IssuerName', '__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509IssuerName', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 199, 4), )
 
-
+    
     X509IssuerName = property(__X509IssuerName.value, __X509IssuerName.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}X509SerialNumber uses Python identifier X509SerialNumber
     __X509SerialNumber = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'X509SerialNumber'), 'X509SerialNumber', '__httpwww_w3_org200009xmldsig_X509IssuerSerialType_httpwww_w3_org200009xmldsigX509SerialNumber', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 200, 4), )
 
-
+    
     X509SerialNumber = property(__X509SerialNumber.value, __X509SerialNumber.set, None, None)
 
     _ElementMap.update({
@@ -748,7 +743,7 @@ class X509IssuerSerialType (pyxb.binding.basis.complexTypeDefinition):
         __X509SerialNumber.name() : __X509SerialNumber
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.X509IssuerSerialType = X509IssuerSerialType
 Namespace.addCategoryObject('typeBinding', 'X509IssuerSerialType', X509IssuerSerialType)
@@ -765,18 +760,18 @@ class PGPDataType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}PGPKeyID uses Python identifier PGPKeyID
     __PGPKeyID = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyID'), 'PGPKeyID', '__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyID', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 212, 6), )
 
-
+    
     PGPKeyID = property(__PGPKeyID.value, __PGPKeyID.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}PGPKeyPacket uses Python identifier PGPKeyPacket
     __PGPKeyPacket = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PGPKeyPacket'), 'PGPKeyPacket', '__httpwww_w3_org200009xmldsig_PGPDataType_httpwww_w3_org200009xmldsigPGPKeyPacket', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 213, 6), )
 
-
+    
     PGPKeyPacket = property(__PGPKeyPacket.value, __PGPKeyPacket.set, None, None)
 
     _HasWildcardElement = True
@@ -785,7 +780,7 @@ class PGPDataType (pyxb.binding.basis.complexTypeDefinition):
         __PGPKeyPacket.name() : __PGPKeyPacket
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.PGPDataType = PGPDataType
 Namespace.addCategoryObject('typeBinding', 'PGPDataType', PGPDataType)
@@ -802,11 +797,11 @@ class SPKIDataType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}SPKISexp uses Python identifier SPKISexp
     __SPKISexp = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SPKISexp'), 'SPKISexp', '__httpwww_w3_org200009xmldsig_SPKIDataType_httpwww_w3_org200009xmldsigSPKISexp', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 232, 4), )
 
-
+    
     SPKISexp = property(__SPKISexp.value, __SPKISexp.set, None, None)
 
     _HasWildcardElement = True
@@ -814,7 +809,7 @@ class SPKIDataType (pyxb.binding.basis.complexTypeDefinition):
         __SPKISexp.name() : __SPKISexp
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.SPKIDataType = SPKIDataType
 Namespace.addCategoryObject('typeBinding', 'SPKIDataType', SPKIDataType)
@@ -831,33 +826,33 @@ class ObjectType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Attribute Id uses Python identifier Id
     __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_ObjectType_Id', pyxb.binding.datatypes.ID)
     __Id._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 248, 2)
     __Id._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 248, 2)
-
+    
     Id = property(__Id.value, __Id.set, None, None)
 
-
+    
     # Attribute MimeType uses Python identifier MimeType
     __MimeType = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'MimeType'), 'MimeType', '__httpwww_w3_org200009xmldsig_ObjectType_MimeType', pyxb.binding.datatypes.string)
     __MimeType._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 249, 2)
     __MimeType._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 249, 2)
-
+    
     MimeType = property(__MimeType.value, __MimeType.set, None, None)
 
-
+    
     # Attribute Encoding uses Python identifier Encoding
     __Encoding = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Encoding'), 'Encoding', '__httpwww_w3_org200009xmldsig_ObjectType_Encoding', pyxb.binding.datatypes.anyURI)
     __Encoding._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 250, 2)
     __Encoding._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 250, 2)
-
+    
     Encoding = property(__Encoding.value, __Encoding.set, None, None)
 
     _HasWildcardElement = True
     _ElementMap.update({
-
+        
     })
     _AttributeMap.update({
         __Id.name() : __Id,
@@ -879,19 +874,19 @@ class ManifestType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Reference uses Python identifier Reference
     __Reference = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Reference'), 'Reference', '__httpwww_w3_org200009xmldsig_ManifestType_httpwww_w3_org200009xmldsigReference', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 96, 0), )
 
-
+    
     Reference = property(__Reference.value, __Reference.set, None, None)
 
-
+    
     # Attribute Id uses Python identifier Id
     __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_ManifestType_Id', pyxb.binding.datatypes.ID)
     __Id._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 258, 2)
     __Id._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 258, 2)
-
+    
     Id = property(__Id.value, __Id.set, None, None)
 
     _ElementMap.update({
@@ -915,19 +910,19 @@ class SignaturePropertiesType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}SignatureProperty uses Python identifier SignatureProperty
     __SignatureProperty = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'SignatureProperty'), 'SignatureProperty', '__httpwww_w3_org200009xmldsig_SignaturePropertiesType_httpwww_w3_org200009xmldsigSignatureProperty', True, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 269, 3), )
 
-
+    
     SignatureProperty = property(__SignatureProperty.value, __SignatureProperty.set, None, None)
 
-
+    
     # Attribute Id uses Python identifier Id
     __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignaturePropertiesType_Id', pyxb.binding.datatypes.ID)
     __Id._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 266, 2)
     __Id._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 266, 2)
-
+    
     Id = property(__Id.value, __Id.set, None, None)
 
     _ElementMap.update({
@@ -951,25 +946,25 @@ class SignaturePropertyType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Attribute Target uses Python identifier Target
     __Target = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Target'), 'Target', '__httpwww_w3_org200009xmldsig_SignaturePropertyType_Target', pyxb.binding.datatypes.anyURI, required=True)
     __Target._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 275, 5)
     __Target._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 275, 5)
-
+    
     Target = property(__Target.value, __Target.set, None, None)
 
-
+    
     # Attribute Id uses Python identifier Id
     __Id = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'Id'), 'Id', '__httpwww_w3_org200009xmldsig_SignaturePropertyType_Id', pyxb.binding.datatypes.ID)
     __Id._DeclarationLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 276, 5)
     __Id._UseLocation = pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 276, 5)
-
+    
     Id = property(__Id.value, __Id.set, None, None)
 
     _HasWildcardElement = True
     _ElementMap.update({
-
+        
     })
     _AttributeMap.update({
         __Target.name() : __Target,
@@ -990,53 +985,53 @@ class DSAKeyValueType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}P uses Python identifier P
     __P = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'P'), 'P', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigP', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 293, 6), )
 
-
+    
     P = property(__P.value, __P.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Q uses Python identifier Q
     __Q = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Q'), 'Q', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigQ', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 294, 6), )
 
-
+    
     Q = property(__Q.value, __Q.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}G uses Python identifier G
     __G = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'G'), 'G', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigG', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 296, 4), )
 
-
+    
     G = property(__G.value, __G.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Y uses Python identifier Y
     __Y = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Y'), 'Y', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigY', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 297, 4), )
 
-
+    
     Y = property(__Y.value, __Y.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}J uses Python identifier J
     __J = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'J'), 'J', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigJ', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 298, 4), )
 
-
+    
     J = property(__J.value, __J.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Seed uses Python identifier Seed
     __Seed = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Seed'), 'Seed', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigSeed', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 300, 6), )
 
-
+    
     Seed = property(__Seed.value, __Seed.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}PgenCounter uses Python identifier PgenCounter
     __PgenCounter = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'PgenCounter'), 'PgenCounter', '__httpwww_w3_org200009xmldsig_DSAKeyValueType_httpwww_w3_org200009xmldsigPgenCounter', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 301, 6), )
 
-
+    
     PgenCounter = property(__PgenCounter.value, __PgenCounter.set, None, None)
 
     _ElementMap.update({
@@ -1049,7 +1044,7 @@ class DSAKeyValueType (pyxb.binding.basis.complexTypeDefinition):
         __PgenCounter.name() : __PgenCounter
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DSAKeyValueType = DSAKeyValueType
 Namespace.addCategoryObject('typeBinding', 'DSAKeyValueType', DSAKeyValueType)
@@ -1066,18 +1061,18 @@ class RSAKeyValueType (pyxb.binding.basis.complexTypeDefinition):
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Modulus uses Python identifier Modulus
     __Modulus = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Modulus'), 'Modulus', '__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigModulus', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 309, 4), )
 
-
+    
     Modulus = property(__Modulus.value, __Modulus.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Exponent uses Python identifier Exponent
     __Exponent = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(Namespace, 'Exponent'), 'Exponent', '__httpwww_w3_org200009xmldsig_RSAKeyValueType_httpwww_w3_org200009xmldsigExponent', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 310, 4), )
 
-
+    
     Exponent = property(__Exponent.value, __Exponent.set, None, None)
 
     _ElementMap.update({
@@ -1085,7 +1080,7 @@ class RSAKeyValueType (pyxb.binding.basis.complexTypeDefinition):
         __Exponent.name() : __Exponent
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.RSAKeyValueType = RSAKeyValueType
 Namespace.addCategoryObject('typeBinding', 'RSAKeyValueType', RSAKeyValueType)

--- a/l10n_it_fatturapa/bindings/_ds.py
+++ b/l10n_it_fatturapa/bindings/_ds.py
@@ -1,18 +1,26 @@
-# ./_ds.py
-# -*- coding: utf-8 -*-
+# flake8: noqa
 # PyXB bindings for NM:f1c343a882e7a65fb879f4ee813309f8231f28c8
 # Generated 2022-09-19 12:37:19.432820 by PyXB version 1.2.6 using Python 3.6.15.final.0
 # Namespace http://www.w3.org/2000/09/xmldsig# [xmlns:ds]
 
 from __future__ import unicode_literals
-import pyxb
-import pyxb.binding
-import pyxb.binding.saxer
+import logging
 import io
-import pyxb.utils.utility
-import pyxb.utils.domutils
-import sys
-import pyxb.utils.six as _six
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import pyxb
+    import pyxb.binding
+    import pyxb.binding.saxer
+    import pyxb.utils.utility
+    import pyxb.utils.domutils
+    import pyxb.utils.six as _six
+    # Import bindings for namespaces imported into schema
+    import pyxb.binding.datatypes
+except (ImportError) as err:
+    _logger.debug(err)
+
 # Unique identifier for bindings created at the same time
 _GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0937e7fe-3807-11ed-9890-99c59b328e7e')
 
@@ -25,9 +33,6 @@ if pyxb.__version__ != _PyXBVersion:
 # A holder for module-level binding classes so we can access them from
 # inside class definitions where property names may conflict.
 _module_typeBindings = pyxb.utils.utility.Object()
-
-# Import bindings for namespaces imported into schema
-import pyxb.binding.datatypes
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://www.w3.org/2000/09/xmldsig#', create_if_missing=True)

--- a/l10n_it_fatturapa/bindings/binding.diff
+++ b/l10n_it_fatturapa/bindings/binding.diff
@@ -30,7 +30,7 @@ index 7f239610..28ff679d 100644
 +except (ImportError) as err:
 +    _logger.debug(err)
  # Unique identifier for bindings created at the same time
- _GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:7b7e2a22-51cf-11ec-b0cc-ec5c6864f137')
+ _GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0937e7fe-3807-11ed-9890-99c59b328e7e')
 
 @@ -25,8 +34,6 @@ if pyxb.__version__ != _PyXBVersion:
  # inside class definitions where property names may conflict.

--- a/l10n_it_fatturapa/bindings/binding.py
+++ b/l10n_it_fatturapa/bindings/binding.py
@@ -1,28 +1,20 @@
-# flake8: noqa
+# ./binding.py
+# -*- coding: utf-8 -*-
 # PyXB bindings for NM:32e521a6da5b62d07147ea75b23acb0fb9726893
-# Generated 2021-11-30 12:20:11.884024 by PyXB version 1.2.6 using Python 3.6.9.final.0
+# Generated 2022-09-19 12:37:19.433213 by PyXB version 1.2.6 using Python 3.6.15.final.0
 # Namespace http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2
 
 from __future__ import unicode_literals
-import logging
+import pyxb
+import pyxb.binding
+import pyxb.binding.saxer
 import io
+import pyxb.utils.utility
+import pyxb.utils.domutils
 import sys
-
-_logger = logging.getLogger(__name__)
-
-try:
-    import pyxb
-    import pyxb.binding
-    import pyxb.binding.saxer
-    import pyxb.utils.utility
-    import pyxb.utils.domutils
-    import pyxb.utils.six as _six
-    # Import bindings for namespaces imported into schema
-    import pyxb.binding.datatypes
-except (ImportError) as err:
-    _logger.debug(err)
+import pyxb.utils.six as _six
 # Unique identifier for bindings created at the same time
-_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:7b7e2a22-51cf-11ec-b0cc-ec5c6864f137')
+_GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0937e7fe-3807-11ed-9890-99c59b328e7e')
 
 # Version of PyXB used to generate the bindings
 _PyXBVersion = '1.2.6'
@@ -34,7 +26,9 @@ if pyxb.__version__ != _PyXBVersion:
 # inside class definitions where property names may conflict.
 _module_typeBindings = pyxb.utils.utility.Object()
 
-from . import _ds as _ImportedBinding__ds
+# Import bindings for namespaces imported into schema
+import pyxb.binding.datatypes
+import _ds as _ImportedBinding__ds
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2', create_if_missing=True)
@@ -91,7 +85,7 @@ class CodiceDestinatarioType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CodiceDestinatarioType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 57, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 57, 2)
     _Documentation = None
 CodiceDestinatarioType._CF_pattern = pyxb.binding.facets.CF_pattern()
 CodiceDestinatarioType._CF_pattern.addPattern(pattern='[A-Z0-9]{6,7}')
@@ -105,7 +99,7 @@ class CodiceType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CodiceType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 68, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 68, 2)
     _Documentation = None
 CodiceType._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
 CodiceType._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(28))
@@ -120,7 +114,7 @@ class FormatoTrasmissioneType (pyxb.binding.datatypes.string, pyxb.binding.basis
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'FormatoTrasmissioneType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 74, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 74, 2)
     _Documentation = None
 FormatoTrasmissioneType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(5))
 FormatoTrasmissioneType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=FormatoTrasmissioneType, enum_prefix=None)
@@ -137,7 +131,7 @@ class CausalePagamentoType (pyxb.binding.datatypes.string, pyxb.binding.basis.en
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CausalePagamentoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 163, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 163, 2)
     _Documentation = None
 CausalePagamentoType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=CausalePagamentoType, enum_prefix=None)
 CausalePagamentoType.A = CausalePagamentoType._CF_enumeration.addEnumeration(unicode_value='A', tag='A')
@@ -179,7 +173,7 @@ class TipoScontoMaggiorazioneType (pyxb.binding.datatypes.string, pyxb.binding.b
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TipoScontoMaggiorazioneType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 198, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 198, 2)
     _Documentation = None
 TipoScontoMaggiorazioneType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(2))
 TipoScontoMaggiorazioneType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=TipoScontoMaggiorazioneType, enum_prefix=None)
@@ -196,7 +190,7 @@ class Art73Type (pyxb.binding.datatypes.string, pyxb.binding.basis.enumeration_m
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Art73Type')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 213, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 213, 2)
     _Documentation = None
 Art73Type._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(2))
 Art73Type._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=Art73Type, enum_prefix=None)
@@ -212,7 +206,7 @@ class TipoCassaType (pyxb.binding.datatypes.string, pyxb.binding.basis.enumerati
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TipoCassaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 223, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 223, 2)
     _Documentation = None
 TipoCassaType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(4))
 TipoCassaType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=TipoCassaType, enum_prefix=None)
@@ -249,7 +243,7 @@ class TipoDocumentoType (pyxb.binding.datatypes.string, pyxb.binding.basis.enume
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TipoDocumentoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 338, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 338, 2)
     _Documentation = None
 TipoDocumentoType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(4))
 TipoDocumentoType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=TipoDocumentoType, enum_prefix=None)
@@ -271,6 +265,7 @@ TipoDocumentoType.TD24 = TipoDocumentoType._CF_enumeration.addEnumeration(unicod
 TipoDocumentoType.TD25 = TipoDocumentoType._CF_enumeration.addEnumeration(unicode_value='TD25', tag='TD25')
 TipoDocumentoType.TD26 = TipoDocumentoType._CF_enumeration.addEnumeration(unicode_value='TD26', tag='TD26')
 TipoDocumentoType.TD27 = TipoDocumentoType._CF_enumeration.addEnumeration(unicode_value='TD27', tag='TD27')
+TipoDocumentoType.TD28 = TipoDocumentoType._CF_enumeration.addEnumeration(unicode_value='TD28', tag='TD28')
 TipoDocumentoType._InitializeFacetMap(TipoDocumentoType._CF_length,
    TipoDocumentoType._CF_enumeration)
 Namespace.addCategoryObject('typeBinding', 'TipoDocumentoType', TipoDocumentoType)
@@ -282,7 +277,7 @@ class TipoRitenutaType (pyxb.binding.datatypes.string, pyxb.binding.basis.enumer
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TipoRitenutaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 433, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 438, 2)
     _Documentation = None
 TipoRitenutaType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(4))
 TipoRitenutaType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=TipoRitenutaType, enum_prefix=None)
@@ -303,7 +298,7 @@ class RiferimentoNumeroLineaType (pyxb.binding.datatypes.integer):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RiferimentoNumeroLineaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 484, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 489, 2)
     _Documentation = None
 RiferimentoNumeroLineaType._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value_datatype=RiferimentoNumeroLineaType, value=pyxb.binding.datatypes.integer(1))
 RiferimentoNumeroLineaType._CF_maxInclusive = pyxb.binding.facets.CF_maxInclusive(value_datatype=RiferimentoNumeroLineaType, value=pyxb.binding.datatypes.integer(9999))
@@ -318,7 +313,7 @@ class SoggettoEmittenteType (pyxb.binding.datatypes.string, pyxb.binding.basis.e
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SoggettoEmittenteType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 530, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 535, 2)
     _Documentation = None
 SoggettoEmittenteType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(2))
 SoggettoEmittenteType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=SoggettoEmittenteType, enum_prefix=None)
@@ -335,7 +330,7 @@ class RegimeFiscaleType (pyxb.binding.datatypes.string, pyxb.binding.basis.enume
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RegimeFiscaleType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 570, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 575, 2)
     _Documentation = None
 RegimeFiscaleType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(4))
 RegimeFiscaleType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=RegimeFiscaleType, enum_prefix=None)
@@ -368,7 +363,7 @@ class CondizioniPagamentoType (pyxb.binding.datatypes.string, pyxb.binding.basis
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CondizioniPagamentoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 782, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 787, 2)
     _Documentation = None
 CondizioniPagamentoType._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(4))
 CondizioniPagamentoType._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(4))
@@ -388,7 +383,7 @@ class ModalitaPagamentoType (pyxb.binding.datatypes.string, pyxb.binding.basis.e
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ModalitaPagamentoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 828, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 833, 2)
     _Documentation = None
 ModalitaPagamentoType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(4))
 ModalitaPagamentoType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=ModalitaPagamentoType, enum_prefix=None)
@@ -426,7 +421,7 @@ class IBANType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'IBANType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 948, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 953, 2)
     _Documentation = None
 IBANType._CF_pattern = pyxb.binding.facets.CF_pattern()
 IBANType._CF_pattern.addPattern(pattern='[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{11,30}')
@@ -440,7 +435,7 @@ class BICType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'BICType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 953, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 958, 2)
     _Documentation = None
 BICType._CF_pattern = pyxb.binding.facets.CF_pattern()
 BICType._CF_pattern.addPattern(pattern='[A-Z]{6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3}){0,1}')
@@ -454,7 +449,7 @@ class RitenutaType (pyxb.binding.datatypes.string, pyxb.binding.basis.enumeratio
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RitenutaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1019, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1024, 2)
     _Documentation = None
 RitenutaType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(2))
 RitenutaType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=RitenutaType, enum_prefix=None)
@@ -470,7 +465,7 @@ class EsigibilitaIVAType (pyxb.binding.datatypes.string, pyxb.binding.basis.enum
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'EsigibilitaIVAType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1041, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1046, 2)
     _Documentation = None
 EsigibilitaIVAType._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
 EsigibilitaIVAType._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
@@ -490,7 +485,7 @@ class NaturaType (pyxb.binding.datatypes.string, pyxb.binding.basis.enumeration_
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'NaturaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1062, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1067, 2)
     _Documentation = None
 NaturaType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=NaturaType, enum_prefix=None)
 NaturaType.N1 = NaturaType._CF_enumeration.addEnumeration(unicode_value='N1', tag='N1')
@@ -527,7 +522,7 @@ class CodiceFiscaleType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CodiceFiscaleType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1189, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1194, 2)
     _Documentation = None
 CodiceFiscaleType._CF_pattern = pyxb.binding.facets.CF_pattern()
 CodiceFiscaleType._CF_pattern.addPattern(pattern='[A-Z0-9]{11,16}')
@@ -541,7 +536,7 @@ class CodiceFiscalePFType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CodiceFiscalePFType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1194, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1199, 2)
     _Documentation = None
 CodiceFiscalePFType._CF_pattern = pyxb.binding.facets.CF_pattern()
 CodiceFiscalePFType._CF_pattern.addPattern(pattern='[A-Z0-9]{16}')
@@ -555,7 +550,7 @@ class CodEORIType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CodEORIType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1199, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1204, 2)
     _Documentation = None
 CodEORIType._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(13))
 CodEORIType._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(17))
@@ -570,7 +565,7 @@ class SocioUnicoType (pyxb.binding.datatypes.string, pyxb.binding.basis.enumerat
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'SocioUnicoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1205, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1210, 2)
     _Documentation = None
 SocioUnicoType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=SocioUnicoType, enum_prefix=None)
 SocioUnicoType.SU = SocioUnicoType._CF_enumeration.addEnumeration(unicode_value='SU', tag='SU')
@@ -585,7 +580,7 @@ class StatoLiquidazioneType (pyxb.binding.datatypes.string, pyxb.binding.basis.e
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'StatoLiquidazioneType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1219, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1224, 2)
     _Documentation = None
 StatoLiquidazioneType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=StatoLiquidazioneType, enum_prefix=None)
 StatoLiquidazioneType.LS = StatoLiquidazioneType._CF_enumeration.addEnumeration(unicode_value='LS', tag='LS')
@@ -600,7 +595,7 @@ class TipoCessionePrestazioneType (pyxb.binding.datatypes.string, pyxb.binding.b
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TipoCessionePrestazioneType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1233, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1238, 2)
     _Documentation = None
 TipoCessionePrestazioneType._CF_length = pyxb.binding.facets.CF_length(value=pyxb.binding.datatypes.nonNegativeInteger(2))
 TipoCessionePrestazioneType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=TipoCessionePrestazioneType, enum_prefix=None)
@@ -619,7 +614,7 @@ class TitoloType (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TitoloType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1258, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1263, 2)
     _Documentation = None
 TitoloType._CF_pattern = pyxb.binding.facets.CF_pattern()
 TitoloType._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{2,10})')
@@ -635,7 +630,7 @@ class String10Type (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String10Type')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1264, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1269, 2)
     _Documentation = None
 String10Type._CF_pattern = pyxb.binding.facets.CF_pattern()
 String10Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,10})')
@@ -649,7 +644,7 @@ class String15Type (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String15Type')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1269, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1274, 2)
     _Documentation = None
 String15Type._CF_pattern = pyxb.binding.facets.CF_pattern()
 String15Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,15})')
@@ -663,7 +658,7 @@ class String20Type (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String20Type')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1274, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1279, 2)
     _Documentation = None
 String20Type._CF_pattern = pyxb.binding.facets.CF_pattern()
 String20Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,20})')
@@ -677,7 +672,7 @@ class String35Type (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String35Type')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1279, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1284, 2)
     _Documentation = None
 String35Type._CF_pattern = pyxb.binding.facets.CF_pattern()
 String35Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,35})')
@@ -691,7 +686,7 @@ class String35LatinExtType (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String35LatinExtType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1284, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1289, 2)
     _Documentation = None
 String35LatinExtType._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(1))
 String35LatinExtType._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(35))
@@ -706,7 +701,7 @@ class String60Type (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String60Type')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1290, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1295, 2)
     _Documentation = None
 String60Type._CF_pattern = pyxb.binding.facets.CF_pattern()
 String60Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,60})')
@@ -720,7 +715,7 @@ class String80Type (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String80Type')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1295, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1300, 2)
     _Documentation = None
 String80Type._CF_pattern = pyxb.binding.facets.CF_pattern()
 String80Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,80})')
@@ -734,7 +729,7 @@ class String100Type (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String100Type')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1300, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1305, 2)
     _Documentation = None
 String100Type._CF_pattern = pyxb.binding.facets.CF_pattern()
 String100Type._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,100})')
@@ -748,7 +743,7 @@ class String60LatinType (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String60LatinType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1305, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1310, 2)
     _Documentation = None
 String60LatinType._CF_pattern = pyxb.binding.facets.CF_pattern()
 String60LatinType._CF_pattern.addPattern(pattern='[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}]{1,60}')
@@ -762,7 +757,7 @@ class String80LatinType (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String80LatinType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1310, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1315, 2)
     _Documentation = None
 String80LatinType._CF_pattern = pyxb.binding.facets.CF_pattern()
 String80LatinType._CF_pattern.addPattern(pattern='[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}]{1,80}')
@@ -776,7 +771,7 @@ class String100LatinType (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String100LatinType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1315, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1320, 2)
     _Documentation = None
 String100LatinType._CF_pattern = pyxb.binding.facets.CF_pattern()
 String100LatinType._CF_pattern.addPattern(pattern='[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}]{1,100}')
@@ -790,7 +785,7 @@ class String200LatinType (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String200LatinType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1320, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1325, 2)
     _Documentation = None
 String200LatinType._CF_pattern = pyxb.binding.facets.CF_pattern()
 String200LatinType._CF_pattern.addPattern(pattern='[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}]{1,200}')
@@ -804,7 +799,7 @@ class String1000LatinType (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'String1000LatinType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1325, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1330, 2)
     _Documentation = None
 String1000LatinType._CF_pattern = pyxb.binding.facets.CF_pattern()
 String1000LatinType._CF_pattern.addPattern(pattern='[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}]{1,1000}')
@@ -818,7 +813,7 @@ class ProvinciaType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ProvinciaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1330, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1335, 2)
     _Documentation = None
 ProvinciaType._CF_pattern = pyxb.binding.facets.CF_pattern()
 ProvinciaType._CF_pattern.addPattern(pattern='[A-Z]{2}')
@@ -832,7 +827,7 @@ class NazioneType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'NazioneType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1335, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1340, 2)
     _Documentation = None
 NazioneType._CF_pattern = pyxb.binding.facets.CF_pattern()
 NazioneType._CF_pattern.addPattern(pattern='[A-Z]{2}')
@@ -846,7 +841,7 @@ class DivisaType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DivisaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1340, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1345, 2)
     _Documentation = None
 DivisaType._CF_pattern = pyxb.binding.facets.CF_pattern()
 DivisaType._CF_pattern.addPattern(pattern='[A-Z]{3}')
@@ -860,7 +855,7 @@ class TipoResaType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TipoResaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1345, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1350, 2)
     _Documentation = None
 TipoResaType._CF_pattern = pyxb.binding.facets.CF_pattern()
 TipoResaType._CF_pattern.addPattern(pattern='[A-Z]{3}')
@@ -874,7 +869,7 @@ class NumeroCivicoType (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'NumeroCivicoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1350, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1355, 2)
     _Documentation = None
 NumeroCivicoType._CF_pattern = pyxb.binding.facets.CF_pattern()
 NumeroCivicoType._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{1,8})')
@@ -888,7 +883,7 @@ class BolloVirtualeType (pyxb.binding.datatypes.string, pyxb.binding.basis.enume
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'BolloVirtualeType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1355, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1360, 2)
     _Documentation = None
 BolloVirtualeType._CF_enumeration = pyxb.binding.facets.CF_enumeration(value_datatype=BolloVirtualeType, enum_prefix=None)
 BolloVirtualeType.SI = BolloVirtualeType._CF_enumeration.addEnumeration(unicode_value='SI', tag='SI')
@@ -902,7 +897,7 @@ class TelFaxType (pyxb.binding.datatypes.normalizedString):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TelFaxType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1360, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1365, 2)
     _Documentation = None
 TelFaxType._CF_pattern = pyxb.binding.facets.CF_pattern()
 TelFaxType._CF_pattern.addPattern(pattern='(\\p{IsBasicLatin}{5,12})')
@@ -916,7 +911,7 @@ class EmailType (pyxb.binding.datatypes.token):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'EmailType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1365, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1370, 2)
     _Documentation = None
 EmailType._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(256))
 EmailType._CF_pattern = pyxb.binding.facets.CF_pattern()
@@ -932,7 +927,7 @@ class EmailContattiType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'EmailContattiType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1371, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1376, 2)
     _Documentation = None
 EmailContattiType._CF_minLength = pyxb.binding.facets.CF_minLength(value=pyxb.binding.datatypes.nonNegativeInteger(7))
 EmailContattiType._CF_maxLength = pyxb.binding.facets.CF_maxLength(value=pyxb.binding.datatypes.nonNegativeInteger(256))
@@ -950,7 +945,7 @@ class PesoType (pyxb.binding.datatypes.decimal):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'PesoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1379, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1384, 2)
     _Documentation = None
 PesoType._CF_pattern = pyxb.binding.facets.CF_pattern()
 PesoType._CF_pattern.addPattern(pattern='[0-9]{1,4}\\.[0-9]{1,2}')
@@ -964,7 +959,7 @@ class Amount8DecimalType (pyxb.binding.datatypes.decimal):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Amount8DecimalType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1384, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1389, 2)
     _Documentation = None
 Amount8DecimalType._CF_pattern = pyxb.binding.facets.CF_pattern()
 Amount8DecimalType._CF_pattern.addPattern(pattern='[\\-]?[0-9]{1,11}\\.[0-9]{2,8}')
@@ -978,7 +973,7 @@ class Amount2DecimalType (pyxb.binding.datatypes.decimal):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'Amount2DecimalType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1389, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1394, 2)
     _Documentation = None
 Amount2DecimalType._CF_pattern = pyxb.binding.facets.CF_pattern()
 Amount2DecimalType._CF_pattern.addPattern(pattern='[\\-]?[0-9]{1,11}\\.[0-9]{2}')
@@ -992,7 +987,7 @@ class RateType (pyxb.binding.datatypes.decimal):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RateType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1394, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1399, 2)
     _Documentation = None
 RateType._CF_pattern = pyxb.binding.facets.CF_pattern()
 RateType._CF_pattern.addPattern(pattern='[0-9]{1,3}\\.[0-9]{2}')
@@ -1008,7 +1003,7 @@ class RiferimentoFaseType (pyxb.binding.datatypes.integer):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RiferimentoFaseType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1400, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1405, 2)
     _Documentation = None
 RiferimentoFaseType._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value_datatype=RiferimentoFaseType, value=pyxb.binding.datatypes.integer(1))
 RiferimentoFaseType._CF_maxInclusive = pyxb.binding.facets.CF_maxInclusive(value_datatype=RiferimentoFaseType, value=pyxb.binding.datatypes.integer(999))
@@ -1023,7 +1018,7 @@ class NumeroColliType (pyxb.binding.datatypes.integer):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'NumeroColliType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1406, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1411, 2)
     _Documentation = None
 NumeroColliType._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value_datatype=NumeroColliType, value=pyxb.binding.datatypes.integer(1))
 NumeroColliType._CF_maxInclusive = pyxb.binding.facets.CF_maxInclusive(value_datatype=NumeroColliType, value=pyxb.binding.datatypes.integer(9999))
@@ -1038,7 +1033,7 @@ class NumeroLineaType (pyxb.binding.datatypes.integer):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'NumeroLineaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1412, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1417, 2)
     _Documentation = None
 NumeroLineaType._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value_datatype=NumeroLineaType, value=pyxb.binding.datatypes.integer(1))
 NumeroLineaType._CF_maxInclusive = pyxb.binding.facets.CF_maxInclusive(value_datatype=NumeroLineaType, value=pyxb.binding.datatypes.integer(9999))
@@ -1053,7 +1048,7 @@ class CAPType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CAPType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1418, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1423, 2)
     _Documentation = None
 CAPType._CF_pattern = pyxb.binding.facets.CF_pattern()
 CAPType._CF_pattern.addPattern(pattern='[0-9][0-9][0-9][0-9][0-9]')
@@ -1067,7 +1062,7 @@ class ABIType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ABIType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1423, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1428, 2)
     _Documentation = None
 ABIType._CF_pattern = pyxb.binding.facets.CF_pattern()
 ABIType._CF_pattern.addPattern(pattern='[0-9][0-9][0-9][0-9][0-9]')
@@ -1081,7 +1076,7 @@ class CABType (pyxb.binding.datatypes.string):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CABType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1428, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1433, 2)
     _Documentation = None
 CABType._CF_pattern = pyxb.binding.facets.CF_pattern()
 CABType._CF_pattern.addPattern(pattern='[0-9][0-9][0-9][0-9][0-9]')
@@ -1095,7 +1090,7 @@ class GiorniTerminePagamentoType (pyxb.binding.datatypes.integer):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'GiorniTerminePagamentoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1433, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1438, 2)
     _Documentation = None
 GiorniTerminePagamentoType._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value_datatype=GiorniTerminePagamentoType, value=pyxb.binding.datatypes.integer(0))
 GiorniTerminePagamentoType._CF_maxInclusive = pyxb.binding.facets.CF_maxInclusive(value_datatype=GiorniTerminePagamentoType, value=pyxb.binding.datatypes.integer(999))
@@ -1110,7 +1105,7 @@ class QuantitaType (pyxb.binding.datatypes.decimal):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'QuantitaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1439, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1444, 2)
     _Documentation = None
 QuantitaType._CF_pattern = pyxb.binding.facets.CF_pattern()
 QuantitaType._CF_pattern.addPattern(pattern='[0-9]{1,12}\\.[0-9]{2,8}')
@@ -1124,7 +1119,7 @@ class DataFatturaType (pyxb.binding.datatypes.date):
     """An atomic simple type."""
 
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DataFatturaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1444, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1449, 2)
     _Documentation = None
 DataFatturaType._CF_minInclusive = pyxb.binding.facets.CF_minInclusive(value_datatype=DataFatturaType, value=pyxb.binding.datatypes.date('1970-01-01'))
 DataFatturaType._InitializeFacetMap(DataFatturaType._CF_minInclusive)
@@ -1138,50 +1133,50 @@ class FatturaElettronicaHeaderType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'FatturaElettronicaHeaderType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 25, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 25, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element DatiTrasmissione uses Python identifier DatiTrasmissione
-    __DatiTrasmissione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiTrasmissione'), 'DatiTrasmissione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_DatiTrasmissione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 27, 6), )
+    __DatiTrasmissione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiTrasmissione'), 'DatiTrasmissione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_DatiTrasmissione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 27, 6), )
 
-
+    
     DatiTrasmissione = property(__DatiTrasmissione.value, __DatiTrasmissione.set, None, None)
 
-
+    
     # Element CedentePrestatore uses Python identifier CedentePrestatore
-    __CedentePrestatore = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CedentePrestatore'), 'CedentePrestatore', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_CedentePrestatore', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 28, 6), )
+    __CedentePrestatore = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CedentePrestatore'), 'CedentePrestatore', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_CedentePrestatore', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 28, 6), )
 
-
+    
     CedentePrestatore = property(__CedentePrestatore.value, __CedentePrestatore.set, None, None)
 
-
+    
     # Element RappresentanteFiscale uses Python identifier RappresentanteFiscale
-    __RappresentanteFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale'), 'RappresentanteFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_RappresentanteFiscale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 29, 6), )
+    __RappresentanteFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale'), 'RappresentanteFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_RappresentanteFiscale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 29, 6), )
 
-
+    
     RappresentanteFiscale = property(__RappresentanteFiscale.value, __RappresentanteFiscale.set, None, None)
 
-
+    
     # Element CessionarioCommittente uses Python identifier CessionarioCommittente
-    __CessionarioCommittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CessionarioCommittente'), 'CessionarioCommittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_CessionarioCommittente', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 30, 6), )
+    __CessionarioCommittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CessionarioCommittente'), 'CessionarioCommittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_CessionarioCommittente', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 30, 6), )
 
-
+    
     CessionarioCommittente = property(__CessionarioCommittente.value, __CessionarioCommittente.set, None, None)
 
-
+    
     # Element TerzoIntermediarioOSoggettoEmittente uses Python identifier TerzoIntermediarioOSoggettoEmittente
-    __TerzoIntermediarioOSoggettoEmittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TerzoIntermediarioOSoggettoEmittente'), 'TerzoIntermediarioOSoggettoEmittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_TerzoIntermediarioOSoggettoEmittente', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 31, 6), )
+    __TerzoIntermediarioOSoggettoEmittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TerzoIntermediarioOSoggettoEmittente'), 'TerzoIntermediarioOSoggettoEmittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_TerzoIntermediarioOSoggettoEmittente', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 31, 6), )
 
-
+    
     TerzoIntermediarioOSoggettoEmittente = property(__TerzoIntermediarioOSoggettoEmittente.value, __TerzoIntermediarioOSoggettoEmittente.set, None, None)
 
-
+    
     # Element SoggettoEmittente uses Python identifier SoggettoEmittente
-    __SoggettoEmittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'SoggettoEmittente'), 'SoggettoEmittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_SoggettoEmittente', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 32, 6), )
+    __SoggettoEmittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'SoggettoEmittente'), 'SoggettoEmittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaHeaderType_SoggettoEmittente', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 32, 6), )
 
-
+    
     SoggettoEmittente = property(__SoggettoEmittente.value, __SoggettoEmittente.set, None, None)
 
     _ElementMap.update({
@@ -1193,7 +1188,7 @@ class FatturaElettronicaHeaderType (pyxb.binding.basis.complexTypeDefinition):
         __SoggettoEmittente.name() : __SoggettoEmittente
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.FatturaElettronicaHeaderType = FatturaElettronicaHeaderType
 Namespace.addCategoryObject('typeBinding', 'FatturaElettronicaHeaderType', FatturaElettronicaHeaderType)
@@ -1206,43 +1201,43 @@ class FatturaElettronicaBodyType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'FatturaElettronicaBodyType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 35, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 35, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element DatiGenerali uses Python identifier DatiGenerali
-    __DatiGenerali = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiGenerali'), 'DatiGenerali', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_DatiGenerali', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 37, 6), )
+    __DatiGenerali = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiGenerali'), 'DatiGenerali', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_DatiGenerali', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 37, 6), )
 
-
+    
     DatiGenerali = property(__DatiGenerali.value, __DatiGenerali.set, None, None)
 
-
+    
     # Element DatiBeniServizi uses Python identifier DatiBeniServizi
-    __DatiBeniServizi = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiBeniServizi'), 'DatiBeniServizi', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_DatiBeniServizi', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 38, 6), )
+    __DatiBeniServizi = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiBeniServizi'), 'DatiBeniServizi', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_DatiBeniServizi', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 38, 6), )
 
-
+    
     DatiBeniServizi = property(__DatiBeniServizi.value, __DatiBeniServizi.set, None, None)
 
-
+    
     # Element DatiVeicoli uses Python identifier DatiVeicoli
-    __DatiVeicoli = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiVeicoli'), 'DatiVeicoli', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_DatiVeicoli', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 39, 6), )
+    __DatiVeicoli = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiVeicoli'), 'DatiVeicoli', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_DatiVeicoli', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 39, 6), )
 
-
+    
     DatiVeicoli = property(__DatiVeicoli.value, __DatiVeicoli.set, None, None)
 
-
+    
     # Element DatiPagamento uses Python identifier DatiPagamento
-    __DatiPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiPagamento'), 'DatiPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_DatiPagamento', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 40, 6), )
+    __DatiPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiPagamento'), 'DatiPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_DatiPagamento', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 40, 6), )
 
-
+    
     DatiPagamento = property(__DatiPagamento.value, __DatiPagamento.set, None, None)
 
-
+    
     # Element Allegati uses Python identifier Allegati
-    __Allegati = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Allegati'), 'Allegati', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_Allegati', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 41, 6), )
+    __Allegati = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Allegati'), 'Allegati', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaBodyType_Allegati', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 41, 6), )
 
-
+    
     Allegati = property(__Allegati.value, __Allegati.set, None, None)
 
     _ElementMap.update({
@@ -1253,7 +1248,7 @@ class FatturaElettronicaBodyType (pyxb.binding.basis.complexTypeDefinition):
         __Allegati.name() : __Allegati
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.FatturaElettronicaBodyType = FatturaElettronicaBodyType
 Namespace.addCategoryObject('typeBinding', 'FatturaElettronicaBodyType', FatturaElettronicaBodyType)
@@ -1266,50 +1261,50 @@ class DatiTrasmissioneType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiTrasmissioneType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 44, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 44, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element IdTrasmittente uses Python identifier IdTrasmittente
-    __IdTrasmittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdTrasmittente'), 'IdTrasmittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_IdTrasmittente', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 49, 6), )
+    __IdTrasmittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdTrasmittente'), 'IdTrasmittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_IdTrasmittente', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 49, 6), )
 
-
+    
     IdTrasmittente = property(__IdTrasmittente.value, __IdTrasmittente.set, None, None)
 
-
+    
     # Element ProgressivoInvio uses Python identifier ProgressivoInvio
-    __ProgressivoInvio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ProgressivoInvio'), 'ProgressivoInvio', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_ProgressivoInvio', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 50, 6), )
+    __ProgressivoInvio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ProgressivoInvio'), 'ProgressivoInvio', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_ProgressivoInvio', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 50, 6), )
 
-
+    
     ProgressivoInvio = property(__ProgressivoInvio.value, __ProgressivoInvio.set, None, None)
 
-
+    
     # Element FormatoTrasmissione uses Python identifier FormatoTrasmissione
-    __FormatoTrasmissione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FormatoTrasmissione'), 'FormatoTrasmissione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_FormatoTrasmissione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 51, 6), )
+    __FormatoTrasmissione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FormatoTrasmissione'), 'FormatoTrasmissione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_FormatoTrasmissione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 51, 6), )
 
-
+    
     FormatoTrasmissione = property(__FormatoTrasmissione.value, __FormatoTrasmissione.set, None, None)
 
-
+    
     # Element CodiceDestinatario uses Python identifier CodiceDestinatario
-    __CodiceDestinatario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceDestinatario'), 'CodiceDestinatario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_CodiceDestinatario', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 52, 6), )
+    __CodiceDestinatario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceDestinatario'), 'CodiceDestinatario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_CodiceDestinatario', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 52, 6), )
 
-
+    
     CodiceDestinatario = property(__CodiceDestinatario.value, __CodiceDestinatario.set, None, None)
 
-
+    
     # Element ContattiTrasmittente uses Python identifier ContattiTrasmittente
-    __ContattiTrasmittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ContattiTrasmittente'), 'ContattiTrasmittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_ContattiTrasmittente', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 53, 6), )
+    __ContattiTrasmittente = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ContattiTrasmittente'), 'ContattiTrasmittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_ContattiTrasmittente', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 53, 6), )
 
-
+    
     ContattiTrasmittente = property(__ContattiTrasmittente.value, __ContattiTrasmittente.set, None, None)
 
-
+    
     # Element PECDestinatario uses Python identifier PECDestinatario
-    __PECDestinatario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PECDestinatario'), 'PECDestinatario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_PECDestinatario', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 54, 6), )
+    __PECDestinatario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PECDestinatario'), 'PECDestinatario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasmissioneType_PECDestinatario', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 54, 6), )
 
-
+    
     PECDestinatario = property(__PECDestinatario.value, __PECDestinatario.set, None, None)
 
     _ElementMap.update({
@@ -1321,7 +1316,7 @@ class DatiTrasmissioneType (pyxb.binding.basis.complexTypeDefinition):
         __PECDestinatario.name() : __PECDestinatario
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiTrasmissioneType = DatiTrasmissioneType
 Namespace.addCategoryObject('typeBinding', 'DatiTrasmissioneType', DatiTrasmissioneType)
@@ -1334,22 +1329,22 @@ class IdFiscaleType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'IdFiscaleType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 62, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 62, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element IdPaese uses Python identifier IdPaese
-    __IdPaese = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdPaese'), 'IdPaese', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IdFiscaleType_IdPaese', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 64, 6), )
+    __IdPaese = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdPaese'), 'IdPaese', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IdFiscaleType_IdPaese', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 64, 6), )
 
-
+    
     IdPaese = property(__IdPaese.value, __IdPaese.set, None, None)
 
-
+    
     # Element IdCodice uses Python identifier IdCodice
-    __IdCodice = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdCodice'), 'IdCodice', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IdFiscaleType_IdCodice', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 65, 6), )
+    __IdCodice = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdCodice'), 'IdCodice', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IdFiscaleType_IdCodice', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 65, 6), )
 
-
+    
     IdCodice = property(__IdCodice.value, __IdCodice.set, None, None)
 
     _ElementMap.update({
@@ -1357,7 +1352,7 @@ class IdFiscaleType (pyxb.binding.basis.complexTypeDefinition):
         __IdCodice.name() : __IdCodice
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.IdFiscaleType = IdFiscaleType
 Namespace.addCategoryObject('typeBinding', 'IdFiscaleType', IdFiscaleType)
@@ -1370,22 +1365,22 @@ class ContattiTrasmittenteType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ContattiTrasmittenteType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 89, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 89, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element Telefono uses Python identifier Telefono
-    __Telefono = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Telefono'), 'Telefono', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiTrasmittenteType_Telefono', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 91, 6), )
+    __Telefono = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Telefono'), 'Telefono', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiTrasmittenteType_Telefono', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 91, 6), )
 
-
+    
     Telefono = property(__Telefono.value, __Telefono.set, None, None)
 
-
+    
     # Element Email uses Python identifier Email
-    __Email = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Email'), 'Email', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiTrasmittenteType_Email', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 92, 6), )
+    __Email = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Email'), 'Email', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiTrasmittenteType_Email', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 92, 6), )
 
-
+    
     Email = property(__Email.value, __Email.set, None, None)
 
     _ElementMap.update({
@@ -1393,7 +1388,7 @@ class ContattiTrasmittenteType (pyxb.binding.basis.complexTypeDefinition):
         __Email.name() : __Email
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.ContattiTrasmittenteType = ContattiTrasmittenteType
 Namespace.addCategoryObject('typeBinding', 'ContattiTrasmittenteType', ContattiTrasmittenteType)
@@ -1408,78 +1403,78 @@ class DatiGeneraliType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiGeneraliType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 95, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 95, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element DatiGeneraliDocumento uses Python identifier DatiGeneraliDocumento
-    __DatiGeneraliDocumento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiGeneraliDocumento'), 'DatiGeneraliDocumento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiGeneraliDocumento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 102, 6), )
+    __DatiGeneraliDocumento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiGeneraliDocumento'), 'DatiGeneraliDocumento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiGeneraliDocumento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 102, 6), )
 
-
+    
     DatiGeneraliDocumento = property(__DatiGeneraliDocumento.value, __DatiGeneraliDocumento.set, None, None)
 
-
+    
     # Element DatiOrdineAcquisto uses Python identifier DatiOrdineAcquisto
-    __DatiOrdineAcquisto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiOrdineAcquisto'), 'DatiOrdineAcquisto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiOrdineAcquisto', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 103, 6), )
+    __DatiOrdineAcquisto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiOrdineAcquisto'), 'DatiOrdineAcquisto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiOrdineAcquisto', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 103, 6), )
 
-
+    
     DatiOrdineAcquisto = property(__DatiOrdineAcquisto.value, __DatiOrdineAcquisto.set, None, None)
 
-
+    
     # Element DatiContratto uses Python identifier DatiContratto
-    __DatiContratto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiContratto'), 'DatiContratto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiContratto', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 104, 6), )
+    __DatiContratto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiContratto'), 'DatiContratto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiContratto', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 104, 6), )
 
-
+    
     DatiContratto = property(__DatiContratto.value, __DatiContratto.set, None, None)
 
-
+    
     # Element DatiConvenzione uses Python identifier DatiConvenzione
-    __DatiConvenzione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiConvenzione'), 'DatiConvenzione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiConvenzione', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 105, 6), )
+    __DatiConvenzione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiConvenzione'), 'DatiConvenzione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiConvenzione', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 105, 6), )
 
-
+    
     DatiConvenzione = property(__DatiConvenzione.value, __DatiConvenzione.set, None, None)
 
-
+    
     # Element DatiRicezione uses Python identifier DatiRicezione
-    __DatiRicezione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiRicezione'), 'DatiRicezione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiRicezione', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 106, 6), )
+    __DatiRicezione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiRicezione'), 'DatiRicezione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiRicezione', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 106, 6), )
 
-
+    
     DatiRicezione = property(__DatiRicezione.value, __DatiRicezione.set, None, None)
 
-
+    
     # Element DatiFattureCollegate uses Python identifier DatiFattureCollegate
-    __DatiFattureCollegate = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiFattureCollegate'), 'DatiFattureCollegate', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiFattureCollegate', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 107, 6), )
+    __DatiFattureCollegate = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiFattureCollegate'), 'DatiFattureCollegate', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiFattureCollegate', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 107, 6), )
 
-
+    
     DatiFattureCollegate = property(__DatiFattureCollegate.value, __DatiFattureCollegate.set, None, None)
 
-
+    
     # Element DatiSAL uses Python identifier DatiSAL
-    __DatiSAL = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiSAL'), 'DatiSAL', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiSAL', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 108, 6), )
+    __DatiSAL = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiSAL'), 'DatiSAL', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiSAL', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 108, 6), )
 
-
+    
     DatiSAL = property(__DatiSAL.value, __DatiSAL.set, None, None)
 
-
+    
     # Element DatiDDT uses Python identifier DatiDDT
-    __DatiDDT = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiDDT'), 'DatiDDT', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiDDT', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 109, 6), )
+    __DatiDDT = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiDDT'), 'DatiDDT', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiDDT', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 109, 6), )
 
-
+    
     DatiDDT = property(__DatiDDT.value, __DatiDDT.set, None, None)
 
-
+    
     # Element DatiTrasporto uses Python identifier DatiTrasporto
-    __DatiTrasporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiTrasporto'), 'DatiTrasporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiTrasporto', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 110, 6), )
+    __DatiTrasporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiTrasporto'), 'DatiTrasporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_DatiTrasporto', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 110, 6), )
 
-
+    
     DatiTrasporto = property(__DatiTrasporto.value, __DatiTrasporto.set, None, None)
 
-
+    
     # Element FatturaPrincipale uses Python identifier FatturaPrincipale
-    __FatturaPrincipale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FatturaPrincipale'), 'FatturaPrincipale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_FatturaPrincipale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 111, 6), )
+    __FatturaPrincipale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FatturaPrincipale'), 'FatturaPrincipale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliType_FatturaPrincipale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 111, 6), )
 
-
+    
     FatturaPrincipale = property(__FatturaPrincipale.value, __FatturaPrincipale.set, None, None)
 
     _ElementMap.update({
@@ -1495,7 +1490,7 @@ class DatiGeneraliType (pyxb.binding.basis.complexTypeDefinition):
         __FatturaPrincipale.name() : __FatturaPrincipale
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiGeneraliType = DatiGeneraliType
 Namespace.addCategoryObject('typeBinding', 'DatiGeneraliType', DatiGeneraliType)
@@ -1508,92 +1503,92 @@ class DatiGeneraliDocumentoType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiGeneraliDocumentoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 114, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 114, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element TipoDocumento uses Python identifier TipoDocumento
-    __TipoDocumento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoDocumento'), 'TipoDocumento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_TipoDocumento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 116, 6), )
+    __TipoDocumento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoDocumento'), 'TipoDocumento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_TipoDocumento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 116, 6), )
 
-
+    
     TipoDocumento = property(__TipoDocumento.value, __TipoDocumento.set, None, None)
 
-
+    
     # Element Divisa uses Python identifier Divisa
-    __Divisa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Divisa'), 'Divisa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Divisa', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 117, 6), )
+    __Divisa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Divisa'), 'Divisa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Divisa', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 117, 6), )
 
-
+    
     Divisa = property(__Divisa.value, __Divisa.set, None, None)
 
-
+    
     # Element Data uses Python identifier Data
-    __Data = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Data'), 'Data', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Data', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 118, 6), )
+    __Data = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Data'), 'Data', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Data', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 118, 6), )
 
-
+    
     Data = property(__Data.value, __Data.set, None, None)
 
-
+    
     # Element Numero uses Python identifier Numero
-    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Numero'), 'Numero', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Numero', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 119, 6), )
+    __Numero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Numero'), 'Numero', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Numero', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 119, 6), )
 
-
+    
     Numero = property(__Numero.value, __Numero.set, None, None)
 
-
+    
     # Element DatiRitenuta uses Python identifier DatiRitenuta
-    __DatiRitenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiRitenuta'), 'DatiRitenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_DatiRitenuta', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 120, 6), )
+    __DatiRitenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiRitenuta'), 'DatiRitenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_DatiRitenuta', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 120, 6), )
 
-
+    
     DatiRitenuta = property(__DatiRitenuta.value, __DatiRitenuta.set, None, None)
 
-
+    
     # Element DatiBollo uses Python identifier DatiBollo
-    __DatiBollo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiBollo'), 'DatiBollo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_DatiBollo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 121, 6), )
+    __DatiBollo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiBollo'), 'DatiBollo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_DatiBollo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 121, 6), )
 
-
+    
     DatiBollo = property(__DatiBollo.value, __DatiBollo.set, None, None)
 
-
+    
     # Element DatiCassaPrevidenziale uses Python identifier DatiCassaPrevidenziale
-    __DatiCassaPrevidenziale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiCassaPrevidenziale'), 'DatiCassaPrevidenziale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_DatiCassaPrevidenziale', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 122, 6), )
+    __DatiCassaPrevidenziale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiCassaPrevidenziale'), 'DatiCassaPrevidenziale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_DatiCassaPrevidenziale', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 122, 6), )
 
-
+    
     DatiCassaPrevidenziale = property(__DatiCassaPrevidenziale.value, __DatiCassaPrevidenziale.set, None, None)
 
-
+    
     # Element ScontoMaggiorazione uses Python identifier ScontoMaggiorazione
-    __ScontoMaggiorazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione'), 'ScontoMaggiorazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_ScontoMaggiorazione', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 123, 6), )
+    __ScontoMaggiorazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione'), 'ScontoMaggiorazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_ScontoMaggiorazione', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 123, 6), )
 
-
+    
     ScontoMaggiorazione = property(__ScontoMaggiorazione.value, __ScontoMaggiorazione.set, None, None)
 
-
+    
     # Element ImportoTotaleDocumento uses Python identifier ImportoTotaleDocumento
-    __ImportoTotaleDocumento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoTotaleDocumento'), 'ImportoTotaleDocumento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_ImportoTotaleDocumento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 124, 6), )
+    __ImportoTotaleDocumento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoTotaleDocumento'), 'ImportoTotaleDocumento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_ImportoTotaleDocumento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 124, 6), )
 
-
+    
     ImportoTotaleDocumento = property(__ImportoTotaleDocumento.value, __ImportoTotaleDocumento.set, None, None)
 
-
+    
     # Element Arrotondamento uses Python identifier Arrotondamento
-    __Arrotondamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Arrotondamento'), 'Arrotondamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Arrotondamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 125, 6), )
+    __Arrotondamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Arrotondamento'), 'Arrotondamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Arrotondamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 125, 6), )
 
-
+    
     Arrotondamento = property(__Arrotondamento.value, __Arrotondamento.set, None, None)
 
-
+    
     # Element Causale uses Python identifier Causale
-    __Causale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Causale'), 'Causale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Causale', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 126, 6), )
+    __Causale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Causale'), 'Causale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Causale', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 126, 6), )
 
-
+    
     Causale = property(__Causale.value, __Causale.set, None, None)
 
-
+    
     # Element Art73 uses Python identifier Art73
-    __Art73 = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Art73'), 'Art73', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Art73', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 127, 6), )
+    __Art73 = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Art73'), 'Art73', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiGeneraliDocumentoType_Art73', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 127, 6), )
 
-
+    
     Art73 = property(__Art73.value, __Art73.set, None, None)
 
     _ElementMap.update({
@@ -1611,7 +1606,7 @@ class DatiGeneraliDocumentoType (pyxb.binding.basis.complexTypeDefinition):
         __Art73.name() : __Art73
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiGeneraliDocumentoType = DatiGeneraliDocumentoType
 Namespace.addCategoryObject('typeBinding', 'DatiGeneraliDocumentoType', DatiGeneraliDocumentoType)
@@ -1624,36 +1619,36 @@ class DatiRitenutaType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiRitenutaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 130, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 130, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element TipoRitenuta uses Python identifier TipoRitenuta
-    __TipoRitenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoRitenuta'), 'TipoRitenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRitenutaType_TipoRitenuta', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 132, 6), )
+    __TipoRitenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoRitenuta'), 'TipoRitenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRitenutaType_TipoRitenuta', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 132, 6), )
 
-
+    
     TipoRitenuta = property(__TipoRitenuta.value, __TipoRitenuta.set, None, None)
 
-
+    
     # Element ImportoRitenuta uses Python identifier ImportoRitenuta
-    __ImportoRitenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoRitenuta'), 'ImportoRitenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRitenutaType_ImportoRitenuta', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 133, 6), )
+    __ImportoRitenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoRitenuta'), 'ImportoRitenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRitenutaType_ImportoRitenuta', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 133, 6), )
 
-
+    
     ImportoRitenuta = property(__ImportoRitenuta.value, __ImportoRitenuta.set, None, None)
 
-
+    
     # Element AliquotaRitenuta uses Python identifier AliquotaRitenuta
-    __AliquotaRitenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AliquotaRitenuta'), 'AliquotaRitenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRitenutaType_AliquotaRitenuta', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 134, 6), )
+    __AliquotaRitenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AliquotaRitenuta'), 'AliquotaRitenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRitenutaType_AliquotaRitenuta', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 134, 6), )
 
-
+    
     AliquotaRitenuta = property(__AliquotaRitenuta.value, __AliquotaRitenuta.set, None, None)
 
-
+    
     # Element CausalePagamento uses Python identifier CausalePagamento
-    __CausalePagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CausalePagamento'), 'CausalePagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRitenutaType_CausalePagamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 135, 6), )
+    __CausalePagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CausalePagamento'), 'CausalePagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRitenutaType_CausalePagamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 135, 6), )
 
-
+    
     CausalePagamento = property(__CausalePagamento.value, __CausalePagamento.set, None, None)
 
     _ElementMap.update({
@@ -1663,7 +1658,7 @@ class DatiRitenutaType (pyxb.binding.basis.complexTypeDefinition):
         __CausalePagamento.name() : __CausalePagamento
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiRitenutaType = DatiRitenutaType
 Namespace.addCategoryObject('typeBinding', 'DatiRitenutaType', DatiRitenutaType)
@@ -1676,22 +1671,22 @@ class DatiBolloType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiBolloType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 138, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 138, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element BolloVirtuale uses Python identifier BolloVirtuale
-    __BolloVirtuale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'BolloVirtuale'), 'BolloVirtuale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiBolloType_BolloVirtuale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 140, 6), )
+    __BolloVirtuale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'BolloVirtuale'), 'BolloVirtuale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiBolloType_BolloVirtuale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 140, 6), )
 
-
+    
     BolloVirtuale = property(__BolloVirtuale.value, __BolloVirtuale.set, None, None)
 
-
+    
     # Element ImportoBollo uses Python identifier ImportoBollo
-    __ImportoBollo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoBollo'), 'ImportoBollo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiBolloType_ImportoBollo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 141, 6), )
+    __ImportoBollo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoBollo'), 'ImportoBollo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiBolloType_ImportoBollo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 141, 6), )
 
-
+    
     ImportoBollo = property(__ImportoBollo.value, __ImportoBollo.set, None, None)
 
     _ElementMap.update({
@@ -1699,7 +1694,7 @@ class DatiBolloType (pyxb.binding.basis.complexTypeDefinition):
         __ImportoBollo.name() : __ImportoBollo
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiBolloType = DatiBolloType
 Namespace.addCategoryObject('typeBinding', 'DatiBolloType', DatiBolloType)
@@ -1712,64 +1707,64 @@ class DatiCassaPrevidenzialeType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiCassaPrevidenzialeType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 144, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 144, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element TipoCassa uses Python identifier TipoCassa
-    __TipoCassa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoCassa'), 'TipoCassa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_TipoCassa', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 146, 6), )
+    __TipoCassa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoCassa'), 'TipoCassa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_TipoCassa', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 146, 6), )
 
-
+    
     TipoCassa = property(__TipoCassa.value, __TipoCassa.set, None, None)
 
-
+    
     # Element AlCassa uses Python identifier AlCassa
-    __AlCassa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AlCassa'), 'AlCassa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_AlCassa', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 147, 6), )
+    __AlCassa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AlCassa'), 'AlCassa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_AlCassa', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 147, 6), )
 
-
+    
     AlCassa = property(__AlCassa.value, __AlCassa.set, None, None)
 
-
+    
     # Element ImportoContributoCassa uses Python identifier ImportoContributoCassa
-    __ImportoContributoCassa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoContributoCassa'), 'ImportoContributoCassa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_ImportoContributoCassa', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 148, 6), )
+    __ImportoContributoCassa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoContributoCassa'), 'ImportoContributoCassa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_ImportoContributoCassa', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 148, 6), )
 
-
+    
     ImportoContributoCassa = property(__ImportoContributoCassa.value, __ImportoContributoCassa.set, None, None)
 
-
+    
     # Element ImponibileCassa uses Python identifier ImponibileCassa
-    __ImponibileCassa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImponibileCassa'), 'ImponibileCassa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_ImponibileCassa', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 149, 6), )
+    __ImponibileCassa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImponibileCassa'), 'ImponibileCassa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_ImponibileCassa', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 149, 6), )
 
-
+    
     ImponibileCassa = property(__ImponibileCassa.value, __ImponibileCassa.set, None, None)
 
-
+    
     # Element AliquotaIVA uses Python identifier AliquotaIVA
-    __AliquotaIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), 'AliquotaIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_AliquotaIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 150, 6), )
+    __AliquotaIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), 'AliquotaIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_AliquotaIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 150, 6), )
 
-
+    
     AliquotaIVA = property(__AliquotaIVA.value, __AliquotaIVA.set, None, None)
 
-
+    
     # Element Ritenuta uses Python identifier Ritenuta
-    __Ritenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Ritenuta'), 'Ritenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_Ritenuta', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 151, 6), )
+    __Ritenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Ritenuta'), 'Ritenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_Ritenuta', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 151, 6), )
 
-
+    
     Ritenuta = property(__Ritenuta.value, __Ritenuta.set, None, None)
 
-
+    
     # Element Natura uses Python identifier Natura
-    __Natura = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Natura'), 'Natura', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_Natura', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 152, 6), )
+    __Natura = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Natura'), 'Natura', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_Natura', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 152, 6), )
 
-
+    
     Natura = property(__Natura.value, __Natura.set, None, None)
 
-
+    
     # Element RiferimentoAmministrazione uses Python identifier RiferimentoAmministrazione
-    __RiferimentoAmministrazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), 'RiferimentoAmministrazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_RiferimentoAmministrazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 153, 6), )
+    __RiferimentoAmministrazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), 'RiferimentoAmministrazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiCassaPrevidenzialeType_RiferimentoAmministrazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 153, 6), )
 
-
+    
     RiferimentoAmministrazione = property(__RiferimentoAmministrazione.value, __RiferimentoAmministrazione.set, None, None)
 
     _ElementMap.update({
@@ -1783,7 +1778,7 @@ class DatiCassaPrevidenzialeType (pyxb.binding.basis.complexTypeDefinition):
         __RiferimentoAmministrazione.name() : __RiferimentoAmministrazione
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiCassaPrevidenzialeType = DatiCassaPrevidenzialeType
 Namespace.addCategoryObject('typeBinding', 'DatiCassaPrevidenzialeType', DatiCassaPrevidenzialeType)
@@ -1796,29 +1791,29 @@ class ScontoMaggiorazioneType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ScontoMaggiorazioneType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 156, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 156, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element Tipo uses Python identifier Tipo
-    __Tipo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Tipo'), 'Tipo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ScontoMaggiorazioneType_Tipo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 158, 6), )
+    __Tipo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Tipo'), 'Tipo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ScontoMaggiorazioneType_Tipo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 158, 6), )
 
-
+    
     Tipo = property(__Tipo.value, __Tipo.set, None, None)
 
-
+    
     # Element Percentuale uses Python identifier Percentuale
-    __Percentuale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Percentuale'), 'Percentuale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ScontoMaggiorazioneType_Percentuale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 159, 6), )
+    __Percentuale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Percentuale'), 'Percentuale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ScontoMaggiorazioneType_Percentuale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 159, 6), )
 
-
+    
     Percentuale = property(__Percentuale.value, __Percentuale.set, None, None)
 
-
+    
     # Element Importo uses Python identifier Importo
-    __Importo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Importo'), 'Importo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ScontoMaggiorazioneType_Importo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 160, 6), )
+    __Importo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Importo'), 'Importo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ScontoMaggiorazioneType_Importo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 160, 6), )
 
-
+    
     Importo = property(__Importo.value, __Importo.set, None, None)
 
     _ElementMap.update({
@@ -1827,7 +1822,7 @@ class ScontoMaggiorazioneType (pyxb.binding.basis.complexTypeDefinition):
         __Importo.name() : __Importo
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.ScontoMaggiorazioneType = ScontoMaggiorazioneType
 Namespace.addCategoryObject('typeBinding', 'ScontoMaggiorazioneType', ScontoMaggiorazioneType)
@@ -1840,22 +1835,22 @@ class DatiSALType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiSALType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 468, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 473, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element RiferimentoFase uses Python identifier RiferimentoFase
-    __RiferimentoFase = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoFase'), 'RiferimentoFase', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiSALType_RiferimentoFase', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 470, 6), )
+    __RiferimentoFase = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoFase'), 'RiferimentoFase', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiSALType_RiferimentoFase', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 475, 6), )
 
-
+    
     RiferimentoFase = property(__RiferimentoFase.value, __RiferimentoFase.set, None, None)
 
     _ElementMap.update({
         __RiferimentoFase.name() : __RiferimentoFase
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiSALType = DatiSALType
 Namespace.addCategoryObject('typeBinding', 'DatiSALType', DatiSALType)
@@ -1868,57 +1863,57 @@ class DatiDocumentiCorrelatiType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiDocumentiCorrelatiType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 473, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 478, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element RiferimentoNumeroLinea uses Python identifier RiferimentoNumeroLinea
-    __RiferimentoNumeroLinea = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea'), 'RiferimentoNumeroLinea', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_RiferimentoNumeroLinea', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 475, 6), )
+    __RiferimentoNumeroLinea = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea'), 'RiferimentoNumeroLinea', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_RiferimentoNumeroLinea', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 480, 6), )
 
-
+    
     RiferimentoNumeroLinea = property(__RiferimentoNumeroLinea.value, __RiferimentoNumeroLinea.set, None, None)
 
-
+    
     # Element IdDocumento uses Python identifier IdDocumento
-    __IdDocumento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdDocumento'), 'IdDocumento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_IdDocumento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 476, 6), )
+    __IdDocumento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdDocumento'), 'IdDocumento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_IdDocumento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 481, 6), )
 
-
+    
     IdDocumento = property(__IdDocumento.value, __IdDocumento.set, None, None)
 
-
+    
     # Element Data uses Python identifier Data
-    __Data = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Data'), 'Data', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_Data', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 477, 6), )
+    __Data = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Data'), 'Data', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_Data', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 482, 6), )
 
-
+    
     Data = property(__Data.value, __Data.set, None, None)
 
-
+    
     # Element NumItem uses Python identifier NumItem
-    __NumItem = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumItem'), 'NumItem', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_NumItem', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 478, 6), )
+    __NumItem = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumItem'), 'NumItem', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_NumItem', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 483, 6), )
 
-
+    
     NumItem = property(__NumItem.value, __NumItem.set, None, None)
 
-
+    
     # Element CodiceCommessaConvenzione uses Python identifier CodiceCommessaConvenzione
-    __CodiceCommessaConvenzione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceCommessaConvenzione'), 'CodiceCommessaConvenzione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_CodiceCommessaConvenzione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 479, 6), )
+    __CodiceCommessaConvenzione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceCommessaConvenzione'), 'CodiceCommessaConvenzione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_CodiceCommessaConvenzione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 484, 6), )
 
-
+    
     CodiceCommessaConvenzione = property(__CodiceCommessaConvenzione.value, __CodiceCommessaConvenzione.set, None, None)
 
-
+    
     # Element CodiceCUP uses Python identifier CodiceCUP
-    __CodiceCUP = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceCUP'), 'CodiceCUP', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_CodiceCUP', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 480, 6), )
+    __CodiceCUP = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceCUP'), 'CodiceCUP', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_CodiceCUP', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 485, 6), )
 
-
+    
     CodiceCUP = property(__CodiceCUP.value, __CodiceCUP.set, None, None)
 
-
+    
     # Element CodiceCIG uses Python identifier CodiceCIG
-    __CodiceCIG = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceCIG'), 'CodiceCIG', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_CodiceCIG', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 481, 6), )
+    __CodiceCIG = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceCIG'), 'CodiceCIG', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDocumentiCorrelatiType_CodiceCIG', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 486, 6), )
 
-
+    
     CodiceCIG = property(__CodiceCIG.value, __CodiceCIG.set, None, None)
 
     _ElementMap.update({
@@ -1931,7 +1926,7 @@ class DatiDocumentiCorrelatiType (pyxb.binding.basis.complexTypeDefinition):
         __CodiceCIG.name() : __CodiceCIG
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiDocumentiCorrelatiType = DatiDocumentiCorrelatiType
 Namespace.addCategoryObject('typeBinding', 'DatiDocumentiCorrelatiType', DatiDocumentiCorrelatiType)
@@ -1944,29 +1939,29 @@ class DatiDDTType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiDDTType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 490, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 495, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element NumeroDDT uses Python identifier NumeroDDT
-    __NumeroDDT = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroDDT'), 'NumeroDDT', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDDTType_NumeroDDT', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 492, 6), )
+    __NumeroDDT = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroDDT'), 'NumeroDDT', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDDTType_NumeroDDT', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 497, 6), )
 
-
+    
     NumeroDDT = property(__NumeroDDT.value, __NumeroDDT.set, None, None)
 
-
+    
     # Element DataDDT uses Python identifier DataDDT
-    __DataDDT = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataDDT'), 'DataDDT', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDDTType_DataDDT', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 493, 6), )
+    __DataDDT = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataDDT'), 'DataDDT', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDDTType_DataDDT', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 498, 6), )
 
-
+    
     DataDDT = property(__DataDDT.value, __DataDDT.set, None, None)
 
-
+    
     # Element RiferimentoNumeroLinea uses Python identifier RiferimentoNumeroLinea
-    __RiferimentoNumeroLinea = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea'), 'RiferimentoNumeroLinea', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDDTType_RiferimentoNumeroLinea', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 494, 6), )
+    __RiferimentoNumeroLinea = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea'), 'RiferimentoNumeroLinea', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiDDTType_RiferimentoNumeroLinea', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 499, 6), )
 
-
+    
     RiferimentoNumeroLinea = property(__RiferimentoNumeroLinea.value, __RiferimentoNumeroLinea.set, None, None)
 
     _ElementMap.update({
@@ -1975,7 +1970,7 @@ class DatiDDTType (pyxb.binding.basis.complexTypeDefinition):
         __RiferimentoNumeroLinea.name() : __RiferimentoNumeroLinea
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiDDTType = DatiDDTType
 Namespace.addCategoryObject('typeBinding', 'DatiDDTType', DatiDDTType)
@@ -1988,99 +1983,99 @@ class DatiTrasportoType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiTrasportoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 497, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 502, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element DatiAnagraficiVettore uses Python identifier DatiAnagraficiVettore
-    __DatiAnagraficiVettore = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagraficiVettore'), 'DatiAnagraficiVettore', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_DatiAnagraficiVettore', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 499, 6), )
+    __DatiAnagraficiVettore = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagraficiVettore'), 'DatiAnagraficiVettore', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_DatiAnagraficiVettore', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 504, 6), )
 
-
+    
     DatiAnagraficiVettore = property(__DatiAnagraficiVettore.value, __DatiAnagraficiVettore.set, None, None)
 
-
+    
     # Element MezzoTrasporto uses Python identifier MezzoTrasporto
-    __MezzoTrasporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'MezzoTrasporto'), 'MezzoTrasporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_MezzoTrasporto', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 500, 6), )
+    __MezzoTrasporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'MezzoTrasporto'), 'MezzoTrasporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_MezzoTrasporto', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 505, 6), )
 
-
+    
     MezzoTrasporto = property(__MezzoTrasporto.value, __MezzoTrasporto.set, None, None)
 
-
+    
     # Element CausaleTrasporto uses Python identifier CausaleTrasporto
-    __CausaleTrasporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CausaleTrasporto'), 'CausaleTrasporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_CausaleTrasporto', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 501, 6), )
+    __CausaleTrasporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CausaleTrasporto'), 'CausaleTrasporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_CausaleTrasporto', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 506, 6), )
 
-
+    
     CausaleTrasporto = property(__CausaleTrasporto.value, __CausaleTrasporto.set, None, None)
 
-
+    
     # Element NumeroColli uses Python identifier NumeroColli
-    __NumeroColli = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroColli'), 'NumeroColli', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_NumeroColli', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 502, 6), )
+    __NumeroColli = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroColli'), 'NumeroColli', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_NumeroColli', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 507, 6), )
 
-
+    
     NumeroColli = property(__NumeroColli.value, __NumeroColli.set, None, None)
 
-
+    
     # Element Descrizione uses Python identifier Descrizione
-    __Descrizione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Descrizione'), 'Descrizione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_Descrizione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 503, 6), )
+    __Descrizione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Descrizione'), 'Descrizione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_Descrizione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 508, 6), )
 
-
+    
     Descrizione = property(__Descrizione.value, __Descrizione.set, None, None)
 
-
+    
     # Element UnitaMisuraPeso uses Python identifier UnitaMisuraPeso
-    __UnitaMisuraPeso = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'UnitaMisuraPeso'), 'UnitaMisuraPeso', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_UnitaMisuraPeso', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 504, 6), )
+    __UnitaMisuraPeso = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'UnitaMisuraPeso'), 'UnitaMisuraPeso', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_UnitaMisuraPeso', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 509, 6), )
 
-
+    
     UnitaMisuraPeso = property(__UnitaMisuraPeso.value, __UnitaMisuraPeso.set, None, None)
 
-
+    
     # Element PesoLordo uses Python identifier PesoLordo
-    __PesoLordo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PesoLordo'), 'PesoLordo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_PesoLordo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 505, 6), )
+    __PesoLordo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PesoLordo'), 'PesoLordo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_PesoLordo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 510, 6), )
 
-
+    
     PesoLordo = property(__PesoLordo.value, __PesoLordo.set, None, None)
 
-
+    
     # Element PesoNetto uses Python identifier PesoNetto
-    __PesoNetto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PesoNetto'), 'PesoNetto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_PesoNetto', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 506, 6), )
+    __PesoNetto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PesoNetto'), 'PesoNetto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_PesoNetto', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 511, 6), )
 
-
+    
     PesoNetto = property(__PesoNetto.value, __PesoNetto.set, None, None)
 
-
+    
     # Element DataOraRitiro uses Python identifier DataOraRitiro
-    __DataOraRitiro = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataOraRitiro'), 'DataOraRitiro', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_DataOraRitiro', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 507, 6), )
+    __DataOraRitiro = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataOraRitiro'), 'DataOraRitiro', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_DataOraRitiro', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 512, 6), )
 
-
+    
     DataOraRitiro = property(__DataOraRitiro.value, __DataOraRitiro.set, None, None)
 
-
+    
     # Element DataInizioTrasporto uses Python identifier DataInizioTrasporto
-    __DataInizioTrasporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataInizioTrasporto'), 'DataInizioTrasporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_DataInizioTrasporto', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 508, 6), )
+    __DataInizioTrasporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataInizioTrasporto'), 'DataInizioTrasporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_DataInizioTrasporto', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 513, 6), )
 
-
+    
     DataInizioTrasporto = property(__DataInizioTrasporto.value, __DataInizioTrasporto.set, None, None)
 
-
+    
     # Element TipoResa uses Python identifier TipoResa
-    __TipoResa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoResa'), 'TipoResa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_TipoResa', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 509, 6), )
+    __TipoResa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoResa'), 'TipoResa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_TipoResa', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 514, 6), )
 
-
+    
     TipoResa = property(__TipoResa.value, __TipoResa.set, None, None)
 
-
+    
     # Element IndirizzoResa uses Python identifier IndirizzoResa
-    __IndirizzoResa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IndirizzoResa'), 'IndirizzoResa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_IndirizzoResa', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 510, 6), )
+    __IndirizzoResa = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IndirizzoResa'), 'IndirizzoResa', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_IndirizzoResa', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 515, 6), )
 
-
+    
     IndirizzoResa = property(__IndirizzoResa.value, __IndirizzoResa.set, None, None)
 
-
+    
     # Element DataOraConsegna uses Python identifier DataOraConsegna
-    __DataOraConsegna = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataOraConsegna'), 'DataOraConsegna', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_DataOraConsegna', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 511, 6), )
+    __DataOraConsegna = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataOraConsegna'), 'DataOraConsegna', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiTrasportoType_DataOraConsegna', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 516, 6), )
 
-
+    
     DataOraConsegna = property(__DataOraConsegna.value, __DataOraConsegna.set, None, None)
 
     _ElementMap.update({
@@ -2099,7 +2094,7 @@ class DatiTrasportoType (pyxb.binding.basis.complexTypeDefinition):
         __DataOraConsegna.name() : __DataOraConsegna
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiTrasportoType = DatiTrasportoType
 Namespace.addCategoryObject('typeBinding', 'DatiTrasportoType', DatiTrasportoType)
@@ -2112,50 +2107,50 @@ class IndirizzoType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'IndirizzoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 514, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 519, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element Indirizzo uses Python identifier Indirizzo
-    __Indirizzo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Indirizzo'), 'Indirizzo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_Indirizzo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 516, 6), )
+    __Indirizzo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Indirizzo'), 'Indirizzo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_Indirizzo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 521, 6), )
 
-
+    
     Indirizzo = property(__Indirizzo.value, __Indirizzo.set, None, None)
 
-
+    
     # Element NumeroCivico uses Python identifier NumeroCivico
-    __NumeroCivico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroCivico'), 'NumeroCivico', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_NumeroCivico', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 517, 6), )
+    __NumeroCivico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroCivico'), 'NumeroCivico', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_NumeroCivico', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 522, 6), )
 
-
+    
     NumeroCivico = property(__NumeroCivico.value, __NumeroCivico.set, None, None)
 
-
+    
     # Element CAP uses Python identifier CAP
-    __CAP = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CAP'), 'CAP', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_CAP', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 518, 6), )
+    __CAP = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CAP'), 'CAP', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_CAP', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 523, 6), )
 
-
+    
     CAP = property(__CAP.value, __CAP.set, None, None)
 
-
+    
     # Element Comune uses Python identifier Comune
-    __Comune = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Comune'), 'Comune', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_Comune', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 519, 6), )
+    __Comune = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Comune'), 'Comune', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_Comune', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 524, 6), )
 
-
+    
     Comune = property(__Comune.value, __Comune.set, None, None)
 
-
+    
     # Element Provincia uses Python identifier Provincia
-    __Provincia = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Provincia'), 'Provincia', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_Provincia', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 520, 6), )
+    __Provincia = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Provincia'), 'Provincia', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_Provincia', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 525, 6), )
 
-
+    
     Provincia = property(__Provincia.value, __Provincia.set, None, None)
 
-
+    
     # Element Nazione uses Python identifier Nazione
-    __Nazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Nazione'), 'Nazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_Nazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 521, 6), )
+    __Nazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Nazione'), 'Nazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IndirizzoType_Nazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 526, 6), )
 
-
+    
     Nazione = property(__Nazione.value, __Nazione.set, None, None)
 
     _ElementMap.update({
@@ -2167,7 +2162,7 @@ class IndirizzoType (pyxb.binding.basis.complexTypeDefinition):
         __Nazione.name() : __Nazione
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.IndirizzoType = IndirizzoType
 Namespace.addCategoryObject('typeBinding', 'IndirizzoType', IndirizzoType)
@@ -2180,22 +2175,22 @@ class FatturaPrincipaleType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'FatturaPrincipaleType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 524, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 529, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element NumeroFatturaPrincipale uses Python identifier NumeroFatturaPrincipale
-    __NumeroFatturaPrincipale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroFatturaPrincipale'), 'NumeroFatturaPrincipale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaPrincipaleType_NumeroFatturaPrincipale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 526, 6), )
+    __NumeroFatturaPrincipale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroFatturaPrincipale'), 'NumeroFatturaPrincipale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaPrincipaleType_NumeroFatturaPrincipale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 531, 6), )
 
-
+    
     NumeroFatturaPrincipale = property(__NumeroFatturaPrincipale.value, __NumeroFatturaPrincipale.set, None, None)
 
-
+    
     # Element DataFatturaPrincipale uses Python identifier DataFatturaPrincipale
-    __DataFatturaPrincipale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataFatturaPrincipale'), 'DataFatturaPrincipale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaPrincipaleType_DataFatturaPrincipale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 527, 6), )
+    __DataFatturaPrincipale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataFatturaPrincipale'), 'DataFatturaPrincipale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaPrincipaleType_DataFatturaPrincipale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 532, 6), )
 
-
+    
     DataFatturaPrincipale = property(__DataFatturaPrincipale.value, __DataFatturaPrincipale.set, None, None)
 
     _ElementMap.update({
@@ -2203,7 +2198,7 @@ class FatturaPrincipaleType (pyxb.binding.basis.complexTypeDefinition):
         __DataFatturaPrincipale.name() : __DataFatturaPrincipale
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.FatturaPrincipaleType = FatturaPrincipaleType
 Namespace.addCategoryObject('typeBinding', 'FatturaPrincipaleType', FatturaPrincipaleType)
@@ -2216,50 +2211,50 @@ class CedentePrestatoreType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CedentePrestatoreType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 545, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 550, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element DatiAnagrafici uses Python identifier DatiAnagrafici
-    __DatiAnagrafici = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), 'DatiAnagrafici', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_DatiAnagrafici', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 550, 6), )
+    __DatiAnagrafici = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), 'DatiAnagrafici', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_DatiAnagrafici', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 555, 6), )
 
-
+    
     DatiAnagrafici = property(__DatiAnagrafici.value, __DatiAnagrafici.set, None, None)
 
-
+    
     # Element Sede uses Python identifier Sede
-    __Sede = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Sede'), 'Sede', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_Sede', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 551, 6), )
+    __Sede = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Sede'), 'Sede', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_Sede', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 556, 6), )
 
-
+    
     Sede = property(__Sede.value, __Sede.set, None, None)
 
-
+    
     # Element StabileOrganizzazione uses Python identifier StabileOrganizzazione
-    __StabileOrganizzazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione'), 'StabileOrganizzazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_StabileOrganizzazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 552, 6), )
+    __StabileOrganizzazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione'), 'StabileOrganizzazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_StabileOrganizzazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 557, 6), )
 
-
+    
     StabileOrganizzazione = property(__StabileOrganizzazione.value, __StabileOrganizzazione.set, None, None)
 
-
+    
     # Element IscrizioneREA uses Python identifier IscrizioneREA
-    __IscrizioneREA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IscrizioneREA'), 'IscrizioneREA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_IscrizioneREA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 553, 6), )
+    __IscrizioneREA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IscrizioneREA'), 'IscrizioneREA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_IscrizioneREA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 558, 6), )
 
-
+    
     IscrizioneREA = property(__IscrizioneREA.value, __IscrizioneREA.set, None, None)
 
-
+    
     # Element Contatti uses Python identifier Contatti
-    __Contatti = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Contatti'), 'Contatti', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_Contatti', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 554, 6), )
+    __Contatti = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Contatti'), 'Contatti', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_Contatti', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 559, 6), )
 
-
+    
     Contatti = property(__Contatti.value, __Contatti.set, None, None)
 
-
+    
     # Element RiferimentoAmministrazione uses Python identifier RiferimentoAmministrazione
-    __RiferimentoAmministrazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), 'RiferimentoAmministrazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_RiferimentoAmministrazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 555, 6), )
+    __RiferimentoAmministrazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), 'RiferimentoAmministrazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CedentePrestatoreType_RiferimentoAmministrazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 560, 6), )
 
-
+    
     RiferimentoAmministrazione = property(__RiferimentoAmministrazione.value, __RiferimentoAmministrazione.set, None, None)
 
     _ElementMap.update({
@@ -2271,7 +2266,7 @@ class CedentePrestatoreType (pyxb.binding.basis.complexTypeDefinition):
         __RiferimentoAmministrazione.name() : __RiferimentoAmministrazione
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.CedentePrestatoreType = CedentePrestatoreType
 Namespace.addCategoryObject('typeBinding', 'CedentePrestatoreType', CedentePrestatoreType)
@@ -2284,64 +2279,64 @@ class DatiAnagraficiCedenteType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiAnagraficiCedenteType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 558, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 563, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element IdFiscaleIVA uses Python identifier IdFiscaleIVA
-    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_IdFiscaleIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 560, 6), )
+    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_IdFiscaleIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 565, 6), )
 
-
+    
     IdFiscaleIVA = property(__IdFiscaleIVA.value, __IdFiscaleIVA.set, None, None)
 
-
+    
     # Element CodiceFiscale uses Python identifier CodiceFiscale
-    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_CodiceFiscale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 561, 6), )
+    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_CodiceFiscale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 566, 6), )
 
-
+    
     CodiceFiscale = property(__CodiceFiscale.value, __CodiceFiscale.set, None, None)
 
-
+    
     # Element Anagrafica uses Python identifier Anagrafica
-    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_Anagrafica', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 562, 6), )
+    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_Anagrafica', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 567, 6), )
 
-
+    
     Anagrafica = property(__Anagrafica.value, __Anagrafica.set, None, None)
 
-
+    
     # Element AlboProfessionale uses Python identifier AlboProfessionale
-    __AlboProfessionale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AlboProfessionale'), 'AlboProfessionale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_AlboProfessionale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 563, 6), )
+    __AlboProfessionale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AlboProfessionale'), 'AlboProfessionale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_AlboProfessionale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 568, 6), )
 
-
+    
     AlboProfessionale = property(__AlboProfessionale.value, __AlboProfessionale.set, None, None)
 
-
+    
     # Element ProvinciaAlbo uses Python identifier ProvinciaAlbo
-    __ProvinciaAlbo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ProvinciaAlbo'), 'ProvinciaAlbo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_ProvinciaAlbo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 564, 6), )
+    __ProvinciaAlbo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ProvinciaAlbo'), 'ProvinciaAlbo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_ProvinciaAlbo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 569, 6), )
 
-
+    
     ProvinciaAlbo = property(__ProvinciaAlbo.value, __ProvinciaAlbo.set, None, None)
 
-
+    
     # Element NumeroIscrizioneAlbo uses Python identifier NumeroIscrizioneAlbo
-    __NumeroIscrizioneAlbo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroIscrizioneAlbo'), 'NumeroIscrizioneAlbo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_NumeroIscrizioneAlbo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 565, 6), )
+    __NumeroIscrizioneAlbo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroIscrizioneAlbo'), 'NumeroIscrizioneAlbo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_NumeroIscrizioneAlbo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 570, 6), )
 
-
+    
     NumeroIscrizioneAlbo = property(__NumeroIscrizioneAlbo.value, __NumeroIscrizioneAlbo.set, None, None)
 
-
+    
     # Element DataIscrizioneAlbo uses Python identifier DataIscrizioneAlbo
-    __DataIscrizioneAlbo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataIscrizioneAlbo'), 'DataIscrizioneAlbo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_DataIscrizioneAlbo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 566, 6), )
+    __DataIscrizioneAlbo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataIscrizioneAlbo'), 'DataIscrizioneAlbo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_DataIscrizioneAlbo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 571, 6), )
 
-
+    
     DataIscrizioneAlbo = property(__DataIscrizioneAlbo.value, __DataIscrizioneAlbo.set, None, None)
 
-
+    
     # Element RegimeFiscale uses Python identifier RegimeFiscale
-    __RegimeFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RegimeFiscale'), 'RegimeFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_RegimeFiscale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 567, 6), )
+    __RegimeFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RegimeFiscale'), 'RegimeFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCedenteType_RegimeFiscale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 572, 6), )
 
-
+    
     RegimeFiscale = property(__RegimeFiscale.value, __RegimeFiscale.set, None, None)
 
     _ElementMap.update({
@@ -2355,7 +2350,7 @@ class DatiAnagraficiCedenteType (pyxb.binding.basis.complexTypeDefinition):
         __RegimeFiscale.name() : __RegimeFiscale
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiAnagraficiCedenteType = DatiAnagraficiCedenteType
 Namespace.addCategoryObject('typeBinding', 'DatiAnagraficiCedenteType', DatiAnagraficiCedenteType)
@@ -2368,43 +2363,43 @@ class AnagraficaType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'AnagraficaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 665, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 670, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element Denominazione uses Python identifier Denominazione
-    __Denominazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Denominazione'), 'Denominazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_Denominazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 672, 10), )
+    __Denominazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Denominazione'), 'Denominazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_Denominazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 677, 10), )
 
-
+    
     Denominazione = property(__Denominazione.value, __Denominazione.set, None, None)
 
-
+    
     # Element Nome uses Python identifier Nome
-    __Nome = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Nome'), 'Nome', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_Nome', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 675, 10), )
+    __Nome = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Nome'), 'Nome', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_Nome', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 680, 10), )
 
-
+    
     Nome = property(__Nome.value, __Nome.set, None, None)
 
-
+    
     # Element Cognome uses Python identifier Cognome
-    __Cognome = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Cognome'), 'Cognome', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_Cognome', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 676, 10), )
+    __Cognome = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Cognome'), 'Cognome', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_Cognome', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 681, 10), )
 
-
+    
     Cognome = property(__Cognome.value, __Cognome.set, None, None)
 
-
+    
     # Element Titolo uses Python identifier Titolo
-    __Titolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Titolo'), 'Titolo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_Titolo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 679, 6), )
+    __Titolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Titolo'), 'Titolo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_Titolo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 684, 6), )
 
-
+    
     Titolo = property(__Titolo.value, __Titolo.set, None, None)
 
-
+    
     # Element CodEORI uses Python identifier CodEORI
-    __CodEORI = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodEORI'), 'CodEORI', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_CodEORI', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 680, 6), )
+    __CodEORI = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodEORI'), 'CodEORI', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AnagraficaType_CodEORI', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 685, 6), )
 
-
+    
     CodEORI = property(__CodEORI.value, __CodEORI.set, None, None)
 
     _ElementMap.update({
@@ -2415,7 +2410,7 @@ class AnagraficaType (pyxb.binding.basis.complexTypeDefinition):
         __CodEORI.name() : __CodEORI
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.AnagraficaType = AnagraficaType
 Namespace.addCategoryObject('typeBinding', 'AnagraficaType', AnagraficaType)
@@ -2428,36 +2423,36 @@ class DatiAnagraficiVettoreType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiAnagraficiVettoreType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 683, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 688, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element IdFiscaleIVA uses Python identifier IdFiscaleIVA
-    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiVettoreType_IdFiscaleIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 685, 6), )
+    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiVettoreType_IdFiscaleIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 690, 6), )
 
-
+    
     IdFiscaleIVA = property(__IdFiscaleIVA.value, __IdFiscaleIVA.set, None, None)
 
-
+    
     # Element CodiceFiscale uses Python identifier CodiceFiscale
-    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiVettoreType_CodiceFiscale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 686, 6), )
+    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiVettoreType_CodiceFiscale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 691, 6), )
 
-
+    
     CodiceFiscale = property(__CodiceFiscale.value, __CodiceFiscale.set, None, None)
 
-
+    
     # Element Anagrafica uses Python identifier Anagrafica
-    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiVettoreType_Anagrafica', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 687, 6), )
+    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiVettoreType_Anagrafica', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 692, 6), )
 
-
+    
     Anagrafica = property(__Anagrafica.value, __Anagrafica.set, None, None)
 
-
+    
     # Element NumeroLicenzaGuida uses Python identifier NumeroLicenzaGuida
-    __NumeroLicenzaGuida = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroLicenzaGuida'), 'NumeroLicenzaGuida', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiVettoreType_NumeroLicenzaGuida', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 688, 6), )
+    __NumeroLicenzaGuida = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroLicenzaGuida'), 'NumeroLicenzaGuida', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiVettoreType_NumeroLicenzaGuida', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 693, 6), )
 
-
+    
     NumeroLicenzaGuida = property(__NumeroLicenzaGuida.value, __NumeroLicenzaGuida.set, None, None)
 
     _ElementMap.update({
@@ -2467,7 +2462,7 @@ class DatiAnagraficiVettoreType (pyxb.binding.basis.complexTypeDefinition):
         __NumeroLicenzaGuida.name() : __NumeroLicenzaGuida
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiAnagraficiVettoreType = DatiAnagraficiVettoreType
 Namespace.addCategoryObject('typeBinding', 'DatiAnagraficiVettoreType', DatiAnagraficiVettoreType)
@@ -2480,43 +2475,43 @@ class IscrizioneREAType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'IscrizioneREAType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 691, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 696, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element Ufficio uses Python identifier Ufficio
-    __Ufficio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Ufficio'), 'Ufficio', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_Ufficio', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 693, 6), )
+    __Ufficio = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Ufficio'), 'Ufficio', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_Ufficio', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 698, 6), )
 
-
+    
     Ufficio = property(__Ufficio.value, __Ufficio.set, None, None)
 
-
+    
     # Element NumeroREA uses Python identifier NumeroREA
-    __NumeroREA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroREA'), 'NumeroREA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_NumeroREA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 694, 6), )
+    __NumeroREA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroREA'), 'NumeroREA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_NumeroREA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 699, 6), )
 
-
+    
     NumeroREA = property(__NumeroREA.value, __NumeroREA.set, None, None)
 
-
+    
     # Element CapitaleSociale uses Python identifier CapitaleSociale
-    __CapitaleSociale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CapitaleSociale'), 'CapitaleSociale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_CapitaleSociale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 695, 6), )
+    __CapitaleSociale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CapitaleSociale'), 'CapitaleSociale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_CapitaleSociale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 700, 6), )
 
-
+    
     CapitaleSociale = property(__CapitaleSociale.value, __CapitaleSociale.set, None, None)
 
-
+    
     # Element SocioUnico uses Python identifier SocioUnico
-    __SocioUnico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'SocioUnico'), 'SocioUnico', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_SocioUnico', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 696, 6), )
+    __SocioUnico = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'SocioUnico'), 'SocioUnico', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_SocioUnico', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 701, 6), )
 
-
+    
     SocioUnico = property(__SocioUnico.value, __SocioUnico.set, None, None)
 
-
+    
     # Element StatoLiquidazione uses Python identifier StatoLiquidazione
-    __StatoLiquidazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'StatoLiquidazione'), 'StatoLiquidazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_StatoLiquidazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 697, 6), )
+    __StatoLiquidazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'StatoLiquidazione'), 'StatoLiquidazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_IscrizioneREAType_StatoLiquidazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 702, 6), )
 
-
+    
     StatoLiquidazione = property(__StatoLiquidazione.value, __StatoLiquidazione.set, None, None)
 
     _ElementMap.update({
@@ -2527,7 +2522,7 @@ class IscrizioneREAType (pyxb.binding.basis.complexTypeDefinition):
         __StatoLiquidazione.name() : __StatoLiquidazione
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.IscrizioneREAType = IscrizioneREAType
 Namespace.addCategoryObject('typeBinding', 'IscrizioneREAType', IscrizioneREAType)
@@ -2540,29 +2535,29 @@ class ContattiType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'ContattiType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 700, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 705, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element Telefono uses Python identifier Telefono
-    __Telefono = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Telefono'), 'Telefono', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiType_Telefono', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 702, 6), )
+    __Telefono = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Telefono'), 'Telefono', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiType_Telefono', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 707, 6), )
 
-
+    
     Telefono = property(__Telefono.value, __Telefono.set, None, None)
 
-
+    
     # Element Fax uses Python identifier Fax
-    __Fax = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Fax'), 'Fax', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiType_Fax', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 703, 6), )
+    __Fax = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Fax'), 'Fax', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiType_Fax', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 708, 6), )
 
-
+    
     Fax = property(__Fax.value, __Fax.set, None, None)
 
-
+    
     # Element Email uses Python identifier Email
-    __Email = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Email'), 'Email', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiType_Email', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 704, 6), )
+    __Email = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Email'), 'Email', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_ContattiType_Email', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 709, 6), )
 
-
+    
     Email = property(__Email.value, __Email.set, None, None)
 
     _ElementMap.update({
@@ -2571,7 +2566,7 @@ class ContattiType (pyxb.binding.basis.complexTypeDefinition):
         __Email.name() : __Email
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.ContattiType = ContattiType
 Namespace.addCategoryObject('typeBinding', 'ContattiType', ContattiType)
@@ -2584,22 +2579,22 @@ class RappresentanteFiscaleType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RappresentanteFiscaleType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 707, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 712, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element DatiAnagrafici uses Python identifier DatiAnagrafici
-    __DatiAnagrafici = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), 'DatiAnagrafici', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleType_DatiAnagrafici', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 712, 6), )
+    __DatiAnagrafici = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), 'DatiAnagrafici', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleType_DatiAnagrafici', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 717, 6), )
 
-
+    
     DatiAnagrafici = property(__DatiAnagrafici.value, __DatiAnagrafici.set, None, None)
 
     _ElementMap.update({
         __DatiAnagrafici.name() : __DatiAnagrafici
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.RappresentanteFiscaleType = RappresentanteFiscaleType
 Namespace.addCategoryObject('typeBinding', 'RappresentanteFiscaleType', RappresentanteFiscaleType)
@@ -2612,29 +2607,29 @@ class DatiAnagraficiRappresentanteType (pyxb.binding.basis.complexTypeDefinition
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiAnagraficiRappresentanteType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 715, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 720, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element IdFiscaleIVA uses Python identifier IdFiscaleIVA
-    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiRappresentanteType_IdFiscaleIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 717, 6), )
+    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiRappresentanteType_IdFiscaleIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 722, 6), )
 
-
+    
     IdFiscaleIVA = property(__IdFiscaleIVA.value, __IdFiscaleIVA.set, None, None)
 
-
+    
     # Element CodiceFiscale uses Python identifier CodiceFiscale
-    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiRappresentanteType_CodiceFiscale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 718, 6), )
+    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiRappresentanteType_CodiceFiscale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 723, 6), )
 
-
+    
     CodiceFiscale = property(__CodiceFiscale.value, __CodiceFiscale.set, None, None)
 
-
+    
     # Element Anagrafica uses Python identifier Anagrafica
-    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiRappresentanteType_Anagrafica', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 719, 6), )
+    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiRappresentanteType_Anagrafica', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 724, 6), )
 
-
+    
     Anagrafica = property(__Anagrafica.value, __Anagrafica.set, None, None)
 
     _ElementMap.update({
@@ -2643,7 +2638,7 @@ class DatiAnagraficiRappresentanteType (pyxb.binding.basis.complexTypeDefinition
         __Anagrafica.name() : __Anagrafica
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiAnagraficiRappresentanteType = DatiAnagraficiRappresentanteType
 Namespace.addCategoryObject('typeBinding', 'DatiAnagraficiRappresentanteType', DatiAnagraficiRappresentanteType)
@@ -2656,36 +2651,36 @@ class CessionarioCommittenteType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CessionarioCommittenteType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 722, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 727, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element DatiAnagrafici uses Python identifier DatiAnagrafici
-    __DatiAnagrafici = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), 'DatiAnagrafici', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CessionarioCommittenteType_DatiAnagrafici', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 727, 6), )
+    __DatiAnagrafici = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), 'DatiAnagrafici', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CessionarioCommittenteType_DatiAnagrafici', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 732, 6), )
 
-
+    
     DatiAnagrafici = property(__DatiAnagrafici.value, __DatiAnagrafici.set, None, None)
 
-
+    
     # Element Sede uses Python identifier Sede
-    __Sede = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Sede'), 'Sede', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CessionarioCommittenteType_Sede', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 728, 6), )
+    __Sede = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Sede'), 'Sede', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CessionarioCommittenteType_Sede', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 733, 6), )
 
-
+    
     Sede = property(__Sede.value, __Sede.set, None, None)
 
-
+    
     # Element StabileOrganizzazione uses Python identifier StabileOrganizzazione
-    __StabileOrganizzazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione'), 'StabileOrganizzazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CessionarioCommittenteType_StabileOrganizzazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 729, 3), )
+    __StabileOrganizzazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione'), 'StabileOrganizzazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CessionarioCommittenteType_StabileOrganizzazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 734, 3), )
 
-
+    
     StabileOrganizzazione = property(__StabileOrganizzazione.value, __StabileOrganizzazione.set, None, None)
 
-
+    
     # Element RappresentanteFiscale uses Python identifier RappresentanteFiscale
-    __RappresentanteFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale'), 'RappresentanteFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CessionarioCommittenteType_RappresentanteFiscale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 730, 6), )
+    __RappresentanteFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale'), 'RappresentanteFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CessionarioCommittenteType_RappresentanteFiscale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 735, 6), )
 
-
+    
     RappresentanteFiscale = property(__RappresentanteFiscale.value, __RappresentanteFiscale.set, None, None)
 
     _ElementMap.update({
@@ -2695,7 +2690,7 @@ class CessionarioCommittenteType (pyxb.binding.basis.complexTypeDefinition):
         __RappresentanteFiscale.name() : __RappresentanteFiscale
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.CessionarioCommittenteType = CessionarioCommittenteType
 Namespace.addCategoryObject('typeBinding', 'CessionarioCommittenteType', CessionarioCommittenteType)
@@ -2708,36 +2703,36 @@ class RappresentanteFiscaleCessionarioType (pyxb.binding.basis.complexTypeDefini
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'RappresentanteFiscaleCessionarioType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 733, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 738, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element IdFiscaleIVA uses Python identifier IdFiscaleIVA
-    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleCessionarioType_IdFiscaleIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 735, 3), )
+    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleCessionarioType_IdFiscaleIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 740, 3), )
 
-
+    
     IdFiscaleIVA = property(__IdFiscaleIVA.value, __IdFiscaleIVA.set, None, None)
 
-
+    
     # Element Denominazione uses Python identifier Denominazione
-    __Denominazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Denominazione'), 'Denominazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleCessionarioType_Denominazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 738, 10), )
+    __Denominazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Denominazione'), 'Denominazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleCessionarioType_Denominazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 743, 10), )
 
-
+    
     Denominazione = property(__Denominazione.value, __Denominazione.set, None, None)
 
-
+    
     # Element Nome uses Python identifier Nome
-    __Nome = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Nome'), 'Nome', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleCessionarioType_Nome', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 741, 10), )
+    __Nome = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Nome'), 'Nome', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleCessionarioType_Nome', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 746, 10), )
 
-
+    
     Nome = property(__Nome.value, __Nome.set, None, None)
 
-
+    
     # Element Cognome uses Python identifier Cognome
-    __Cognome = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Cognome'), 'Cognome', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleCessionarioType_Cognome', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 742, 10), )
+    __Cognome = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Cognome'), 'Cognome', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_RappresentanteFiscaleCessionarioType_Cognome', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 747, 10), )
 
-
+    
     Cognome = property(__Cognome.value, __Cognome.set, None, None)
 
     _ElementMap.update({
@@ -2747,7 +2742,7 @@ class RappresentanteFiscaleCessionarioType (pyxb.binding.basis.complexTypeDefini
         __Cognome.name() : __Cognome
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.RappresentanteFiscaleCessionarioType = RappresentanteFiscaleCessionarioType
 Namespace.addCategoryObject('typeBinding', 'RappresentanteFiscaleCessionarioType', RappresentanteFiscaleCessionarioType)
@@ -2760,29 +2755,29 @@ class DatiAnagraficiCessionarioType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiAnagraficiCessionarioType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 747, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 752, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element IdFiscaleIVA uses Python identifier IdFiscaleIVA
-    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCessionarioType_IdFiscaleIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 749, 6), )
+    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCessionarioType_IdFiscaleIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 754, 6), )
 
-
+    
     IdFiscaleIVA = property(__IdFiscaleIVA.value, __IdFiscaleIVA.set, None, None)
 
-
+    
     # Element CodiceFiscale uses Python identifier CodiceFiscale
-    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCessionarioType_CodiceFiscale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 750, 6), )
+    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCessionarioType_CodiceFiscale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 755, 6), )
 
-
+    
     CodiceFiscale = property(__CodiceFiscale.value, __CodiceFiscale.set, None, None)
 
-
+    
     # Element Anagrafica uses Python identifier Anagrafica
-    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCessionarioType_Anagrafica', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 751, 6), )
+    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiCessionarioType_Anagrafica', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 756, 6), )
 
-
+    
     Anagrafica = property(__Anagrafica.value, __Anagrafica.set, None, None)
 
     _ElementMap.update({
@@ -2791,7 +2786,7 @@ class DatiAnagraficiCessionarioType (pyxb.binding.basis.complexTypeDefinition):
         __Anagrafica.name() : __Anagrafica
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiAnagraficiCessionarioType = DatiAnagraficiCessionarioType
 Namespace.addCategoryObject('typeBinding', 'DatiAnagraficiCessionarioType', DatiAnagraficiCessionarioType)
@@ -2804,22 +2799,22 @@ class DatiBeniServiziType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiBeniServiziType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 754, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 759, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element DettaglioLinee uses Python identifier DettaglioLinee
-    __DettaglioLinee = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DettaglioLinee'), 'DettaglioLinee', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiBeniServiziType_DettaglioLinee', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 759, 6), )
+    __DettaglioLinee = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DettaglioLinee'), 'DettaglioLinee', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiBeniServiziType_DettaglioLinee', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 764, 6), )
 
-
+    
     DettaglioLinee = property(__DettaglioLinee.value, __DettaglioLinee.set, None, None)
 
-
+    
     # Element DatiRiepilogo uses Python identifier DatiRiepilogo
-    __DatiRiepilogo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiRiepilogo'), 'DatiRiepilogo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiBeniServiziType_DatiRiepilogo', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 760, 6), )
+    __DatiRiepilogo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiRiepilogo'), 'DatiRiepilogo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiBeniServiziType_DatiRiepilogo', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 765, 6), )
 
-
+    
     DatiRiepilogo = property(__DatiRiepilogo.value, __DatiRiepilogo.set, None, None)
 
     _ElementMap.update({
@@ -2827,7 +2822,7 @@ class DatiBeniServiziType (pyxb.binding.basis.complexTypeDefinition):
         __DatiRiepilogo.name() : __DatiRiepilogo
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiBeniServiziType = DatiBeniServiziType
 Namespace.addCategoryObject('typeBinding', 'DatiBeniServiziType', DatiBeniServiziType)
@@ -2841,22 +2836,22 @@ class DatiVeicoliType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiVeicoliType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 763, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 768, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element Data uses Python identifier Data
-    __Data = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Data'), 'Data', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiVeicoliType_Data', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 769, 6), )
+    __Data = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Data'), 'Data', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiVeicoliType_Data', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 774, 6), )
 
-
+    
     Data = property(__Data.value, __Data.set, None, None)
 
-
+    
     # Element TotalePercorso uses Python identifier TotalePercorso
-    __TotalePercorso = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TotalePercorso'), 'TotalePercorso', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiVeicoliType_TotalePercorso', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 770, 6), )
+    __TotalePercorso = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TotalePercorso'), 'TotalePercorso', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiVeicoliType_TotalePercorso', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 775, 6), )
 
-
+    
     TotalePercorso = property(__TotalePercorso.value, __TotalePercorso.set, None, None)
 
     _ElementMap.update({
@@ -2864,7 +2859,7 @@ class DatiVeicoliType (pyxb.binding.basis.complexTypeDefinition):
         __TotalePercorso.name() : __TotalePercorso
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiVeicoliType = DatiVeicoliType
 Namespace.addCategoryObject('typeBinding', 'DatiVeicoliType', DatiVeicoliType)
@@ -2877,22 +2872,22 @@ class DatiPagamentoType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiPagamentoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 773, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 778, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element CondizioniPagamento uses Python identifier CondizioniPagamento
-    __CondizioniPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CondizioniPagamento'), 'CondizioniPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiPagamentoType_CondizioniPagamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 778, 6), )
+    __CondizioniPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CondizioniPagamento'), 'CondizioniPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiPagamentoType_CondizioniPagamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 783, 6), )
 
-
+    
     CondizioniPagamento = property(__CondizioniPagamento.value, __CondizioniPagamento.set, None, None)
 
-
+    
     # Element DettaglioPagamento uses Python identifier DettaglioPagamento
-    __DettaglioPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DettaglioPagamento'), 'DettaglioPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiPagamentoType_DettaglioPagamento', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 779, 6), )
+    __DettaglioPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DettaglioPagamento'), 'DettaglioPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiPagamentoType_DettaglioPagamento', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 784, 6), )
 
-
+    
     DettaglioPagamento = property(__DettaglioPagamento.value, __DettaglioPagamento.set, None, None)
 
     _ElementMap.update({
@@ -2900,7 +2895,7 @@ class DatiPagamentoType (pyxb.binding.basis.complexTypeDefinition):
         __DettaglioPagamento.name() : __DettaglioPagamento
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiPagamentoType = DatiPagamentoType
 Namespace.addCategoryObject('typeBinding', 'DatiPagamentoType', DatiPagamentoType)
@@ -2913,155 +2908,155 @@ class DettaglioPagamentoType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DettaglioPagamentoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 803, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 808, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element Beneficiario uses Python identifier Beneficiario
-    __Beneficiario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Beneficiario'), 'Beneficiario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_Beneficiario', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 805, 6), )
+    __Beneficiario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Beneficiario'), 'Beneficiario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_Beneficiario', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 810, 6), )
 
-
+    
     Beneficiario = property(__Beneficiario.value, __Beneficiario.set, None, None)
 
-
+    
     # Element ModalitaPagamento uses Python identifier ModalitaPagamento
-    __ModalitaPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ModalitaPagamento'), 'ModalitaPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_ModalitaPagamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 806, 6), )
+    __ModalitaPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ModalitaPagamento'), 'ModalitaPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_ModalitaPagamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 811, 6), )
 
-
+    
     ModalitaPagamento = property(__ModalitaPagamento.value, __ModalitaPagamento.set, None, None)
 
-
+    
     # Element DataRiferimentoTerminiPagamento uses Python identifier DataRiferimentoTerminiPagamento
-    __DataRiferimentoTerminiPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataRiferimentoTerminiPagamento'), 'DataRiferimentoTerminiPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_DataRiferimentoTerminiPagamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 807, 6), )
+    __DataRiferimentoTerminiPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataRiferimentoTerminiPagamento'), 'DataRiferimentoTerminiPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_DataRiferimentoTerminiPagamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 812, 6), )
 
-
+    
     DataRiferimentoTerminiPagamento = property(__DataRiferimentoTerminiPagamento.value, __DataRiferimentoTerminiPagamento.set, None, None)
 
-
+    
     # Element GiorniTerminiPagamento uses Python identifier GiorniTerminiPagamento
-    __GiorniTerminiPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'GiorniTerminiPagamento'), 'GiorniTerminiPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_GiorniTerminiPagamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 808, 6), )
+    __GiorniTerminiPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'GiorniTerminiPagamento'), 'GiorniTerminiPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_GiorniTerminiPagamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 813, 6), )
 
-
+    
     GiorniTerminiPagamento = property(__GiorniTerminiPagamento.value, __GiorniTerminiPagamento.set, None, None)
 
-
+    
     # Element DataScadenzaPagamento uses Python identifier DataScadenzaPagamento
-    __DataScadenzaPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataScadenzaPagamento'), 'DataScadenzaPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_DataScadenzaPagamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 809, 6), )
+    __DataScadenzaPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataScadenzaPagamento'), 'DataScadenzaPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_DataScadenzaPagamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 814, 6), )
 
-
+    
     DataScadenzaPagamento = property(__DataScadenzaPagamento.value, __DataScadenzaPagamento.set, None, None)
 
-
+    
     # Element ImportoPagamento uses Python identifier ImportoPagamento
-    __ImportoPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoPagamento'), 'ImportoPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_ImportoPagamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 810, 6), )
+    __ImportoPagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImportoPagamento'), 'ImportoPagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_ImportoPagamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 815, 6), )
 
-
+    
     ImportoPagamento = property(__ImportoPagamento.value, __ImportoPagamento.set, None, None)
 
-
+    
     # Element CodUfficioPostale uses Python identifier CodUfficioPostale
-    __CodUfficioPostale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodUfficioPostale'), 'CodUfficioPostale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CodUfficioPostale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 811, 6), )
+    __CodUfficioPostale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodUfficioPostale'), 'CodUfficioPostale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CodUfficioPostale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 816, 6), )
 
-
+    
     CodUfficioPostale = property(__CodUfficioPostale.value, __CodUfficioPostale.set, None, None)
 
-
+    
     # Element CognomeQuietanzante uses Python identifier CognomeQuietanzante
-    __CognomeQuietanzante = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CognomeQuietanzante'), 'CognomeQuietanzante', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CognomeQuietanzante', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 812, 6), )
+    __CognomeQuietanzante = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CognomeQuietanzante'), 'CognomeQuietanzante', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CognomeQuietanzante', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 817, 6), )
 
-
+    
     CognomeQuietanzante = property(__CognomeQuietanzante.value, __CognomeQuietanzante.set, None, None)
 
-
+    
     # Element NomeQuietanzante uses Python identifier NomeQuietanzante
-    __NomeQuietanzante = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NomeQuietanzante'), 'NomeQuietanzante', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_NomeQuietanzante', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 813, 6), )
+    __NomeQuietanzante = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NomeQuietanzante'), 'NomeQuietanzante', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_NomeQuietanzante', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 818, 6), )
 
-
+    
     NomeQuietanzante = property(__NomeQuietanzante.value, __NomeQuietanzante.set, None, None)
 
-
+    
     # Element CFQuietanzante uses Python identifier CFQuietanzante
-    __CFQuietanzante = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CFQuietanzante'), 'CFQuietanzante', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CFQuietanzante', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 814, 6), )
+    __CFQuietanzante = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CFQuietanzante'), 'CFQuietanzante', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CFQuietanzante', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 819, 6), )
 
-
+    
     CFQuietanzante = property(__CFQuietanzante.value, __CFQuietanzante.set, None, None)
 
-
+    
     # Element TitoloQuietanzante uses Python identifier TitoloQuietanzante
-    __TitoloQuietanzante = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TitoloQuietanzante'), 'TitoloQuietanzante', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_TitoloQuietanzante', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 815, 6), )
+    __TitoloQuietanzante = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TitoloQuietanzante'), 'TitoloQuietanzante', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_TitoloQuietanzante', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 820, 6), )
 
-
+    
     TitoloQuietanzante = property(__TitoloQuietanzante.value, __TitoloQuietanzante.set, None, None)
 
-
+    
     # Element IstitutoFinanziario uses Python identifier IstitutoFinanziario
-    __IstitutoFinanziario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IstitutoFinanziario'), 'IstitutoFinanziario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_IstitutoFinanziario', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 816, 6), )
+    __IstitutoFinanziario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IstitutoFinanziario'), 'IstitutoFinanziario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_IstitutoFinanziario', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 821, 6), )
 
-
+    
     IstitutoFinanziario = property(__IstitutoFinanziario.value, __IstitutoFinanziario.set, None, None)
 
-
+    
     # Element IBAN uses Python identifier IBAN
-    __IBAN = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IBAN'), 'IBAN', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_IBAN', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 817, 6), )
+    __IBAN = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IBAN'), 'IBAN', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_IBAN', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 822, 6), )
 
-
+    
     IBAN = property(__IBAN.value, __IBAN.set, None, None)
 
-
+    
     # Element ABI uses Python identifier ABI
-    __ABI = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ABI'), 'ABI', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_ABI', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 818, 6), )
+    __ABI = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ABI'), 'ABI', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_ABI', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 823, 6), )
 
-
+    
     ABI = property(__ABI.value, __ABI.set, None, None)
 
-
+    
     # Element CAB uses Python identifier CAB
-    __CAB = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CAB'), 'CAB', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CAB', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 819, 6), )
+    __CAB = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CAB'), 'CAB', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CAB', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 824, 6), )
 
-
+    
     CAB = property(__CAB.value, __CAB.set, None, None)
 
-
+    
     # Element BIC uses Python identifier BIC
-    __BIC = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'BIC'), 'BIC', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_BIC', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 820, 6), )
+    __BIC = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'BIC'), 'BIC', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_BIC', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 825, 6), )
 
-
+    
     BIC = property(__BIC.value, __BIC.set, None, None)
 
-
+    
     # Element ScontoPagamentoAnticipato uses Python identifier ScontoPagamentoAnticipato
-    __ScontoPagamentoAnticipato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ScontoPagamentoAnticipato'), 'ScontoPagamentoAnticipato', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_ScontoPagamentoAnticipato', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 821, 6), )
+    __ScontoPagamentoAnticipato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ScontoPagamentoAnticipato'), 'ScontoPagamentoAnticipato', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_ScontoPagamentoAnticipato', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 826, 6), )
 
-
+    
     ScontoPagamentoAnticipato = property(__ScontoPagamentoAnticipato.value, __ScontoPagamentoAnticipato.set, None, None)
 
-
+    
     # Element DataLimitePagamentoAnticipato uses Python identifier DataLimitePagamentoAnticipato
-    __DataLimitePagamentoAnticipato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataLimitePagamentoAnticipato'), 'DataLimitePagamentoAnticipato', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_DataLimitePagamentoAnticipato', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 822, 6), )
+    __DataLimitePagamentoAnticipato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataLimitePagamentoAnticipato'), 'DataLimitePagamentoAnticipato', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_DataLimitePagamentoAnticipato', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 827, 6), )
 
-
+    
     DataLimitePagamentoAnticipato = property(__DataLimitePagamentoAnticipato.value, __DataLimitePagamentoAnticipato.set, None, None)
 
-
+    
     # Element PenalitaPagamentiRitardati uses Python identifier PenalitaPagamentiRitardati
-    __PenalitaPagamentiRitardati = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PenalitaPagamentiRitardati'), 'PenalitaPagamentiRitardati', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_PenalitaPagamentiRitardati', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 823, 6), )
+    __PenalitaPagamentiRitardati = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PenalitaPagamentiRitardati'), 'PenalitaPagamentiRitardati', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_PenalitaPagamentiRitardati', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 828, 6), )
 
-
+    
     PenalitaPagamentiRitardati = property(__PenalitaPagamentiRitardati.value, __PenalitaPagamentiRitardati.set, None, None)
 
-
+    
     # Element DataDecorrenzaPenale uses Python identifier DataDecorrenzaPenale
-    __DataDecorrenzaPenale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataDecorrenzaPenale'), 'DataDecorrenzaPenale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_DataDecorrenzaPenale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 824, 6), )
+    __DataDecorrenzaPenale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataDecorrenzaPenale'), 'DataDecorrenzaPenale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_DataDecorrenzaPenale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 829, 6), )
 
-
+    
     DataDecorrenzaPenale = property(__DataDecorrenzaPenale.value, __DataDecorrenzaPenale.set, None, None)
 
-
+    
     # Element CodicePagamento uses Python identifier CodicePagamento
-    __CodicePagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodicePagamento'), 'CodicePagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CodicePagamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 825, 6), )
+    __CodicePagamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodicePagamento'), 'CodicePagamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioPagamentoType_CodicePagamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 830, 6), )
 
-
+    
     CodicePagamento = property(__CodicePagamento.value, __CodicePagamento.set, None, None)
 
     _ElementMap.update({
@@ -3088,7 +3083,7 @@ class DettaglioPagamentoType (pyxb.binding.basis.complexTypeDefinition):
         __CodicePagamento.name() : __CodicePagamento
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DettaglioPagamentoType = DettaglioPagamentoType
 Namespace.addCategoryObject('typeBinding', 'DettaglioPagamentoType', DettaglioPagamentoType)
@@ -3101,22 +3096,22 @@ class TerzoIntermediarioSoggettoEmittenteType (pyxb.binding.basis.complexTypeDef
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'TerzoIntermediarioSoggettoEmittenteType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 958, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 963, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element DatiAnagrafici uses Python identifier DatiAnagrafici
-    __DatiAnagrafici = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), 'DatiAnagrafici', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_TerzoIntermediarioSoggettoEmittenteType_DatiAnagrafici', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 963, 6), )
+    __DatiAnagrafici = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), 'DatiAnagrafici', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_TerzoIntermediarioSoggettoEmittenteType_DatiAnagrafici', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 968, 6), )
 
-
+    
     DatiAnagrafici = property(__DatiAnagrafici.value, __DatiAnagrafici.set, None, None)
 
     _ElementMap.update({
         __DatiAnagrafici.name() : __DatiAnagrafici
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.TerzoIntermediarioSoggettoEmittenteType = TerzoIntermediarioSoggettoEmittenteType
 Namespace.addCategoryObject('typeBinding', 'TerzoIntermediarioSoggettoEmittenteType', TerzoIntermediarioSoggettoEmittenteType)
@@ -3129,29 +3124,29 @@ class DatiAnagraficiTerzoIntermediarioType (pyxb.binding.basis.complexTypeDefini
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiAnagraficiTerzoIntermediarioType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 966, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 971, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element IdFiscaleIVA uses Python identifier IdFiscaleIVA
-    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiTerzoIntermediarioType_IdFiscaleIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 968, 6), )
+    __IdFiscaleIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), 'IdFiscaleIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiTerzoIntermediarioType_IdFiscaleIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 973, 6), )
 
-
+    
     IdFiscaleIVA = property(__IdFiscaleIVA.value, __IdFiscaleIVA.set, None, None)
 
-
+    
     # Element CodiceFiscale uses Python identifier CodiceFiscale
-    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiTerzoIntermediarioType_CodiceFiscale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 969, 6), )
+    __CodiceFiscale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), 'CodiceFiscale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiTerzoIntermediarioType_CodiceFiscale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 974, 6), )
 
-
+    
     CodiceFiscale = property(__CodiceFiscale.value, __CodiceFiscale.set, None, None)
 
-
+    
     # Element Anagrafica uses Python identifier Anagrafica
-    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiTerzoIntermediarioType_Anagrafica', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 970, 6), )
+    __Anagrafica = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Anagrafica'), 'Anagrafica', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiAnagraficiTerzoIntermediarioType_Anagrafica', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 975, 6), )
 
-
+    
     Anagrafica = property(__Anagrafica.value, __Anagrafica.set, None, None)
 
     _ElementMap.update({
@@ -3160,7 +3155,7 @@ class DatiAnagraficiTerzoIntermediarioType (pyxb.binding.basis.complexTypeDefini
         __Anagrafica.name() : __Anagrafica
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiAnagraficiTerzoIntermediarioType = DatiAnagraficiTerzoIntermediarioType
 Namespace.addCategoryObject('typeBinding', 'DatiAnagraficiTerzoIntermediarioType', DatiAnagraficiTerzoIntermediarioType)
@@ -3173,43 +3168,43 @@ class AllegatiType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'AllegatiType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 973, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 978, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element NomeAttachment uses Python identifier NomeAttachment
-    __NomeAttachment = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NomeAttachment'), 'NomeAttachment', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_NomeAttachment', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 978, 6), )
+    __NomeAttachment = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NomeAttachment'), 'NomeAttachment', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_NomeAttachment', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 983, 6), )
 
-
+    
     NomeAttachment = property(__NomeAttachment.value, __NomeAttachment.set, None, None)
 
-
+    
     # Element AlgoritmoCompressione uses Python identifier AlgoritmoCompressione
-    __AlgoritmoCompressione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AlgoritmoCompressione'), 'AlgoritmoCompressione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_AlgoritmoCompressione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 979, 6), )
+    __AlgoritmoCompressione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AlgoritmoCompressione'), 'AlgoritmoCompressione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_AlgoritmoCompressione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 984, 6), )
 
-
+    
     AlgoritmoCompressione = property(__AlgoritmoCompressione.value, __AlgoritmoCompressione.set, None, None)
 
-
+    
     # Element FormatoAttachment uses Python identifier FormatoAttachment
-    __FormatoAttachment = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FormatoAttachment'), 'FormatoAttachment', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_FormatoAttachment', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 980, 6), )
+    __FormatoAttachment = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FormatoAttachment'), 'FormatoAttachment', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_FormatoAttachment', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 985, 6), )
 
-
+    
     FormatoAttachment = property(__FormatoAttachment.value, __FormatoAttachment.set, None, None)
 
-
+    
     # Element DescrizioneAttachment uses Python identifier DescrizioneAttachment
-    __DescrizioneAttachment = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DescrizioneAttachment'), 'DescrizioneAttachment', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_DescrizioneAttachment', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 981, 6), )
+    __DescrizioneAttachment = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DescrizioneAttachment'), 'DescrizioneAttachment', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_DescrizioneAttachment', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 986, 6), )
 
-
+    
     DescrizioneAttachment = property(__DescrizioneAttachment.value, __DescrizioneAttachment.set, None, None)
 
-
+    
     # Element Attachment uses Python identifier Attachment
-    __Attachment = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Attachment'), 'Attachment', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_Attachment', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 982, 6), )
+    __Attachment = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Attachment'), 'Attachment', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AllegatiType_Attachment', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 987, 6), )
 
-
+    
     Attachment = property(__Attachment.value, __Attachment.set, None, None)
 
     _ElementMap.update({
@@ -3220,7 +3215,7 @@ class AllegatiType (pyxb.binding.basis.complexTypeDefinition):
         __Attachment.name() : __Attachment
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.AllegatiType = AllegatiType
 Namespace.addCategoryObject('typeBinding', 'AllegatiType', AllegatiType)
@@ -3233,120 +3228,120 @@ class DettaglioLineeType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DettaglioLineeType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 985, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 990, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element NumeroLinea uses Python identifier NumeroLinea
-    __NumeroLinea = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroLinea'), 'NumeroLinea', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_NumeroLinea', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 987, 6), )
+    __NumeroLinea = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'NumeroLinea'), 'NumeroLinea', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_NumeroLinea', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 992, 6), )
 
-
+    
     NumeroLinea = property(__NumeroLinea.value, __NumeroLinea.set, None, None)
 
-
+    
     # Element TipoCessionePrestazione uses Python identifier TipoCessionePrestazione
-    __TipoCessionePrestazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoCessionePrestazione'), 'TipoCessionePrestazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_TipoCessionePrestazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 988, 6), )
+    __TipoCessionePrestazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoCessionePrestazione'), 'TipoCessionePrestazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_TipoCessionePrestazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 993, 6), )
 
-
+    
     TipoCessionePrestazione = property(__TipoCessionePrestazione.value, __TipoCessionePrestazione.set, None, None)
 
-
+    
     # Element CodiceArticolo uses Python identifier CodiceArticolo
-    __CodiceArticolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceArticolo'), 'CodiceArticolo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_CodiceArticolo', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 989, 6), )
+    __CodiceArticolo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceArticolo'), 'CodiceArticolo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_CodiceArticolo', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 994, 6), )
 
-
+    
     CodiceArticolo = property(__CodiceArticolo.value, __CodiceArticolo.set, None, None)
 
-
+    
     # Element Descrizione uses Python identifier Descrizione
-    __Descrizione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Descrizione'), 'Descrizione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_Descrizione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 990, 6), )
+    __Descrizione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Descrizione'), 'Descrizione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_Descrizione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 995, 6), )
 
-
+    
     Descrizione = property(__Descrizione.value, __Descrizione.set, None, None)
 
-
+    
     # Element Quantita uses Python identifier Quantita
-    __Quantita = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Quantita'), 'Quantita', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_Quantita', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 991, 6), )
+    __Quantita = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Quantita'), 'Quantita', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_Quantita', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 996, 6), )
 
-
+    
     Quantita = property(__Quantita.value, __Quantita.set, None, None)
 
-
+    
     # Element UnitaMisura uses Python identifier UnitaMisura
-    __UnitaMisura = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'UnitaMisura'), 'UnitaMisura', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_UnitaMisura', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 992, 6), )
+    __UnitaMisura = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'UnitaMisura'), 'UnitaMisura', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_UnitaMisura', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 997, 6), )
 
-
+    
     UnitaMisura = property(__UnitaMisura.value, __UnitaMisura.set, None, None)
 
-
+    
     # Element DataInizioPeriodo uses Python identifier DataInizioPeriodo
-    __DataInizioPeriodo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataInizioPeriodo'), 'DataInizioPeriodo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_DataInizioPeriodo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 993, 6), )
+    __DataInizioPeriodo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataInizioPeriodo'), 'DataInizioPeriodo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_DataInizioPeriodo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 998, 6), )
 
-
+    
     DataInizioPeriodo = property(__DataInizioPeriodo.value, __DataInizioPeriodo.set, None, None)
 
-
+    
     # Element DataFinePeriodo uses Python identifier DataFinePeriodo
-    __DataFinePeriodo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataFinePeriodo'), 'DataFinePeriodo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_DataFinePeriodo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 994, 6), )
+    __DataFinePeriodo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'DataFinePeriodo'), 'DataFinePeriodo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_DataFinePeriodo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 999, 6), )
 
-
+    
     DataFinePeriodo = property(__DataFinePeriodo.value, __DataFinePeriodo.set, None, None)
 
-
+    
     # Element PrezzoUnitario uses Python identifier PrezzoUnitario
-    __PrezzoUnitario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PrezzoUnitario'), 'PrezzoUnitario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_PrezzoUnitario', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 995, 6), )
+    __PrezzoUnitario = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PrezzoUnitario'), 'PrezzoUnitario', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_PrezzoUnitario', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1000, 6), )
 
-
+    
     PrezzoUnitario = property(__PrezzoUnitario.value, __PrezzoUnitario.set, None, None)
 
-
+    
     # Element ScontoMaggiorazione uses Python identifier ScontoMaggiorazione
-    __ScontoMaggiorazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione'), 'ScontoMaggiorazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_ScontoMaggiorazione', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 996, 6), )
+    __ScontoMaggiorazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione'), 'ScontoMaggiorazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_ScontoMaggiorazione', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1001, 6), )
 
-
+    
     ScontoMaggiorazione = property(__ScontoMaggiorazione.value, __ScontoMaggiorazione.set, None, None)
 
-
+    
     # Element PrezzoTotale uses Python identifier PrezzoTotale
-    __PrezzoTotale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PrezzoTotale'), 'PrezzoTotale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_PrezzoTotale', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 997, 6), )
+    __PrezzoTotale = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'PrezzoTotale'), 'PrezzoTotale', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_PrezzoTotale', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1002, 6), )
 
-
+    
     PrezzoTotale = property(__PrezzoTotale.value, __PrezzoTotale.set, None, None)
 
-
+    
     # Element AliquotaIVA uses Python identifier AliquotaIVA
-    __AliquotaIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), 'AliquotaIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_AliquotaIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 998, 6), )
+    __AliquotaIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), 'AliquotaIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_AliquotaIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1003, 6), )
 
-
+    
     AliquotaIVA = property(__AliquotaIVA.value, __AliquotaIVA.set, None, None)
 
-
+    
     # Element Ritenuta uses Python identifier Ritenuta
-    __Ritenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Ritenuta'), 'Ritenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_Ritenuta', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 999, 6), )
+    __Ritenuta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Ritenuta'), 'Ritenuta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_Ritenuta', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1004, 6), )
 
-
+    
     Ritenuta = property(__Ritenuta.value, __Ritenuta.set, None, None)
 
-
+    
     # Element Natura uses Python identifier Natura
-    __Natura = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Natura'), 'Natura', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_Natura', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1000, 6), )
+    __Natura = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Natura'), 'Natura', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_Natura', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1005, 6), )
 
-
+    
     Natura = property(__Natura.value, __Natura.set, None, None)
 
-
+    
     # Element RiferimentoAmministrazione uses Python identifier RiferimentoAmministrazione
-    __RiferimentoAmministrazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), 'RiferimentoAmministrazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_RiferimentoAmministrazione', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1001, 6), )
+    __RiferimentoAmministrazione = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), 'RiferimentoAmministrazione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_RiferimentoAmministrazione', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1006, 6), )
 
-
+    
     RiferimentoAmministrazione = property(__RiferimentoAmministrazione.value, __RiferimentoAmministrazione.set, None, None)
 
-
+    
     # Element AltriDatiGestionali uses Python identifier AltriDatiGestionali
-    __AltriDatiGestionali = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AltriDatiGestionali'), 'AltriDatiGestionali', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_AltriDatiGestionali', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1002, 6), )
+    __AltriDatiGestionali = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AltriDatiGestionali'), 'AltriDatiGestionali', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DettaglioLineeType_AltriDatiGestionali', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1007, 6), )
 
-
+    
     AltriDatiGestionali = property(__AltriDatiGestionali.value, __AltriDatiGestionali.set, None, None)
 
     _ElementMap.update({
@@ -3368,7 +3363,7 @@ class DettaglioLineeType (pyxb.binding.basis.complexTypeDefinition):
         __AltriDatiGestionali.name() : __AltriDatiGestionali
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DettaglioLineeType = DettaglioLineeType
 Namespace.addCategoryObject('typeBinding', 'DettaglioLineeType', DettaglioLineeType)
@@ -3381,22 +3376,22 @@ class CodiceArticoloType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'CodiceArticoloType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1005, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1010, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element CodiceTipo uses Python identifier CodiceTipo
-    __CodiceTipo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceTipo'), 'CodiceTipo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CodiceArticoloType_CodiceTipo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1007, 6), )
+    __CodiceTipo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceTipo'), 'CodiceTipo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CodiceArticoloType_CodiceTipo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1012, 6), )
 
-
+    
     CodiceTipo = property(__CodiceTipo.value, __CodiceTipo.set, None, None)
 
-
+    
     # Element CodiceValore uses Python identifier CodiceValore
-    __CodiceValore = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceValore'), 'CodiceValore', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CodiceArticoloType_CodiceValore', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1008, 6), )
+    __CodiceValore = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'CodiceValore'), 'CodiceValore', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_CodiceArticoloType_CodiceValore', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1013, 6), )
 
-
+    
     CodiceValore = property(__CodiceValore.value, __CodiceValore.set, None, None)
 
     _ElementMap.update({
@@ -3404,7 +3399,7 @@ class CodiceArticoloType (pyxb.binding.basis.complexTypeDefinition):
         __CodiceValore.name() : __CodiceValore
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.CodiceArticoloType = CodiceArticoloType
 Namespace.addCategoryObject('typeBinding', 'CodiceArticoloType', CodiceArticoloType)
@@ -3417,36 +3412,36 @@ class AltriDatiGestionaliType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'AltriDatiGestionaliType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1011, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1016, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element TipoDato uses Python identifier TipoDato
-    __TipoDato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoDato'), 'TipoDato', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AltriDatiGestionaliType_TipoDato', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1013, 6), )
+    __TipoDato = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'TipoDato'), 'TipoDato', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AltriDatiGestionaliType_TipoDato', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1018, 6), )
 
-
+    
     TipoDato = property(__TipoDato.value, __TipoDato.set, None, None)
 
-
+    
     # Element RiferimentoTesto uses Python identifier RiferimentoTesto
-    __RiferimentoTesto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoTesto'), 'RiferimentoTesto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AltriDatiGestionaliType_RiferimentoTesto', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1014, 6), )
+    __RiferimentoTesto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoTesto'), 'RiferimentoTesto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AltriDatiGestionaliType_RiferimentoTesto', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1019, 6), )
 
-
+    
     RiferimentoTesto = property(__RiferimentoTesto.value, __RiferimentoTesto.set, None, None)
 
-
+    
     # Element RiferimentoNumero uses Python identifier RiferimentoNumero
-    __RiferimentoNumero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoNumero'), 'RiferimentoNumero', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AltriDatiGestionaliType_RiferimentoNumero', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1015, 6), )
+    __RiferimentoNumero = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoNumero'), 'RiferimentoNumero', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AltriDatiGestionaliType_RiferimentoNumero', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1020, 6), )
 
-
+    
     RiferimentoNumero = property(__RiferimentoNumero.value, __RiferimentoNumero.set, None, None)
 
-
+    
     # Element RiferimentoData uses Python identifier RiferimentoData
-    __RiferimentoData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoData'), 'RiferimentoData', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AltriDatiGestionaliType_RiferimentoData', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1016, 6), )
+    __RiferimentoData = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoData'), 'RiferimentoData', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_AltriDatiGestionaliType_RiferimentoData', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1021, 6), )
 
-
+    
     RiferimentoData = property(__RiferimentoData.value, __RiferimentoData.set, None, None)
 
     _ElementMap.update({
@@ -3456,7 +3451,7 @@ class AltriDatiGestionaliType (pyxb.binding.basis.complexTypeDefinition):
         __RiferimentoData.name() : __RiferimentoData
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.AltriDatiGestionaliType = AltriDatiGestionaliType
 Namespace.addCategoryObject('typeBinding', 'AltriDatiGestionaliType', AltriDatiGestionaliType)
@@ -3469,64 +3464,64 @@ class DatiRiepilogoType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'DatiRiepilogoType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1029, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1034, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element AliquotaIVA uses Python identifier AliquotaIVA
-    __AliquotaIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), 'AliquotaIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_AliquotaIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1031, 6), )
+    __AliquotaIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), 'AliquotaIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_AliquotaIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1036, 6), )
 
-
+    
     AliquotaIVA = property(__AliquotaIVA.value, __AliquotaIVA.set, None, None)
 
-
+    
     # Element Natura uses Python identifier Natura
-    __Natura = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Natura'), 'Natura', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_Natura', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1032, 6), )
+    __Natura = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Natura'), 'Natura', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_Natura', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1037, 6), )
 
-
+    
     Natura = property(__Natura.value, __Natura.set, None, None)
 
-
+    
     # Element SpeseAccessorie uses Python identifier SpeseAccessorie
-    __SpeseAccessorie = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'SpeseAccessorie'), 'SpeseAccessorie', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_SpeseAccessorie', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1033, 6), )
+    __SpeseAccessorie = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'SpeseAccessorie'), 'SpeseAccessorie', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_SpeseAccessorie', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1038, 6), )
 
-
+    
     SpeseAccessorie = property(__SpeseAccessorie.value, __SpeseAccessorie.set, None, None)
 
-
+    
     # Element Arrotondamento uses Python identifier Arrotondamento
-    __Arrotondamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Arrotondamento'), 'Arrotondamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_Arrotondamento', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1034, 6), )
+    __Arrotondamento = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Arrotondamento'), 'Arrotondamento', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_Arrotondamento', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1039, 6), )
 
-
+    
     Arrotondamento = property(__Arrotondamento.value, __Arrotondamento.set, None, None)
 
-
+    
     # Element ImponibileImporto uses Python identifier ImponibileImporto
-    __ImponibileImporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImponibileImporto'), 'ImponibileImporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_ImponibileImporto', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1035, 6), )
+    __ImponibileImporto = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'ImponibileImporto'), 'ImponibileImporto', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_ImponibileImporto', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1040, 6), )
 
-
+    
     ImponibileImporto = property(__ImponibileImporto.value, __ImponibileImporto.set, None, None)
 
-
+    
     # Element Imposta uses Python identifier Imposta
-    __Imposta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Imposta'), 'Imposta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_Imposta', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1036, 6), )
+    __Imposta = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'Imposta'), 'Imposta', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_Imposta', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1041, 6), )
 
-
+    
     Imposta = property(__Imposta.value, __Imposta.set, None, None)
 
-
+    
     # Element EsigibilitaIVA uses Python identifier EsigibilitaIVA
-    __EsigibilitaIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'EsigibilitaIVA'), 'EsigibilitaIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_EsigibilitaIVA', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1037, 6), )
+    __EsigibilitaIVA = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'EsigibilitaIVA'), 'EsigibilitaIVA', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_EsigibilitaIVA', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1042, 6), )
 
-
+    
     EsigibilitaIVA = property(__EsigibilitaIVA.value, __EsigibilitaIVA.set, None, None)
 
-
+    
     # Element RiferimentoNormativo uses Python identifier RiferimentoNormativo
-    __RiferimentoNormativo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoNormativo'), 'RiferimentoNormativo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_RiferimentoNormativo', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1038, 6), )
+    __RiferimentoNormativo = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'RiferimentoNormativo'), 'RiferimentoNormativo', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_DatiRiepilogoType_RiferimentoNormativo', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1043, 6), )
 
-
+    
     RiferimentoNormativo = property(__RiferimentoNormativo.value, __RiferimentoNormativo.set, None, None)
 
     _ElementMap.update({
@@ -3540,7 +3535,7 @@ class DatiRiepilogoType (pyxb.binding.basis.complexTypeDefinition):
         __RiferimentoNormativo.name() : __RiferimentoNormativo
     })
     _AttributeMap.update({
-
+        
     })
 _module_typeBindings.DatiRiepilogoType = DatiRiepilogoType
 Namespace.addCategoryObject('typeBinding', 'DatiRiepilogoType', DatiRiepilogoType)
@@ -3553,45 +3548,45 @@ class FatturaElettronicaType (pyxb.binding.basis.complexTypeDefinition):
     _ContentTypeTag = pyxb.binding.basis.complexTypeDefinition._CT_ELEMENT_ONLY
     _Abstract = False
     _ExpandedName = pyxb.namespace.ExpandedName(Namespace, 'FatturaElettronicaType')
-    _XSDLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 16, 2)
+    _XSDLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 16, 2)
     _ElementMap = {}
     _AttributeMap = {}
     # Base type is pyxb.binding.datatypes.anyType
-
+    
     # Element FatturaElettronicaHeader uses Python identifier FatturaElettronicaHeader
-    __FatturaElettronicaHeader = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaHeader'), 'FatturaElettronicaHeader', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaType_FatturaElettronicaHeader', False, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 18, 6), )
+    __FatturaElettronicaHeader = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaHeader'), 'FatturaElettronicaHeader', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaType_FatturaElettronicaHeader', False, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 18, 6), )
 
-
+    
     FatturaElettronicaHeader = property(__FatturaElettronicaHeader.value, __FatturaElettronicaHeader.set, None, None)
 
-
+    
     # Element FatturaElettronicaBody uses Python identifier FatturaElettronicaBody
-    __FatturaElettronicaBody = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaBody'), 'FatturaElettronicaBody', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaType_FatturaElettronicaBody', True, pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 19, 6), )
+    __FatturaElettronicaBody = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaBody'), 'FatturaElettronicaBody', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaType_FatturaElettronicaBody', True, pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 19, 6), )
 
-
+    
     FatturaElettronicaBody = property(__FatturaElettronicaBody.value, __FatturaElettronicaBody.set, None, None)
 
-
+    
     # Element {http://www.w3.org/2000/09/xmldsig#}Signature uses Python identifier Signature
     __Signature = pyxb.binding.content.ElementDeclaration(pyxb.namespace.ExpandedName(_Namespace_ds, 'Signature'), 'Signature', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaType_httpwww_w3_org200009xmldsigSignature', False, pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 43, 0), )
 
-
+    
     Signature = property(__Signature.value, __Signature.set, None, None)
 
-
+    
     # Attribute versione uses Python identifier versione
     __versione = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'versione'), 'versione', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaType_versione', _module_typeBindings.FormatoTrasmissioneType, required=True)
-    __versione._DeclarationLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 22, 4)
-    __versione._UseLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 22, 4)
-
+    __versione._DeclarationLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 22, 4)
+    __versione._UseLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 22, 4)
+    
     versione = property(__versione.value, __versione.set, None, None)
 
-
+    
     # Attribute SistemaEmittente uses Python identifier SistemaEmittente
     __SistemaEmittente = pyxb.binding.content.AttributeUse(pyxb.namespace.ExpandedName(None, 'SistemaEmittente'), 'SistemaEmittente', '__httpivaservizi_agenziaentrate_gov_itdocsxsdfatturev1_2_FatturaElettronicaType_SistemaEmittente', _module_typeBindings.String10Type)
-    __SistemaEmittente._DeclarationLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 23, 4)
-    __SistemaEmittente._UseLocation = pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 23, 4)
-
+    __SistemaEmittente._DeclarationLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 23, 4)
+    __SistemaEmittente._UseLocation = pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 23, 4)
+    
     SistemaEmittente = property(__SistemaEmittente.value, __SistemaEmittente.set, None, None)
 
     _ElementMap.update({
@@ -3607,22 +3602,22 @@ _module_typeBindings.FatturaElettronicaType = FatturaElettronicaType
 Namespace.addCategoryObject('typeBinding', 'FatturaElettronicaType', FatturaElettronicaType)
 
 
-FatturaElettronica = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'FatturaElettronica'), FatturaElettronicaType, documentation='XML schema fatture destinate a PA e privati in forma ordinaria 1.2.1', location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 10, 2))
+FatturaElettronica = pyxb.binding.basis.element(pyxb.namespace.ExpandedName(Namespace, 'FatturaElettronica'), FatturaElettronicaType, documentation='XML schema fatture destinate a PA e privati in forma ordinaria 1.2.2', location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 10, 2))
 Namespace.addCategoryObject('elementBinding', FatturaElettronica.name().localName(), FatturaElettronica)
 
 
 
-FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiTrasmissione'), DatiTrasmissioneType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 27, 6)))
+FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiTrasmissione'), DatiTrasmissioneType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 27, 6)))
 
-FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CedentePrestatore'), CedentePrestatoreType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 28, 6)))
+FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CedentePrestatore'), CedentePrestatoreType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 28, 6)))
 
-FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale'), RappresentanteFiscaleType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 29, 6)))
+FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale'), RappresentanteFiscaleType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 29, 6)))
 
-FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CessionarioCommittente'), CessionarioCommittenteType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 30, 6)))
+FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CessionarioCommittente'), CessionarioCommittenteType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 30, 6)))
 
-FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TerzoIntermediarioOSoggettoEmittente'), TerzoIntermediarioSoggettoEmittenteType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 31, 6)))
+FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TerzoIntermediarioOSoggettoEmittente'), TerzoIntermediarioSoggettoEmittenteType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 31, 6)))
 
-FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'SoggettoEmittente'), SoggettoEmittenteType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 32, 6)))
+FatturaElettronicaHeaderType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'SoggettoEmittente'), SoggettoEmittenteType, scope=FatturaElettronicaHeaderType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 32, 6)))
 
 def _BuildAutomaton ():
     # Remove this helper function from the namespace after it is invoked
@@ -3631,37 +3626,37 @@ def _BuildAutomaton ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 29, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 29, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 31, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 31, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 32, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 32, 6))
     counters.add(cc_2)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiTrasmissione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 27, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiTrasmissione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 27, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'CedentePrestatore')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 28, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'CedentePrestatore')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 28, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 29, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 29, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'CessionarioCommittente')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 30, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'CessionarioCommittente')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 30, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'TerzoIntermediarioOSoggettoEmittente')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 31, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'TerzoIntermediarioOSoggettoEmittente')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 31, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'SoggettoEmittente')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 32, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaHeaderType._UseForTag(pyxb.namespace.ExpandedName(None, 'SoggettoEmittente')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 32, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     transitions = []
@@ -3702,15 +3697,15 @@ FatturaElettronicaHeaderType._Automaton = _BuildAutomaton()
 
 
 
-FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiGenerali'), DatiGeneraliType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 37, 6)))
+FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiGenerali'), DatiGeneraliType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 37, 6)))
 
-FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiBeniServizi'), DatiBeniServiziType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 38, 6)))
+FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiBeniServizi'), DatiBeniServiziType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 38, 6)))
 
-FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiVeicoli'), DatiVeicoliType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 39, 6)))
+FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiVeicoli'), DatiVeicoliType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 39, 6)))
 
-FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiPagamento'), DatiPagamentoType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 40, 6)))
+FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiPagamento'), DatiPagamentoType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 40, 6)))
 
-FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Allegati'), AllegatiType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 41, 6)))
+FatturaElettronicaBodyType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Allegati'), AllegatiType, scope=FatturaElettronicaBodyType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 41, 6)))
 
 def _BuildAutomaton_ ():
     # Remove this helper function from the namespace after it is invoked
@@ -3719,34 +3714,34 @@ def _BuildAutomaton_ ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 39, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 39, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 40, 6))
+    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 40, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 41, 6))
+    cc_2 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 41, 6))
     counters.add(cc_2)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiGenerali')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 37, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiGenerali')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 37, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiBeniServizi')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 38, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiBeniServizi')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 38, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiVeicoli')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 39, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiVeicoli')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 39, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiPagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 40, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiPagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 40, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'Allegati')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 41, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaBodyType._UseForTag(pyxb.namespace.ExpandedName(None, 'Allegati')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 41, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     transitions = []
@@ -3785,17 +3780,17 @@ FatturaElettronicaBodyType._Automaton = _BuildAutomaton_()
 
 
 
-DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdTrasmittente'), IdFiscaleType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 49, 6)))
+DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdTrasmittente'), IdFiscaleType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 49, 6)))
 
-DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ProgressivoInvio'), String10Type, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 50, 6)))
+DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ProgressivoInvio'), String10Type, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 50, 6)))
 
-DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FormatoTrasmissione'), FormatoTrasmissioneType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 51, 6)))
+DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FormatoTrasmissione'), FormatoTrasmissioneType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 51, 6)))
 
-DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceDestinatario'), CodiceDestinatarioType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 52, 6)))
+DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceDestinatario'), CodiceDestinatarioType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 52, 6)))
 
-DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ContattiTrasmittente'), ContattiTrasmittenteType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 53, 6)))
+DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ContattiTrasmittente'), ContattiTrasmittenteType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 53, 6)))
 
-DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PECDestinatario'), EmailType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 54, 6)))
+DatiTrasmissioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PECDestinatario'), EmailType, scope=DatiTrasmissioneType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 54, 6)))
 
 def _BuildAutomaton_2 ():
     # Remove this helper function from the namespace after it is invoked
@@ -3804,35 +3799,35 @@ def _BuildAutomaton_2 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 53, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 53, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 54, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 54, 6))
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdTrasmittente')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 49, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdTrasmittente')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 49, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'ProgressivoInvio')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 50, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'ProgressivoInvio')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 50, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'FormatoTrasmissione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 51, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'FormatoTrasmissione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 51, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceDestinatario')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 52, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceDestinatario')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 52, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'ContattiTrasmittente')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 53, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'ContattiTrasmittente')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 53, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'PECDestinatario')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 54, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasmissioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'PECDestinatario')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 54, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     transitions = []
@@ -3869,9 +3864,9 @@ DatiTrasmissioneType._Automaton = _BuildAutomaton_2()
 
 
 
-IdFiscaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdPaese'), NazioneType, scope=IdFiscaleType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 64, 6)))
+IdFiscaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdPaese'), NazioneType, scope=IdFiscaleType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 64, 6)))
 
-IdFiscaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdCodice'), CodiceType, scope=IdFiscaleType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 65, 6)))
+IdFiscaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdCodice'), CodiceType, scope=IdFiscaleType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 65, 6)))
 
 def _BuildAutomaton_3 ():
     # Remove this helper function from the namespace after it is invoked
@@ -3882,11 +3877,11 @@ def _BuildAutomaton_3 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IdFiscaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdPaese')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 64, 6))
+    symbol = pyxb.binding.content.ElementUse(IdFiscaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdPaese')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 64, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(IdFiscaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdCodice')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 65, 6))
+    symbol = pyxb.binding.content.ElementUse(IdFiscaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdCodice')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 65, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     transitions = []
@@ -3901,9 +3896,9 @@ IdFiscaleType._Automaton = _BuildAutomaton_3()
 
 
 
-ContattiTrasmittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Telefono'), TelFaxType, scope=ContattiTrasmittenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 91, 6)))
+ContattiTrasmittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Telefono'), TelFaxType, scope=ContattiTrasmittenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 91, 6)))
 
-ContattiTrasmittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Email'), EmailContattiType, scope=ContattiTrasmittenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 92, 6)))
+ContattiTrasmittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Email'), EmailContattiType, scope=ContattiTrasmittenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 92, 6)))
 
 def _BuildAutomaton_4 ():
     # Remove this helper function from the namespace after it is invoked
@@ -3912,19 +3907,19 @@ def _BuildAutomaton_4 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 91, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 91, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 92, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 92, 6))
     counters.add(cc_1)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(ContattiTrasmittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Telefono')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 91, 6))
+    symbol = pyxb.binding.content.ElementUse(ContattiTrasmittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Telefono')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 91, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(ContattiTrasmittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Email')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 92, 6))
+    symbol = pyxb.binding.content.ElementUse(ContattiTrasmittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Email')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 92, 6))
     st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     transitions = []
@@ -3943,25 +3938,25 @@ ContattiTrasmittenteType._Automaton = _BuildAutomaton_4()
 
 
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiGeneraliDocumento'), DatiGeneraliDocumentoType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 102, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiGeneraliDocumento'), DatiGeneraliDocumentoType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 102, 6)))
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiOrdineAcquisto'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 103, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiOrdineAcquisto'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 103, 6)))
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiContratto'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 104, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiContratto'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 104, 6)))
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiConvenzione'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 105, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiConvenzione'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 105, 6)))
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiRicezione'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 106, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiRicezione'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 106, 6)))
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiFattureCollegate'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 107, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiFattureCollegate'), DatiDocumentiCorrelatiType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 107, 6)))
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiSAL'), DatiSALType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 108, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiSAL'), DatiSALType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 108, 6)))
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiDDT'), DatiDDTType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 109, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiDDT'), DatiDDTType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 109, 6)))
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiTrasporto'), DatiTrasportoType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 110, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiTrasporto'), DatiTrasportoType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 110, 6)))
 
-DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FatturaPrincipale'), FatturaPrincipaleType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 111, 6)))
+DatiGeneraliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FatturaPrincipale'), FatturaPrincipaleType, scope=DatiGeneraliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 111, 6)))
 
 def _BuildAutomaton_5 ():
     # Remove this helper function from the namespace after it is invoked
@@ -3970,72 +3965,72 @@ def _BuildAutomaton_5 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 103, 6))
+    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 103, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 104, 6))
+    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 104, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 105, 6))
+    cc_2 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 105, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 106, 6))
+    cc_3 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 106, 6))
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 107, 6))
+    cc_4 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 107, 6))
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 108, 6))
+    cc_5 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 108, 6))
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 109, 6))
+    cc_6 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 109, 6))
     counters.add(cc_6)
-    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 110, 6))
+    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 110, 6))
     counters.add(cc_7)
-    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 111, 6))
+    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 111, 6))
     counters.add(cc_8)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiGeneraliDocumento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 102, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiGeneraliDocumento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 102, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiOrdineAcquisto')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 103, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiOrdineAcquisto')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 103, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiContratto')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 104, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiContratto')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 104, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiConvenzione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 105, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiConvenzione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 105, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiRicezione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 106, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiRicezione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 106, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiFattureCollegate')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 107, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiFattureCollegate')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 107, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_5, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiSAL')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 108, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiSAL')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 108, 6))
     st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_6, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiDDT')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 109, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiDDT')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 109, 6))
     st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_7)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_7, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiTrasporto')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 110, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiTrasporto')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 110, 6))
     st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_8)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_8, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'FatturaPrincipale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 111, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliType._UseForTag(pyxb.namespace.ExpandedName(None, 'FatturaPrincipale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 111, 6))
     st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_9)
     transitions = []
@@ -4172,29 +4167,29 @@ DatiGeneraliType._Automaton = _BuildAutomaton_5()
 
 
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoDocumento'), TipoDocumentoType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 116, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoDocumento'), TipoDocumentoType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 116, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Divisa'), DivisaType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 117, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Divisa'), DivisaType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 117, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Data'), DataFatturaType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 118, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Data'), DataFatturaType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 118, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Numero'), String20Type, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 119, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Numero'), String20Type, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 119, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiRitenuta'), DatiRitenutaType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 120, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiRitenuta'), DatiRitenutaType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 120, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiBollo'), DatiBolloType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 121, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiBollo'), DatiBolloType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 121, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiCassaPrevidenziale'), DatiCassaPrevidenzialeType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 122, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiCassaPrevidenziale'), DatiCassaPrevidenzialeType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 122, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione'), ScontoMaggiorazioneType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 123, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione'), ScontoMaggiorazioneType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 123, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoTotaleDocumento'), Amount2DecimalType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 124, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoTotaleDocumento'), Amount2DecimalType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 124, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Arrotondamento'), Amount2DecimalType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 125, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Arrotondamento'), Amount2DecimalType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 125, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Causale'), String200LatinType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 126, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Causale'), String200LatinType, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 126, 6)))
 
-DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Art73'), Art73Type, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 127, 6)))
+DatiGeneraliDocumentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Art73'), Art73Type, scope=DatiGeneraliDocumentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 127, 6)))
 
 def _BuildAutomaton_6 ():
     # Remove this helper function from the namespace after it is invoked
@@ -4203,77 +4198,77 @@ def _BuildAutomaton_6 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 120, 6))
+    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 120, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 121, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 121, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 122, 6))
+    cc_2 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 122, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 123, 6))
+    cc_3 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 123, 6))
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 124, 6))
+    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 124, 6))
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 125, 6))
+    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 125, 6))
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 126, 6))
+    cc_6 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 126, 6))
     counters.add(cc_6)
-    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 127, 6))
+    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 127, 6))
     counters.add(cc_7)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoDocumento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 116, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoDocumento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 116, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Divisa')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 117, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Divisa')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 117, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Data')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 118, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Data')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 118, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Numero')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 119, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Numero')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 119, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiRitenuta')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 120, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiRitenuta')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 120, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiBollo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 121, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiBollo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 121, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiCassaPrevidenziale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 122, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiCassaPrevidenziale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 122, 6))
     st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 123, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 123, 6))
     st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_7)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoTotaleDocumento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 124, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoTotaleDocumento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 124, 6))
     st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_8)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_5, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Arrotondamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 125, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Arrotondamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 125, 6))
     st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_9)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_6, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Causale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 126, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Causale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 126, 6))
     st_10 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_10)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_7, False))
-    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Art73')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 127, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiGeneraliDocumentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Art73')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 127, 6))
     st_11 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_11)
     transitions = []
@@ -4400,13 +4395,13 @@ DatiGeneraliDocumentoType._Automaton = _BuildAutomaton_6()
 
 
 
-DatiRitenutaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoRitenuta'), TipoRitenutaType, scope=DatiRitenutaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 132, 6)))
+DatiRitenutaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoRitenuta'), TipoRitenutaType, scope=DatiRitenutaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 132, 6)))
 
-DatiRitenutaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoRitenuta'), Amount2DecimalType, scope=DatiRitenutaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 133, 6)))
+DatiRitenutaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoRitenuta'), Amount2DecimalType, scope=DatiRitenutaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 133, 6)))
 
-DatiRitenutaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AliquotaRitenuta'), RateType, scope=DatiRitenutaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 134, 6)))
+DatiRitenutaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AliquotaRitenuta'), RateType, scope=DatiRitenutaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 134, 6)))
 
-DatiRitenutaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CausalePagamento'), CausalePagamentoType, scope=DatiRitenutaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 135, 6)))
+DatiRitenutaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CausalePagamento'), CausalePagamentoType, scope=DatiRitenutaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 135, 6)))
 
 def _BuildAutomaton_7 ():
     # Remove this helper function from the namespace after it is invoked
@@ -4417,19 +4412,19 @@ def _BuildAutomaton_7 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiRitenutaType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoRitenuta')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 132, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRitenutaType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoRitenuta')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 132, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiRitenutaType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoRitenuta')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 133, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRitenutaType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoRitenuta')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 133, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiRitenutaType._UseForTag(pyxb.namespace.ExpandedName(None, 'AliquotaRitenuta')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 134, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRitenutaType._UseForTag(pyxb.namespace.ExpandedName(None, 'AliquotaRitenuta')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 134, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiRitenutaType._UseForTag(pyxb.namespace.ExpandedName(None, 'CausalePagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 135, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRitenutaType._UseForTag(pyxb.namespace.ExpandedName(None, 'CausalePagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 135, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     transitions = []
@@ -4452,9 +4447,9 @@ DatiRitenutaType._Automaton = _BuildAutomaton_7()
 
 
 
-DatiBolloType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'BolloVirtuale'), BolloVirtualeType, scope=DatiBolloType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 140, 6)))
+DatiBolloType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'BolloVirtuale'), BolloVirtualeType, scope=DatiBolloType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 140, 6)))
 
-DatiBolloType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoBollo'), Amount2DecimalType, scope=DatiBolloType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 141, 6)))
+DatiBolloType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoBollo'), Amount2DecimalType, scope=DatiBolloType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 141, 6)))
 
 def _BuildAutomaton_8 ():
     # Remove this helper function from the namespace after it is invoked
@@ -4463,16 +4458,16 @@ def _BuildAutomaton_8 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 141, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 141, 6))
     counters.add(cc_0)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiBolloType._UseForTag(pyxb.namespace.ExpandedName(None, 'BolloVirtuale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 140, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiBolloType._UseForTag(pyxb.namespace.ExpandedName(None, 'BolloVirtuale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 140, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(DatiBolloType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoBollo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 141, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiBolloType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoBollo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 141, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     transitions = []
@@ -4489,21 +4484,21 @@ DatiBolloType._Automaton = _BuildAutomaton_8()
 
 
 
-DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoCassa'), TipoCassaType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 146, 6)))
+DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoCassa'), TipoCassaType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 146, 6)))
 
-DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AlCassa'), RateType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 147, 6)))
+DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AlCassa'), RateType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 147, 6)))
 
-DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoContributoCassa'), Amount2DecimalType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 148, 6)))
+DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoContributoCassa'), Amount2DecimalType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 148, 6)))
 
-DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImponibileCassa'), Amount2DecimalType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 149, 6)))
+DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImponibileCassa'), Amount2DecimalType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 149, 6)))
 
-DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), RateType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 150, 6)))
+DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), RateType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 150, 6)))
 
-DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Ritenuta'), RitenutaType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 151, 6)))
+DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Ritenuta'), RitenutaType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 151, 6)))
 
-DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Natura'), NaturaType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 152, 6)))
+DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Natura'), NaturaType, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 152, 6)))
 
-DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), String20Type, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 153, 6)))
+DatiCassaPrevidenzialeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), String20Type, scope=DatiCassaPrevidenzialeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 153, 6)))
 
 def _BuildAutomaton_9 ():
     # Remove this helper function from the namespace after it is invoked
@@ -4512,48 +4507,48 @@ def _BuildAutomaton_9 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 149, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 149, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 151, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 151, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 152, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 152, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 153, 6))
+    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 153, 6))
     counters.add(cc_3)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoCassa')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 146, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoCassa')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 146, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'AlCassa')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 147, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'AlCassa')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 147, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoContributoCassa')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 148, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoContributoCassa')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 148, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImponibileCassa')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 149, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImponibileCassa')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 149, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'AliquotaIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 150, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'AliquotaIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 150, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Ritenuta')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 151, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Ritenuta')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 151, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Natura')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 152, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Natura')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 152, 6))
     st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 153, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiCassaPrevidenzialeType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 153, 6))
     st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_7)
     transitions = []
@@ -4608,11 +4603,11 @@ DatiCassaPrevidenzialeType._Automaton = _BuildAutomaton_9()
 
 
 
-ScontoMaggiorazioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Tipo'), TipoScontoMaggiorazioneType, scope=ScontoMaggiorazioneType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 158, 6)))
+ScontoMaggiorazioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Tipo'), TipoScontoMaggiorazioneType, scope=ScontoMaggiorazioneType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 158, 6)))
 
-ScontoMaggiorazioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Percentuale'), RateType, scope=ScontoMaggiorazioneType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 159, 6)))
+ScontoMaggiorazioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Percentuale'), RateType, scope=ScontoMaggiorazioneType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 159, 6)))
 
-ScontoMaggiorazioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Importo'), Amount8DecimalType, scope=ScontoMaggiorazioneType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 160, 6)))
+ScontoMaggiorazioneType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Importo'), Amount8DecimalType, scope=ScontoMaggiorazioneType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 160, 6)))
 
 def _BuildAutomaton_10 ():
     # Remove this helper function from the namespace after it is invoked
@@ -4621,23 +4616,23 @@ def _BuildAutomaton_10 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 159, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 159, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 160, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 160, 6))
     counters.add(cc_1)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(ScontoMaggiorazioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'Tipo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 158, 6))
+    symbol = pyxb.binding.content.ElementUse(ScontoMaggiorazioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'Tipo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 158, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(ScontoMaggiorazioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'Percentuale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 159, 6))
+    symbol = pyxb.binding.content.ElementUse(ScontoMaggiorazioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'Percentuale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 159, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(ScontoMaggiorazioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'Importo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 160, 6))
+    symbol = pyxb.binding.content.ElementUse(ScontoMaggiorazioneType._UseForTag(pyxb.namespace.ExpandedName(None, 'Importo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 160, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     transitions = []
@@ -4662,7 +4657,7 @@ ScontoMaggiorazioneType._Automaton = _BuildAutomaton_10()
 
 
 
-DatiSALType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoFase'), RiferimentoFaseType, scope=DatiSALType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 470, 6)))
+DatiSALType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoFase'), RiferimentoFaseType, scope=DatiSALType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 475, 6)))
 
 def _BuildAutomaton_11 ():
     # Remove this helper function from the namespace after it is invoked
@@ -4673,7 +4668,7 @@ def _BuildAutomaton_11 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiSALType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoFase')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 470, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiSALType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoFase')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 475, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     transitions = []
@@ -4684,19 +4679,19 @@ DatiSALType._Automaton = _BuildAutomaton_11()
 
 
 
-DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea'), RiferimentoNumeroLineaType, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 475, 6)))
+DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea'), RiferimentoNumeroLineaType, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 480, 6)))
 
-DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdDocumento'), String20Type, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 476, 6)))
+DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdDocumento'), String20Type, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 481, 6)))
 
-DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Data'), pyxb.binding.datatypes.date, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 477, 6)))
+DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Data'), pyxb.binding.datatypes.date, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 482, 6)))
 
-DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumItem'), String20Type, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 478, 6)))
+DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumItem'), String20Type, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 483, 6)))
 
-DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceCommessaConvenzione'), String100LatinType, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 479, 6)))
+DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceCommessaConvenzione'), String100LatinType, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 484, 6)))
 
-DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceCUP'), String15Type, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 480, 6)))
+DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceCUP'), String15Type, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 485, 6)))
 
-DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceCIG'), String15Type, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 481, 6)))
+DatiDocumentiCorrelatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceCIG'), String15Type, scope=DatiDocumentiCorrelatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 486, 6)))
 
 def _BuildAutomaton_12 ():
     # Remove this helper function from the namespace after it is invoked
@@ -4705,50 +4700,50 @@ def _BuildAutomaton_12 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 475, 6))
+    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 480, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 477, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 482, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 478, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 483, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 479, 6))
+    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 484, 6))
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 480, 6))
+    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 485, 6))
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 481, 6))
+    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 486, 6))
     counters.add(cc_5)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 475, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 480, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdDocumento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 476, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdDocumento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 481, 6))
     st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Data')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 477, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Data')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 482, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumItem')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 478, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumItem')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 483, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceCommessaConvenzione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 479, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceCommessaConvenzione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 484, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceCUP')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 480, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceCUP')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 485, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_5, False))
-    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceCIG')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 481, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDocumentiCorrelatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceCIG')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 486, 6))
     st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     transitions = []
@@ -4815,11 +4810,11 @@ DatiDocumentiCorrelatiType._Automaton = _BuildAutomaton_12()
 
 
 
-DatiDDTType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroDDT'), String20Type, scope=DatiDDTType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 492, 6)))
+DatiDDTType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroDDT'), String20Type, scope=DatiDDTType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 497, 6)))
 
-DatiDDTType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataDDT'), pyxb.binding.datatypes.date, scope=DatiDDTType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 493, 6)))
+DatiDDTType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataDDT'), pyxb.binding.datatypes.date, scope=DatiDDTType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 498, 6)))
 
-DatiDDTType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea'), RiferimentoNumeroLineaType, scope=DatiDDTType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 494, 6)))
+DatiDDTType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea'), RiferimentoNumeroLineaType, scope=DatiDDTType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 499, 6)))
 
 def _BuildAutomaton_13 ():
     # Remove this helper function from the namespace after it is invoked
@@ -4828,20 +4823,20 @@ def _BuildAutomaton_13 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 494, 6))
+    cc_0 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 499, 6))
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiDDTType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroDDT')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 492, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDDTType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroDDT')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 497, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiDDTType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataDDT')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 493, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDDTType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataDDT')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 498, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(DatiDDTType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 494, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiDDTType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoNumeroLinea')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 499, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     transitions = []
@@ -4862,31 +4857,31 @@ DatiDDTType._Automaton = _BuildAutomaton_13()
 
 
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagraficiVettore'), DatiAnagraficiVettoreType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 499, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagraficiVettore'), DatiAnagraficiVettoreType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 504, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'MezzoTrasporto'), String80LatinType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 500, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'MezzoTrasporto'), String80LatinType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 505, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CausaleTrasporto'), String100LatinType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 501, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CausaleTrasporto'), String100LatinType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 506, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroColli'), NumeroColliType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 502, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroColli'), NumeroColliType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 507, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Descrizione'), String100LatinType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 503, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Descrizione'), String100LatinType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 508, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'UnitaMisuraPeso'), String10Type, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 504, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'UnitaMisuraPeso'), String10Type, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 509, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PesoLordo'), PesoType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 505, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PesoLordo'), PesoType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 510, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PesoNetto'), PesoType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 506, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PesoNetto'), PesoType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 511, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataOraRitiro'), pyxb.binding.datatypes.dateTime, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 507, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataOraRitiro'), pyxb.binding.datatypes.dateTime, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 512, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataInizioTrasporto'), pyxb.binding.datatypes.date, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 508, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataInizioTrasporto'), pyxb.binding.datatypes.date, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 513, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoResa'), TipoResaType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 509, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoResa'), TipoResaType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 514, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IndirizzoResa'), IndirizzoType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 510, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IndirizzoResa'), IndirizzoType, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 515, 6)))
 
-DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataOraConsegna'), pyxb.binding.datatypes.dateTime, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 511, 6)))
+DatiTrasportoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataOraConsegna'), pyxb.binding.datatypes.dateTime, scope=DatiTrasportoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 516, 6)))
 
 def _BuildAutomaton_14 ():
     # Remove this helper function from the namespace after it is invoked
@@ -4895,96 +4890,96 @@ def _BuildAutomaton_14 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 499, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 504, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 500, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 505, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 501, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 506, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 502, 6))
+    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 507, 6))
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 503, 6))
+    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 508, 6))
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 504, 6))
+    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 509, 6))
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 505, 6))
+    cc_6 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 510, 6))
     counters.add(cc_6)
-    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 506, 6))
+    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 511, 6))
     counters.add(cc_7)
-    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 507, 6))
+    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 512, 6))
     counters.add(cc_8)
-    cc_9 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 508, 6))
+    cc_9 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 513, 6))
     counters.add(cc_9)
-    cc_10 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 509, 6))
+    cc_10 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 514, 6))
     counters.add(cc_10)
-    cc_11 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 510, 6))
+    cc_11 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 515, 6))
     counters.add(cc_11)
-    cc_12 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 511, 6))
+    cc_12 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 516, 6))
     counters.add(cc_12)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagraficiVettore')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 499, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagraficiVettore')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 504, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'MezzoTrasporto')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 500, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'MezzoTrasporto')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 505, 6))
     st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CausaleTrasporto')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 501, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CausaleTrasporto')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 506, 6))
     st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroColli')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 502, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroColli')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 507, 6))
     st_3 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Descrizione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 503, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Descrizione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 508, 6))
     st_4 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_5, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'UnitaMisuraPeso')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 504, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'UnitaMisuraPeso')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 509, 6))
     st_5 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_6, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'PesoLordo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 505, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'PesoLordo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 510, 6))
     st_6 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_7, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'PesoNetto')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 506, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'PesoNetto')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 511, 6))
     st_7 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_7)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_8, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataOraRitiro')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 507, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataOraRitiro')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 512, 6))
     st_8 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_8)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_9, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataInizioTrasporto')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 508, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataInizioTrasporto')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 513, 6))
     st_9 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_9)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_10, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoResa')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 509, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoResa')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 514, 6))
     st_10 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_10)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_11, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'IndirizzoResa')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 510, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'IndirizzoResa')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 515, 6))
     st_11 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_11)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_12, False))
-    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataOraConsegna')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 511, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiTrasportoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataOraConsegna')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 516, 6))
     st_12 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_12)
     transitions = []
@@ -5201,17 +5196,17 @@ DatiTrasportoType._Automaton = _BuildAutomaton_14()
 
 
 
-IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Indirizzo'), String60LatinType, scope=IndirizzoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 516, 6)))
+IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Indirizzo'), String60LatinType, scope=IndirizzoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 521, 6)))
 
-IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroCivico'), NumeroCivicoType, scope=IndirizzoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 517, 6)))
+IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroCivico'), NumeroCivicoType, scope=IndirizzoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 522, 6)))
 
-IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CAP'), CAPType, scope=IndirizzoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 518, 6)))
+IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CAP'), CAPType, scope=IndirizzoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 523, 6)))
 
-IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Comune'), String60LatinType, scope=IndirizzoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 519, 6)))
+IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Comune'), String60LatinType, scope=IndirizzoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 524, 6)))
 
-IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Provincia'), ProvinciaType, scope=IndirizzoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 520, 6)))
+IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Provincia'), ProvinciaType, scope=IndirizzoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 525, 6)))
 
-IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Nazione'), NazioneType, scope=IndirizzoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 521, 6), unicode_default='IT'))
+IndirizzoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Nazione'), NazioneType, scope=IndirizzoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 526, 6), unicode_default='IT'))
 
 def _BuildAutomaton_15 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5220,33 +5215,33 @@ def _BuildAutomaton_15 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 517, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 522, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 520, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 525, 6))
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Indirizzo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 516, 6))
+    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Indirizzo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 521, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroCivico')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 517, 6))
+    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroCivico')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 522, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CAP')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 518, 6))
+    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CAP')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 523, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Comune')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 519, 6))
+    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Comune')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 524, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Provincia')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 520, 6))
+    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Provincia')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 525, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Nazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 521, 6))
+    symbol = pyxb.binding.content.ElementUse(IndirizzoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Nazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 526, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     transitions = []
@@ -5285,9 +5280,9 @@ IndirizzoType._Automaton = _BuildAutomaton_15()
 
 
 
-FatturaPrincipaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroFatturaPrincipale'), String20Type, scope=FatturaPrincipaleType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 526, 6)))
+FatturaPrincipaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroFatturaPrincipale'), String20Type, scope=FatturaPrincipaleType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 531, 6)))
 
-FatturaPrincipaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataFatturaPrincipale'), pyxb.binding.datatypes.date, scope=FatturaPrincipaleType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 527, 6)))
+FatturaPrincipaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataFatturaPrincipale'), pyxb.binding.datatypes.date, scope=FatturaPrincipaleType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 532, 6)))
 
 def _BuildAutomaton_16 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5298,11 +5293,11 @@ def _BuildAutomaton_16 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(FatturaPrincipaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroFatturaPrincipale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 526, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaPrincipaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroFatturaPrincipale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 531, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(FatturaPrincipaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataFatturaPrincipale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 527, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaPrincipaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataFatturaPrincipale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 532, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     transitions = []
@@ -5317,17 +5312,17 @@ FatturaPrincipaleType._Automaton = _BuildAutomaton_16()
 
 
 
-CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), DatiAnagraficiCedenteType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 550, 6)))
+CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), DatiAnagraficiCedenteType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 555, 6)))
 
-CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Sede'), IndirizzoType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 551, 6)))
+CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Sede'), IndirizzoType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 556, 6)))
 
-CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione'), IndirizzoType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 552, 6)))
+CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione'), IndirizzoType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 557, 6)))
 
-CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IscrizioneREA'), IscrizioneREAType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 553, 6)))
+CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IscrizioneREA'), IscrizioneREAType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 558, 6)))
 
-CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Contatti'), ContattiType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 554, 6)))
+CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Contatti'), ContattiType, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 559, 6)))
 
-CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), String20Type, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 555, 6)))
+CedentePrestatoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), String20Type, scope=CedentePrestatoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 560, 6)))
 
 def _BuildAutomaton_17 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5336,41 +5331,41 @@ def _BuildAutomaton_17 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 552, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 557, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 553, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 558, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 554, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 559, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 555, 6))
+    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 560, 6))
     counters.add(cc_3)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 550, 6))
+    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 555, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'Sede')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 551, 6))
+    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'Sede')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 556, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 552, 6))
+    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 557, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'IscrizioneREA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 553, 6))
+    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'IscrizioneREA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 558, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'Contatti')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 554, 6))
+    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'Contatti')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 559, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 555, 6))
+    symbol = pyxb.binding.content.ElementUse(CedentePrestatoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 560, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     transitions = []
@@ -5421,21 +5416,21 @@ CedentePrestatoreType._Automaton = _BuildAutomaton_17()
 
 
 
-DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 560, 6)))
+DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 565, 6)))
 
-DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 561, 6)))
+DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 566, 6)))
 
-DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 562, 6)))
+DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 567, 6)))
 
-DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AlboProfessionale'), String60LatinType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 563, 6)))
+DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AlboProfessionale'), String60LatinType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 568, 6)))
 
-DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ProvinciaAlbo'), ProvinciaType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 564, 6)))
+DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ProvinciaAlbo'), ProvinciaType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 569, 6)))
 
-DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroIscrizioneAlbo'), String60Type, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 565, 6)))
+DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroIscrizioneAlbo'), String60Type, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 570, 6)))
 
-DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataIscrizioneAlbo'), pyxb.binding.datatypes.date, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 566, 6)))
+DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataIscrizioneAlbo'), pyxb.binding.datatypes.date, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 571, 6)))
 
-DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RegimeFiscale'), RegimeFiscaleType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 567, 6)))
+DatiAnagraficiCedenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RegimeFiscale'), RegimeFiscaleType, scope=DatiAnagraficiCedenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 572, 6)))
 
 def _BuildAutomaton_18 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5444,47 +5439,47 @@ def _BuildAutomaton_18 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 561, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 566, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 563, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 568, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 564, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 569, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 565, 6))
+    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 570, 6))
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 566, 6))
+    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 571, 6))
     counters.add(cc_4)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 560, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 565, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 561, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 566, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 562, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 567, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'AlboProfessionale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 563, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'AlboProfessionale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 568, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'ProvinciaAlbo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 564, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'ProvinciaAlbo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 569, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroIscrizioneAlbo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 565, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroIscrizioneAlbo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 570, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataIscrizioneAlbo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 566, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataIscrizioneAlbo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 571, 6))
     st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'RegimeFiscale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 567, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCedenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'RegimeFiscale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 572, 6))
     st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_7)
     transitions = []
@@ -5555,15 +5550,15 @@ DatiAnagraficiCedenteType._Automaton = _BuildAutomaton_18()
 
 
 
-AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Denominazione'), String80LatinType, scope=AnagraficaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 672, 10)))
+AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Denominazione'), String80LatinType, scope=AnagraficaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 677, 10)))
 
-AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Nome'), String60LatinType, scope=AnagraficaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 675, 10)))
+AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Nome'), String60LatinType, scope=AnagraficaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 680, 10)))
 
-AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Cognome'), String60LatinType, scope=AnagraficaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 676, 10)))
+AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Cognome'), String60LatinType, scope=AnagraficaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 681, 10)))
 
-AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Titolo'), TitoloType, scope=AnagraficaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 679, 6)))
+AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Titolo'), TitoloType, scope=AnagraficaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 684, 6)))
 
-AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodEORI'), CodEORIType, scope=AnagraficaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 680, 6)))
+AnagraficaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodEORI'), CodEORIType, scope=AnagraficaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 685, 6)))
 
 def _BuildAutomaton_19 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5572,31 +5567,31 @@ def _BuildAutomaton_19 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 679, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 684, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 680, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 685, 6))
     counters.add(cc_1)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'Denominazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 672, 10))
+    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'Denominazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 677, 10))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'Nome')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 675, 10))
+    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'Nome')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 680, 10))
     st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'Cognome')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 676, 10))
+    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'Cognome')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 681, 10))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'Titolo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 679, 6))
+    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'Titolo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 684, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodEORI')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 680, 6))
+    symbol = pyxb.binding.content.ElementUse(AnagraficaType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodEORI')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 685, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     transitions = []
@@ -5631,13 +5626,13 @@ AnagraficaType._Automaton = _BuildAutomaton_19()
 
 
 
-DatiAnagraficiVettoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiVettoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 685, 6)))
+DatiAnagraficiVettoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiVettoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 690, 6)))
 
-DatiAnagraficiVettoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiVettoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 686, 6)))
+DatiAnagraficiVettoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiVettoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 691, 6)))
 
-DatiAnagraficiVettoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiVettoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 687, 6)))
+DatiAnagraficiVettoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiVettoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 692, 6)))
 
-DatiAnagraficiVettoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroLicenzaGuida'), String20Type, scope=DatiAnagraficiVettoreType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 688, 6)))
+DatiAnagraficiVettoreType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroLicenzaGuida'), String20Type, scope=DatiAnagraficiVettoreType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 693, 6)))
 
 def _BuildAutomaton_20 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5646,26 +5641,26 @@ def _BuildAutomaton_20 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 686, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 691, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 688, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 693, 6))
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiVettoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 685, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiVettoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 690, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiVettoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 686, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiVettoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 691, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiVettoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 687, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiVettoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 692, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiVettoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroLicenzaGuida')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 688, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiVettoreType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroLicenzaGuida')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 693, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     transitions = []
@@ -5694,15 +5689,15 @@ DatiAnagraficiVettoreType._Automaton = _BuildAutomaton_20()
 
 
 
-IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Ufficio'), ProvinciaType, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 693, 6)))
+IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Ufficio'), ProvinciaType, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 698, 6)))
 
-IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroREA'), String20Type, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 694, 6)))
+IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroREA'), String20Type, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 699, 6)))
 
-IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CapitaleSociale'), Amount2DecimalType, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 695, 6)))
+IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CapitaleSociale'), Amount2DecimalType, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 700, 6)))
 
-IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'SocioUnico'), SocioUnicoType, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 696, 6)))
+IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'SocioUnico'), SocioUnicoType, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 701, 6)))
 
-IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'StatoLiquidazione'), StatoLiquidazioneType, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 697, 6)))
+IscrizioneREAType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'StatoLiquidazione'), StatoLiquidazioneType, scope=IscrizioneREAType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 702, 6)))
 
 def _BuildAutomaton_21 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5711,29 +5706,29 @@ def _BuildAutomaton_21 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 695, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 700, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 696, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 701, 6))
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'Ufficio')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 693, 6))
+    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'Ufficio')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 698, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroREA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 694, 6))
+    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroREA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 699, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'CapitaleSociale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 695, 6))
+    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'CapitaleSociale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 700, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'SocioUnico')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 696, 6))
+    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'SocioUnico')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 701, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'StatoLiquidazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 697, 6))
+    symbol = pyxb.binding.content.ElementUse(IscrizioneREAType._UseForTag(pyxb.namespace.ExpandedName(None, 'StatoLiquidazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 702, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     transitions = []
@@ -5770,11 +5765,11 @@ IscrizioneREAType._Automaton = _BuildAutomaton_21()
 
 
 
-ContattiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Telefono'), TelFaxType, scope=ContattiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 702, 6)))
+ContattiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Telefono'), TelFaxType, scope=ContattiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 707, 6)))
 
-ContattiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Fax'), TelFaxType, scope=ContattiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 703, 6)))
+ContattiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Fax'), TelFaxType, scope=ContattiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 708, 6)))
 
-ContattiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Email'), EmailContattiType, scope=ContattiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 704, 6)))
+ContattiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Email'), EmailContattiType, scope=ContattiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 709, 6)))
 
 def _BuildAutomaton_22 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5783,26 +5778,26 @@ def _BuildAutomaton_22 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 702, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 707, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 703, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 708, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 704, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 709, 6))
     counters.add(cc_2)
     states = []
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(ContattiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Telefono')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 702, 6))
+    symbol = pyxb.binding.content.ElementUse(ContattiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Telefono')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 707, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(ContattiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Fax')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 703, 6))
+    symbol = pyxb.binding.content.ElementUse(ContattiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Fax')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 708, 6))
     st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(ContattiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Email')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 704, 6))
+    symbol = pyxb.binding.content.ElementUse(ContattiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Email')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 709, 6))
     st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     transitions = []
@@ -5829,7 +5824,7 @@ ContattiType._Automaton = _BuildAutomaton_22()
 
 
 
-RappresentanteFiscaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), DatiAnagraficiRappresentanteType, scope=RappresentanteFiscaleType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 712, 6)))
+RappresentanteFiscaleType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), DatiAnagraficiRappresentanteType, scope=RappresentanteFiscaleType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 717, 6)))
 
 def _BuildAutomaton_23 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5840,7 +5835,7 @@ def _BuildAutomaton_23 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 712, 6))
+    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 717, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     transitions = []
@@ -5851,11 +5846,11 @@ RappresentanteFiscaleType._Automaton = _BuildAutomaton_23()
 
 
 
-DatiAnagraficiRappresentanteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiRappresentanteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 717, 6)))
+DatiAnagraficiRappresentanteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiRappresentanteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 722, 6)))
 
-DatiAnagraficiRappresentanteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiRappresentanteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 718, 6)))
+DatiAnagraficiRappresentanteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiRappresentanteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 723, 6)))
 
-DatiAnagraficiRappresentanteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiRappresentanteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 719, 6)))
+DatiAnagraficiRappresentanteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiRappresentanteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 724, 6)))
 
 def _BuildAutomaton_24 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5864,19 +5859,19 @@ def _BuildAutomaton_24 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 718, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 723, 6))
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiRappresentanteType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 717, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiRappresentanteType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 722, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiRappresentanteType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 718, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiRappresentanteType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 723, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiRappresentanteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 719, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiRappresentanteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 724, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     transitions = []
@@ -5899,13 +5894,13 @@ DatiAnagraficiRappresentanteType._Automaton = _BuildAutomaton_24()
 
 
 
-CessionarioCommittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), DatiAnagraficiCessionarioType, scope=CessionarioCommittenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 727, 6)))
+CessionarioCommittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), DatiAnagraficiCessionarioType, scope=CessionarioCommittenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 732, 6)))
 
-CessionarioCommittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Sede'), IndirizzoType, scope=CessionarioCommittenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 728, 6)))
+CessionarioCommittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Sede'), IndirizzoType, scope=CessionarioCommittenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 733, 6)))
 
-CessionarioCommittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione'), IndirizzoType, scope=CessionarioCommittenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 729, 3)))
+CessionarioCommittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione'), IndirizzoType, scope=CessionarioCommittenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 734, 3)))
 
-CessionarioCommittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale'), RappresentanteFiscaleCessionarioType, scope=CessionarioCommittenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 730, 6)))
+CessionarioCommittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale'), RappresentanteFiscaleCessionarioType, scope=CessionarioCommittenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 735, 6)))
 
 def _BuildAutomaton_25 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5914,27 +5909,27 @@ def _BuildAutomaton_25 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 729, 3))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 734, 3))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 730, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 735, 6))
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CessionarioCommittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 727, 6))
+    symbol = pyxb.binding.content.ElementUse(CessionarioCommittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 732, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CessionarioCommittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Sede')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 728, 6))
+    symbol = pyxb.binding.content.ElementUse(CessionarioCommittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'Sede')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 733, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(CessionarioCommittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 729, 3))
+    symbol = pyxb.binding.content.ElementUse(CessionarioCommittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'StabileOrganizzazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 734, 3))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(CessionarioCommittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 730, 6))
+    symbol = pyxb.binding.content.ElementUse(CessionarioCommittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'RappresentanteFiscale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 735, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     transitions = []
@@ -5963,13 +5958,13 @@ CessionarioCommittenteType._Automaton = _BuildAutomaton_25()
 
 
 
-RappresentanteFiscaleCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=RappresentanteFiscaleCessionarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 735, 3)))
+RappresentanteFiscaleCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=RappresentanteFiscaleCessionarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 740, 3)))
 
-RappresentanteFiscaleCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Denominazione'), String80LatinType, scope=RappresentanteFiscaleCessionarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 738, 10)))
+RappresentanteFiscaleCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Denominazione'), String80LatinType, scope=RappresentanteFiscaleCessionarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 743, 10)))
 
-RappresentanteFiscaleCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Nome'), String60LatinType, scope=RappresentanteFiscaleCessionarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 741, 10)))
+RappresentanteFiscaleCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Nome'), String60LatinType, scope=RappresentanteFiscaleCessionarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 746, 10)))
 
-RappresentanteFiscaleCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Cognome'), String60LatinType, scope=RappresentanteFiscaleCessionarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 742, 10)))
+RappresentanteFiscaleCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Cognome'), String60LatinType, scope=RappresentanteFiscaleCessionarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 747, 10)))
 
 def _BuildAutomaton_26 ():
     # Remove this helper function from the namespace after it is invoked
@@ -5980,19 +5975,19 @@ def _BuildAutomaton_26 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 735, 3))
+    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 740, 3))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Denominazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 738, 10))
+    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Denominazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 743, 10))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Nome')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 741, 10))
+    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Nome')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 746, 10))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Cognome')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 742, 10))
+    symbol = pyxb.binding.content.ElementUse(RappresentanteFiscaleCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Cognome')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 747, 10))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     transitions = []
@@ -6015,11 +6010,11 @@ RappresentanteFiscaleCessionarioType._Automaton = _BuildAutomaton_26()
 
 
 
-DatiAnagraficiCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiCessionarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 749, 6)))
+DatiAnagraficiCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiCessionarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 754, 6)))
 
-DatiAnagraficiCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiCessionarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 750, 6)))
+DatiAnagraficiCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiCessionarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 755, 6)))
 
-DatiAnagraficiCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiCessionarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 751, 6)))
+DatiAnagraficiCessionarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiCessionarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 756, 6)))
 
 def _BuildAutomaton_27 ():
     # Remove this helper function from the namespace after it is invoked
@@ -6028,21 +6023,21 @@ def _BuildAutomaton_27 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 749, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 754, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 750, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 755, 6))
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 749, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 754, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 750, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 755, 6))
     st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 751, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiCessionarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 756, 6))
     st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     transitions = []
@@ -6067,9 +6062,9 @@ DatiAnagraficiCessionarioType._Automaton = _BuildAutomaton_27()
 
 
 
-DatiBeniServiziType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DettaglioLinee'), DettaglioLineeType, scope=DatiBeniServiziType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 759, 6)))
+DatiBeniServiziType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DettaglioLinee'), DettaglioLineeType, scope=DatiBeniServiziType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 764, 6)))
 
-DatiBeniServiziType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiRiepilogo'), DatiRiepilogoType, scope=DatiBeniServiziType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 760, 6)))
+DatiBeniServiziType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiRiepilogo'), DatiRiepilogoType, scope=DatiBeniServiziType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 765, 6)))
 
 def _BuildAutomaton_28 ():
     # Remove this helper function from the namespace after it is invoked
@@ -6080,11 +6075,11 @@ def _BuildAutomaton_28 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiBeniServiziType._UseForTag(pyxb.namespace.ExpandedName(None, 'DettaglioLinee')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 759, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiBeniServiziType._UseForTag(pyxb.namespace.ExpandedName(None, 'DettaglioLinee')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 764, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiBeniServiziType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiRiepilogo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 760, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiBeniServiziType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiRiepilogo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 765, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     transitions = []
@@ -6103,9 +6098,9 @@ DatiBeniServiziType._Automaton = _BuildAutomaton_28()
 
 
 
-DatiVeicoliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Data'), pyxb.binding.datatypes.date, scope=DatiVeicoliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 769, 6)))
+DatiVeicoliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Data'), pyxb.binding.datatypes.date, scope=DatiVeicoliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 774, 6)))
 
-DatiVeicoliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TotalePercorso'), String15Type, scope=DatiVeicoliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 770, 6)))
+DatiVeicoliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TotalePercorso'), String15Type, scope=DatiVeicoliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 775, 6)))
 
 def _BuildAutomaton_29 ():
     # Remove this helper function from the namespace after it is invoked
@@ -6116,11 +6111,11 @@ def _BuildAutomaton_29 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiVeicoliType._UseForTag(pyxb.namespace.ExpandedName(None, 'Data')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 769, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiVeicoliType._UseForTag(pyxb.namespace.ExpandedName(None, 'Data')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 774, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiVeicoliType._UseForTag(pyxb.namespace.ExpandedName(None, 'TotalePercorso')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 770, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiVeicoliType._UseForTag(pyxb.namespace.ExpandedName(None, 'TotalePercorso')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 775, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     transitions = []
@@ -6135,9 +6130,9 @@ DatiVeicoliType._Automaton = _BuildAutomaton_29()
 
 
 
-DatiPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CondizioniPagamento'), CondizioniPagamentoType, scope=DatiPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 778, 6)))
+DatiPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CondizioniPagamento'), CondizioniPagamentoType, scope=DatiPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 783, 6)))
 
-DatiPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DettaglioPagamento'), DettaglioPagamentoType, scope=DatiPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 779, 6)))
+DatiPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DettaglioPagamento'), DettaglioPagamentoType, scope=DatiPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 784, 6)))
 
 def _BuildAutomaton_30 ():
     # Remove this helper function from the namespace after it is invoked
@@ -6148,11 +6143,11 @@ def _BuildAutomaton_30 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CondizioniPagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 778, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CondizioniPagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 783, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DettaglioPagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 779, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DettaglioPagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 784, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     transitions = []
@@ -6169,47 +6164,47 @@ DatiPagamentoType._Automaton = _BuildAutomaton_30()
 
 
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Beneficiario'), String200LatinType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 805, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Beneficiario'), String200LatinType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 810, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ModalitaPagamento'), ModalitaPagamentoType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 806, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ModalitaPagamento'), ModalitaPagamentoType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 811, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataRiferimentoTerminiPagamento'), pyxb.binding.datatypes.date, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 807, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataRiferimentoTerminiPagamento'), pyxb.binding.datatypes.date, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 812, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'GiorniTerminiPagamento'), GiorniTerminePagamentoType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 808, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'GiorniTerminiPagamento'), GiorniTerminePagamentoType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 813, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataScadenzaPagamento'), pyxb.binding.datatypes.date, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 809, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataScadenzaPagamento'), pyxb.binding.datatypes.date, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 814, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoPagamento'), Amount2DecimalType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 810, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImportoPagamento'), Amount2DecimalType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 815, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodUfficioPostale'), String20Type, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 811, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodUfficioPostale'), String20Type, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 816, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CognomeQuietanzante'), String60LatinType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 812, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CognomeQuietanzante'), String60LatinType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 817, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NomeQuietanzante'), String60LatinType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 813, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NomeQuietanzante'), String60LatinType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 818, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CFQuietanzante'), CodiceFiscalePFType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 814, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CFQuietanzante'), CodiceFiscalePFType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 819, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TitoloQuietanzante'), TitoloType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 815, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TitoloQuietanzante'), TitoloType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 820, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IstitutoFinanziario'), String80LatinType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 816, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IstitutoFinanziario'), String80LatinType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 821, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IBAN'), IBANType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 817, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IBAN'), IBANType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 822, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ABI'), ABIType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 818, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ABI'), ABIType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 823, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CAB'), CABType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 819, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CAB'), CABType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 824, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'BIC'), BICType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 820, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'BIC'), BICType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 825, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ScontoPagamentoAnticipato'), Amount2DecimalType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 821, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ScontoPagamentoAnticipato'), Amount2DecimalType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 826, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataLimitePagamentoAnticipato'), pyxb.binding.datatypes.date, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 822, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataLimitePagamentoAnticipato'), pyxb.binding.datatypes.date, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 827, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PenalitaPagamentiRitardati'), Amount2DecimalType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 823, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PenalitaPagamentiRitardati'), Amount2DecimalType, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 828, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataDecorrenzaPenale'), pyxb.binding.datatypes.date, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 824, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataDecorrenzaPenale'), pyxb.binding.datatypes.date, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 829, 6)))
 
-DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodicePagamento'), String60Type, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 825, 6)))
+DettaglioPagamentoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodicePagamento'), String60Type, scope=DettaglioPagamentoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 830, 6)))
 
 def _BuildAutomaton_31 ():
     # Remove this helper function from the namespace after it is invoked
@@ -6218,142 +6213,142 @@ def _BuildAutomaton_31 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 805, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 810, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 807, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 812, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 808, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 813, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 809, 6))
+    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 814, 6))
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 811, 6))
+    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 816, 6))
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 812, 6))
+    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 817, 6))
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 813, 6))
+    cc_6 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 818, 6))
     counters.add(cc_6)
-    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 814, 6))
+    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 819, 6))
     counters.add(cc_7)
-    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 815, 6))
+    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 820, 6))
     counters.add(cc_8)
-    cc_9 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 816, 6))
+    cc_9 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 821, 6))
     counters.add(cc_9)
-    cc_10 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 817, 6))
+    cc_10 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 822, 6))
     counters.add(cc_10)
-    cc_11 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 818, 6))
+    cc_11 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 823, 6))
     counters.add(cc_11)
-    cc_12 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 819, 6))
+    cc_12 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 824, 6))
     counters.add(cc_12)
-    cc_13 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 820, 6))
+    cc_13 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 825, 6))
     counters.add(cc_13)
-    cc_14 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 821, 6))
+    cc_14 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 826, 6))
     counters.add(cc_14)
-    cc_15 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 822, 6))
+    cc_15 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 827, 6))
     counters.add(cc_15)
-    cc_16 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 823, 6))
+    cc_16 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 828, 6))
     counters.add(cc_16)
-    cc_17 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 824, 6))
+    cc_17 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 829, 6))
     counters.add(cc_17)
-    cc_18 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 825, 6))
+    cc_18 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 830, 6))
     counters.add(cc_18)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Beneficiario')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 805, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Beneficiario')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 810, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ModalitaPagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 806, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ModalitaPagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 811, 6))
     st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataRiferimentoTerminiPagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 807, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataRiferimentoTerminiPagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 812, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'GiorniTerminiPagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 808, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'GiorniTerminiPagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 813, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataScadenzaPagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 809, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataScadenzaPagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 814, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoPagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 810, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImportoPagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 815, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodUfficioPostale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 811, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodUfficioPostale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 816, 6))
     st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_5, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CognomeQuietanzante')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 812, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CognomeQuietanzante')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 817, 6))
     st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_7)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_6, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'NomeQuietanzante')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 813, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'NomeQuietanzante')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 818, 6))
     st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_8)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_7, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CFQuietanzante')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 814, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CFQuietanzante')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 819, 6))
     st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_9)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_8, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'TitoloQuietanzante')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 815, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'TitoloQuietanzante')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 820, 6))
     st_10 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_10)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_9, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'IstitutoFinanziario')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 816, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'IstitutoFinanziario')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 821, 6))
     st_11 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_11)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_10, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'IBAN')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 817, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'IBAN')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 822, 6))
     st_12 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_12)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_11, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ABI')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 818, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ABI')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 823, 6))
     st_13 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_13)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_12, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CAB')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 819, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CAB')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 824, 6))
     st_14 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_14)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_13, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'BIC')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 820, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'BIC')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 825, 6))
     st_15 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_15)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_14, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ScontoPagamentoAnticipato')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 821, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ScontoPagamentoAnticipato')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 826, 6))
     st_16 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_16)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_15, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataLimitePagamentoAnticipato')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 822, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataLimitePagamentoAnticipato')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 827, 6))
     st_17 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_17)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_16, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'PenalitaPagamentiRitardati')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 823, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'PenalitaPagamentiRitardati')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 828, 6))
     st_18 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_18)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_17, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataDecorrenzaPenale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 824, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataDecorrenzaPenale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 829, 6))
     st_19 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_19)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_18, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodicePagamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 825, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioPagamentoType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodicePagamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 830, 6))
     st_20 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_20)
     transitions = []
@@ -6704,7 +6699,7 @@ DettaglioPagamentoType._Automaton = _BuildAutomaton_31()
 
 
 
-TerzoIntermediarioSoggettoEmittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), DatiAnagraficiTerzoIntermediarioType, scope=TerzoIntermediarioSoggettoEmittenteType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 963, 6)))
+TerzoIntermediarioSoggettoEmittenteType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici'), DatiAnagraficiTerzoIntermediarioType, scope=TerzoIntermediarioSoggettoEmittenteType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 968, 6)))
 
 def _BuildAutomaton_32 ():
     # Remove this helper function from the namespace after it is invoked
@@ -6715,7 +6710,7 @@ def _BuildAutomaton_32 ():
     counters = set()
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(TerzoIntermediarioSoggettoEmittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 963, 6))
+    symbol = pyxb.binding.content.ElementUse(TerzoIntermediarioSoggettoEmittenteType._UseForTag(pyxb.namespace.ExpandedName(None, 'DatiAnagrafici')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 968, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     transitions = []
@@ -6726,11 +6721,11 @@ TerzoIntermediarioSoggettoEmittenteType._Automaton = _BuildAutomaton_32()
 
 
 
-DatiAnagraficiTerzoIntermediarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiTerzoIntermediarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 968, 6)))
+DatiAnagraficiTerzoIntermediarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA'), IdFiscaleType, scope=DatiAnagraficiTerzoIntermediarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 973, 6)))
 
-DatiAnagraficiTerzoIntermediarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiTerzoIntermediarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 969, 6)))
+DatiAnagraficiTerzoIntermediarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceFiscale'), CodiceFiscaleType, scope=DatiAnagraficiTerzoIntermediarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 974, 6)))
 
-DatiAnagraficiTerzoIntermediarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiTerzoIntermediarioType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 970, 6)))
+DatiAnagraficiTerzoIntermediarioType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Anagrafica'), AnagraficaType, scope=DatiAnagraficiTerzoIntermediarioType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 975, 6)))
 
 def _BuildAutomaton_33 ():
     # Remove this helper function from the namespace after it is invoked
@@ -6739,21 +6734,21 @@ def _BuildAutomaton_33 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 968, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 973, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 969, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 974, 6))
     counters.add(cc_1)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiTerzoIntermediarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 968, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiTerzoIntermediarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'IdFiscaleIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 973, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiTerzoIntermediarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 969, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiTerzoIntermediarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceFiscale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 974, 6))
     st_1 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiTerzoIntermediarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 970, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiAnagraficiTerzoIntermediarioType._UseForTag(pyxb.namespace.ExpandedName(None, 'Anagrafica')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 975, 6))
     st_2 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     transitions = []
@@ -6778,15 +6773,15 @@ DatiAnagraficiTerzoIntermediarioType._Automaton = _BuildAutomaton_33()
 
 
 
-AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NomeAttachment'), String60LatinType, scope=AllegatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 978, 6)))
+AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NomeAttachment'), String60LatinType, scope=AllegatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 983, 6)))
 
-AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AlgoritmoCompressione'), String10Type, scope=AllegatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 979, 6)))
+AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AlgoritmoCompressione'), String10Type, scope=AllegatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 984, 6)))
 
-AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FormatoAttachment'), String10Type, scope=AllegatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 980, 6)))
+AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FormatoAttachment'), String10Type, scope=AllegatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 985, 6)))
 
-AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DescrizioneAttachment'), String100LatinType, scope=AllegatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 981, 6)))
+AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DescrizioneAttachment'), String100LatinType, scope=AllegatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 986, 6)))
 
-AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Attachment'), pyxb.binding.datatypes.base64Binary, scope=AllegatiType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 982, 6)))
+AllegatiType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Attachment'), pyxb.binding.datatypes.base64Binary, scope=AllegatiType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 987, 6)))
 
 def _BuildAutomaton_34 ():
     # Remove this helper function from the namespace after it is invoked
@@ -6795,31 +6790,31 @@ def _BuildAutomaton_34 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 979, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 984, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 980, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 985, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 981, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 986, 6))
     counters.add(cc_2)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'NomeAttachment')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 978, 6))
+    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'NomeAttachment')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 983, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'AlgoritmoCompressione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 979, 6))
+    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'AlgoritmoCompressione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 984, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'FormatoAttachment')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 980, 6))
+    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'FormatoAttachment')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 985, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'DescrizioneAttachment')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 981, 6))
+    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'DescrizioneAttachment')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 986, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Attachment')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 982, 6))
+    symbol = pyxb.binding.content.ElementUse(AllegatiType._UseForTag(pyxb.namespace.ExpandedName(None, 'Attachment')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 987, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     transitions = []
@@ -6864,37 +6859,37 @@ AllegatiType._Automaton = _BuildAutomaton_34()
 
 
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroLinea'), NumeroLineaType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 987, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'NumeroLinea'), NumeroLineaType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 992, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoCessionePrestazione'), TipoCessionePrestazioneType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 988, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoCessionePrestazione'), TipoCessionePrestazioneType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 993, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceArticolo'), CodiceArticoloType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 989, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceArticolo'), CodiceArticoloType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 994, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Descrizione'), String1000LatinType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 990, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Descrizione'), String1000LatinType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 995, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Quantita'), QuantitaType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 991, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Quantita'), QuantitaType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 996, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'UnitaMisura'), String10Type, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 992, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'UnitaMisura'), String10Type, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 997, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataInizioPeriodo'), pyxb.binding.datatypes.date, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 993, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataInizioPeriodo'), pyxb.binding.datatypes.date, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 998, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataFinePeriodo'), pyxb.binding.datatypes.date, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 994, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'DataFinePeriodo'), pyxb.binding.datatypes.date, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 999, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PrezzoUnitario'), Amount8DecimalType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 995, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PrezzoUnitario'), Amount8DecimalType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1000, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione'), ScontoMaggiorazioneType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 996, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione'), ScontoMaggiorazioneType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1001, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PrezzoTotale'), Amount8DecimalType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 997, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'PrezzoTotale'), Amount8DecimalType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1002, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), RateType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 998, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), RateType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1003, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Ritenuta'), RitenutaType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 999, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Ritenuta'), RitenutaType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1004, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Natura'), NaturaType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1000, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Natura'), NaturaType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1005, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), String20Type, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1001, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione'), String20Type, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1006, 6)))
 
-DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AltriDatiGestionali'), AltriDatiGestionaliType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1002, 6)))
+DettaglioLineeType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AltriDatiGestionali'), AltriDatiGestionaliType, scope=DettaglioLineeType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1007, 6)))
 
 def _BuildAutomaton_35 ():
     # Remove this helper function from the namespace after it is invoked
@@ -6903,95 +6898,95 @@ def _BuildAutomaton_35 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 988, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 993, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 989, 6))
+    cc_1 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 994, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 991, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 996, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 992, 6))
+    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 997, 6))
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 993, 6))
+    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 998, 6))
     counters.add(cc_4)
-    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 994, 6))
+    cc_5 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 999, 6))
     counters.add(cc_5)
-    cc_6 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 996, 6))
+    cc_6 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1001, 6))
     counters.add(cc_6)
-    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 999, 6))
+    cc_7 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1004, 6))
     counters.add(cc_7)
-    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1000, 6))
+    cc_8 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1005, 6))
     counters.add(cc_8)
-    cc_9 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1001, 6))
+    cc_9 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1006, 6))
     counters.add(cc_9)
-    cc_10 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1002, 6))
+    cc_10 = fac.CounterCondition(min=0, max=None, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1007, 6))
     counters.add(cc_10)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroLinea')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 987, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'NumeroLinea')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 992, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoCessionePrestazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 988, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoCessionePrestazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 993, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceArticolo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 989, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceArticolo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 994, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Descrizione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 990, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Descrizione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 995, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Quantita')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 991, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Quantita')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 996, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'UnitaMisura')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 992, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'UnitaMisura')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 997, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataInizioPeriodo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 993, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataInizioPeriodo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 998, 6))
     st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataFinePeriodo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 994, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'DataFinePeriodo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 999, 6))
     st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_7)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'PrezzoUnitario')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 995, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'PrezzoUnitario')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1000, 6))
     st_8 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_8)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 996, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'ScontoMaggiorazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1001, 6))
     st_9 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_9)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'PrezzoTotale')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 997, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'PrezzoTotale')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1002, 6))
     st_10 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_10)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'AliquotaIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 998, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'AliquotaIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1003, 6))
     st_11 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_11)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_7, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Ritenuta')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 999, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Ritenuta')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1004, 6))
     st_12 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_12)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_8, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Natura')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1000, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'Natura')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1005, 6))
     st_13 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_13)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_9, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1001, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoAmministrazione')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1006, 6))
     st_14 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_14)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_10, False))
-    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'AltriDatiGestionali')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1002, 6))
+    symbol = pyxb.binding.content.ElementUse(DettaglioLineeType._UseForTag(pyxb.namespace.ExpandedName(None, 'AltriDatiGestionali')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1007, 6))
     st_15 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_15)
     transitions = []
@@ -7124,9 +7119,9 @@ DettaglioLineeType._Automaton = _BuildAutomaton_35()
 
 
 
-CodiceArticoloType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceTipo'), String35Type, scope=CodiceArticoloType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1007, 6)))
+CodiceArticoloType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceTipo'), String35Type, scope=CodiceArticoloType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1012, 6)))
 
-CodiceArticoloType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceValore'), String35LatinExtType, scope=CodiceArticoloType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1008, 6)))
+CodiceArticoloType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'CodiceValore'), String35LatinExtType, scope=CodiceArticoloType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1013, 6)))
 
 def _BuildAutomaton_36 ():
     # Remove this helper function from the namespace after it is invoked
@@ -7137,11 +7132,11 @@ def _BuildAutomaton_36 ():
     counters = set()
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(CodiceArticoloType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceTipo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1007, 6))
+    symbol = pyxb.binding.content.ElementUse(CodiceArticoloType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceTipo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1012, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(CodiceArticoloType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceValore')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1008, 6))
+    symbol = pyxb.binding.content.ElementUse(CodiceArticoloType._UseForTag(pyxb.namespace.ExpandedName(None, 'CodiceValore')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1013, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     transitions = []
@@ -7156,13 +7151,13 @@ CodiceArticoloType._Automaton = _BuildAutomaton_36()
 
 
 
-AltriDatiGestionaliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoDato'), String10Type, scope=AltriDatiGestionaliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1013, 6)))
+AltriDatiGestionaliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'TipoDato'), String10Type, scope=AltriDatiGestionaliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1018, 6)))
 
-AltriDatiGestionaliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoTesto'), String60LatinType, scope=AltriDatiGestionaliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1014, 6)))
+AltriDatiGestionaliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoTesto'), String60LatinType, scope=AltriDatiGestionaliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1019, 6)))
 
-AltriDatiGestionaliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoNumero'), Amount8DecimalType, scope=AltriDatiGestionaliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1015, 6)))
+AltriDatiGestionaliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoNumero'), Amount8DecimalType, scope=AltriDatiGestionaliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1020, 6)))
 
-AltriDatiGestionaliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoData'), pyxb.binding.datatypes.date, scope=AltriDatiGestionaliType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1016, 6)))
+AltriDatiGestionaliType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoData'), pyxb.binding.datatypes.date, scope=AltriDatiGestionaliType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1021, 6)))
 
 def _BuildAutomaton_37 ():
     # Remove this helper function from the namespace after it is invoked
@@ -7171,30 +7166,30 @@ def _BuildAutomaton_37 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1014, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1019, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1015, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1020, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1016, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1021, 6))
     counters.add(cc_2)
     states = []
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(AltriDatiGestionaliType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoDato')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1013, 6))
+    symbol = pyxb.binding.content.ElementUse(AltriDatiGestionaliType._UseForTag(pyxb.namespace.ExpandedName(None, 'TipoDato')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1018, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(AltriDatiGestionaliType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoTesto')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1014, 6))
+    symbol = pyxb.binding.content.ElementUse(AltriDatiGestionaliType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoTesto')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1019, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_1, False))
-    symbol = pyxb.binding.content.ElementUse(AltriDatiGestionaliType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoNumero')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1015, 6))
+    symbol = pyxb.binding.content.ElementUse(AltriDatiGestionaliType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoNumero')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1020, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_2, False))
-    symbol = pyxb.binding.content.ElementUse(AltriDatiGestionaliType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoData')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1016, 6))
+    symbol = pyxb.binding.content.ElementUse(AltriDatiGestionaliType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoData')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1021, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     transitions = []
@@ -7229,21 +7224,21 @@ AltriDatiGestionaliType._Automaton = _BuildAutomaton_37()
 
 
 
-DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), RateType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1031, 6)))
+DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'AliquotaIVA'), RateType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1036, 6)))
 
-DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Natura'), NaturaType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1032, 6)))
+DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Natura'), NaturaType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1037, 6)))
 
-DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'SpeseAccessorie'), Amount2DecimalType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1033, 6)))
+DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'SpeseAccessorie'), Amount2DecimalType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1038, 6)))
 
-DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Arrotondamento'), Amount8DecimalType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1034, 6)))
+DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Arrotondamento'), Amount8DecimalType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1039, 6)))
 
-DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImponibileImporto'), Amount2DecimalType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1035, 6)))
+DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'ImponibileImporto'), Amount2DecimalType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1040, 6)))
 
-DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Imposta'), Amount2DecimalType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1036, 6)))
+DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'Imposta'), Amount2DecimalType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1041, 6)))
 
-DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'EsigibilitaIVA'), EsigibilitaIVAType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1037, 6)))
+DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'EsigibilitaIVA'), EsigibilitaIVAType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1042, 6)))
 
-DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoNormativo'), String100LatinType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1038, 6)))
+DatiRiepilogoType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'RiferimentoNormativo'), String100LatinType, scope=DatiRiepilogoType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1043, 6)))
 
 def _BuildAutomaton_38 ():
     # Remove this helper function from the namespace after it is invoked
@@ -7252,49 +7247,49 @@ def _BuildAutomaton_38 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1032, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1037, 6))
     counters.add(cc_0)
-    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1033, 6))
+    cc_1 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1038, 6))
     counters.add(cc_1)
-    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1034, 6))
+    cc_2 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1039, 6))
     counters.add(cc_2)
-    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1037, 6))
+    cc_3 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1042, 6))
     counters.add(cc_3)
-    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1038, 6))
+    cc_4 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1043, 6))
     counters.add(cc_4)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'AliquotaIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1031, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'AliquotaIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1036, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Natura')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1032, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Natura')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1037, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'SpeseAccessorie')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1033, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'SpeseAccessorie')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1038, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Arrotondamento')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1034, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Arrotondamento')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1039, 6))
     st_3 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_3)
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImponibileImporto')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1035, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'ImponibileImporto')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1040, 6))
     st_4 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_4)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Imposta')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1036, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'Imposta')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1041, 6))
     st_5 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_5)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_3, False))
-    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'EsigibilitaIVA')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1037, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'EsigibilitaIVA')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1042, 6))
     st_6 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_6)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_4, False))
-    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoNormativo')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 1038, 6))
+    symbol = pyxb.binding.content.ElementUse(DatiRiepilogoType._UseForTag(pyxb.namespace.ExpandedName(None, 'RiferimentoNormativo')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 1043, 6))
     st_7 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_7)
     transitions = []
@@ -7357,9 +7352,9 @@ DatiRiepilogoType._Automaton = _BuildAutomaton_38()
 
 
 
-FatturaElettronicaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaHeader'), FatturaElettronicaHeaderType, scope=FatturaElettronicaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 18, 6)))
+FatturaElettronicaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaHeader'), FatturaElettronicaHeaderType, scope=FatturaElettronicaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 18, 6)))
 
-FatturaElettronicaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaBody'), FatturaElettronicaBodyType, scope=FatturaElettronicaType, location=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 19, 6)))
+FatturaElettronicaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaBody'), FatturaElettronicaBodyType, scope=FatturaElettronicaType, location=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 19, 6)))
 
 FatturaElettronicaType._AddElement(pyxb.binding.basis.element(pyxb.namespace.ExpandedName(_Namespace_ds, 'Signature'), _ImportedBinding__ds.SignatureType, scope=FatturaElettronicaType, location=pyxb.utils.utility.Location('http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd', 43, 0)))
 
@@ -7370,20 +7365,20 @@ def _BuildAutomaton_39 ():
     import pyxb.utils.fac as fac
 
     counters = set()
-    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 20, 6))
+    cc_0 = fac.CounterCondition(min=0, max=1, metadata=pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 20, 6))
     counters.add(cc_0)
     states = []
     final_update = None
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaType._UseForTag(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaHeader')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 18, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaType._UseForTag(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaHeader')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 18, 6))
     st_0 = fac.State(symbol, is_initial=True, final_update=final_update, is_unordered_catenation=False)
     states.append(st_0)
     final_update = set()
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaType._UseForTag(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaBody')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 19, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaType._UseForTag(pyxb.namespace.ExpandedName(None, 'FatturaElettronicaBody')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 19, 6))
     st_1 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_1)
     final_update = set()
     final_update.add(fac.UpdateInstruction(cc_0, False))
-    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaType._UseForTag(pyxb.namespace.ExpandedName(_Namespace_ds, 'Signature')), pyxb.utils.utility.Location('https://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.3/Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd', 20, 6))
+    symbol = pyxb.binding.content.ElementUse(FatturaElettronicaType._UseForTag(pyxb.namespace.ExpandedName(_Namespace_ds, 'Signature')), pyxb.utils.utility.Location('/home/simone/work/odoo12/l10n-italy/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd', 20, 6))
     st_2 = fac.State(symbol, is_initial=False, final_update=final_update, is_unordered_catenation=False)
     states.append(st_2)
     transitions = []

--- a/l10n_it_fatturapa/bindings/binding.py
+++ b/l10n_it_fatturapa/bindings/binding.py
@@ -1,18 +1,26 @@
-# ./binding.py
-# -*- coding: utf-8 -*-
+# flake8: noqa
 # PyXB bindings for NM:32e521a6da5b62d07147ea75b23acb0fb9726893
 # Generated 2022-09-19 12:37:19.433213 by PyXB version 1.2.6 using Python 3.6.15.final.0
 # Namespace http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2
 
 from __future__ import unicode_literals
-import pyxb
-import pyxb.binding
-import pyxb.binding.saxer
+import logging
 import io
-import pyxb.utils.utility
-import pyxb.utils.domutils
 import sys
-import pyxb.utils.six as _six
+
+_logger = logging.getLogger(__name__)
+
+try:
+    import pyxb
+    import pyxb.binding
+    import pyxb.binding.saxer
+    import pyxb.utils.utility
+    import pyxb.utils.domutils
+    import pyxb.utils.six as _six
+    # Import bindings for namespaces imported into schema
+    import pyxb.binding.datatypes
+except (ImportError) as err:
+    _logger.debug(err)
 # Unique identifier for bindings created at the same time
 _GenerationUID = pyxb.utils.utility.UniqueIdentifier('urn:uuid:0937e7fe-3807-11ed-9890-99c59b328e7e')
 
@@ -26,9 +34,7 @@ if pyxb.__version__ != _PyXBVersion:
 # inside class definitions where property names may conflict.
 _module_typeBindings = pyxb.utils.utility.Object()
 
-# Import bindings for namespaces imported into schema
-import pyxb.binding.datatypes
-import _ds as _ImportedBinding__ds
+from . import _ds as _ImportedBinding__ds
 
 # NOTE: All namespace declarations are reserved within the binding
 Namespace = pyxb.namespace.NamespaceForURI('http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2', create_if_missing=True)

--- a/l10n_it_fatturapa/bindings/fatturapa.py
+++ b/l10n_it_fatturapa/bindings/fatturapa.py
@@ -12,7 +12,7 @@ except (ImportError) as err:
 
 from .binding import *  # noqa: F403
 
-XSD_SCHEMA = 'Schema_del_file_xml_FatturaPA_versione_1.2.1.xsd'
+XSD_SCHEMA = 'Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd'
 
 _xsd_schema = get_module_resource('l10n_it_fatturapa', 'bindings', 'xsd',
                                   XSD_SCHEMA)

--- a/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd
+++ b/l10n_it_fatturapa/bindings/xsd/Schema_del_file_xml_FatturaPA_versione_1.2.2.xsd
@@ -3,16 +3,16 @@
 	xmlns:ds="http://www.w3.org/2000/09/xmldsig#" 
 	xmlns="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" 
 	targetNamespace="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" 
-	version="1.2.1">
+	version="1.2.2">
   
   <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="http://www.w3.org/TR/2002/REC-xmldsig-core-20020212/xmldsig-core-schema.xsd" />
-    
+
   <xs:element name="FatturaElettronica" type="FatturaElettronicaType">
     <xs:annotation>
-      <xs:documentation>XML schema fatture destinate a PA e privati in forma ordinaria 1.2.1</xs:documentation>
+      <xs:documentation>XML schema fatture destinate a PA e privati in forma ordinaria 1.2.2</xs:documentation>
     </xs:annotation>
   </xs:element>
-  
+
   <xs:complexType name="FatturaElettronicaType">
     <xs:sequence>
       <xs:element name="FatturaElettronicaHeader" type="FatturaElettronicaHeaderType"                       />
@@ -426,6 +426,11 @@
       <xs:enumeration value="TD27">
         <xs:annotation>
           <xs:documentation>Fattura per autoconsumo o per cessioni gratuite senza rivalsa</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="TD28">
+        <xs:annotation>
+          <xs:documentation>Acquisti da San Marino con IVA (fattura cartacea)</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
     </xs:restriction>
@@ -1181,7 +1186,7 @@
       </xs:enumeration>
       <xs:enumeration value="N7">
         <xs:annotation>
-          <xs:documentation>IVA assolta in altro stato UE (prestazione di servizi di telecomunicazioni, tele-radiodiffusione ed elettronici ex art. 7-sexies lett. f, g, art. 74-sexies DPR 633/72)</xs:documentation>
+          <xs:documentation>IVA assolta in altro stato UE (prestazione di servizi di telecomunicazioni, tele-radiodiffusione ed elettronici ex art. 7-octies lett. a, b, art. 74-sexies DPR 633/72)</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
     </xs:restriction>

--- a/l10n_it_fatturapa/data/FoglioStileAssoSoftware_v1.1.xsl
+++ b/l10n_it_fatturapa/data/FoglioStileAssoSoftware_v1.1.xsl
@@ -493,7 +493,7 @@
 
           <td class="import" >
             <xsl:if test="PrezzoUnitario">
-              <xsl:if test="number(PrezzoTotale)">
+              <xsl:if test="number(PrezzoUnitario)">
 
                 <xsl:value-of select="format-number(PrezzoUnitario,  '###.###.##0,00######', 'euro')" />
               </xsl:if>
@@ -1799,14 +1799,7 @@
               <tr>
 
                 <th>Tipologia documento</th>
-				<xsl:if test="$IsFPRS='0'">
-					<th class="perc">Art. 73</th>
-				</xsl:if>
-
-				<xsl:if test="$IsFPRS='1'">
-                  <th class="perc">Imposta bollo</th>
-                </xsl:if>
-
+                <th class="perc">Art. 73</th>
                 <th >Numero documento</th>
                 <th class="data">Data documento</th>
                 <th >Codice destinatario</th>
@@ -1879,6 +1872,9 @@
 						<xsl:when test="$TD='TD27'">
 							fattura per autoconsumo o per cessioni gratuite senza rivalsa
 						</xsl:when>
+						<xsl:when test="$TD='TD28'">
+							acquisti da San Marino con IVA - fattura cartacea
+						</xsl:when>
 
                       <!--FPRS-->
                       <xsl:when test="$TD='TD07'">
@@ -1900,21 +1896,11 @@
                   </xsl:if>
                 </td>
 
-				<xsl:if test="$IsFPRS='0'">
-					<td class="ritenuta"  >
-					  <xsl:if test="DatiGenerali/DatiGeneraliDocumento/Art73">
-						<xsl:value-of select="DatiGenerali/DatiGeneraliDocumento/Art73" />
-					  </xsl:if>
-					</td>
-				</xsl:if>
-
-				 <xsl:if test="$IsFPRS='1'">
-                  <td class="textCenter">
-                    <xsl:if test="DatiGenerali/DatiGeneraliDocumento/BolloVirtuale">
-                      <xsl:value-of select="DatiGenerali/DatiGeneraliDocumento/BolloVirtuale" />
-                    </xsl:if>
-                  </td>
-                </xsl:if>
+                <td class="ritenuta"  >
+                  <xsl:if test="DatiGenerali/DatiGeneraliDocumento/Art73">
+                    <xsl:value-of select="DatiGenerali/DatiGeneraliDocumento/Art73" />
+                  </xsl:if>
+                </td>
 
                 <td class="textCenter" >
 
@@ -1970,7 +1956,6 @@
 
                       <xsl:for-each select="DatiGenerali/DatiGeneraliDocumento/Causale"  >
                         <xsl:value-of select="." />
-						<br/>
                       </xsl:for-each>
 
                     </xsl:if>
@@ -2485,7 +2470,7 @@
                   <tr >
 
                     <th  colspan="2">
-                      Imposta bollo
+                      Importo bollo
                     </th>
                     <th  colspan="3">
                       Sconto/Maggiorazione

--- a/l10n_it_fatturapa/data/fatturaordinaria_v1.2.1.xsl
+++ b/l10n_it_fatturapa/data/fatturaordinaria_v1.2.1.xsl
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0"?>
-<xsl:stylesheet 
-	version="1.1" 
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+<xsl:stylesheet
+	version="1.2.2"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:a="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2">
 	<xsl:output method="html" />
 
@@ -322,7 +322,7 @@
 																		(contribuenti minimi)
 																	</xsl:when>
 																	<xsl:when test="$RF='RF03'">
-																		(nuove iniziative produttive) - Non più valido in quanto abrogato dalla legge di stabilità 2015																	
+																		(nuove iniziative produttive) - Non più valido in quanto abrogato dalla legge di stabilità 2015
 																	</xsl:when>
 																	<xsl:when test="$RF='RF04'">
 																		(agricoltura e attività connesse e pesca)
@@ -889,11 +889,11 @@
 													</xsl:for-each>
 												</ul>
 											</xsl:if>
-											
+
 											<xsl:if test="a:FatturaElettronica/FatturaElettronicaHeader/CessionarioCommittente/RappresentanteFiscale">
 												<div id="rappresentante-fiscale">
 													<h4>Dati del rappresentante fiscale del cessionario / committente</h4>
-		
+
 													<ul>
 															<xsl:for-each select="a:FatturaElettronica/FatturaElettronicaHeader/CessionarioCommittente/RappresentanteFiscale">
 																<xsl:if test="IdFiscaleIVA">
@@ -934,7 +934,7 @@
 												</div>
 											</xsl:if>
 											<!--FINE DATI RAPPRESENTANTE FISCALE-->
-											
+
 										</div>
 									</xsl:if>
 									<!--FINE DATI CESSIONARIO COMMITTENTE-->
@@ -1114,24 +1114,24 @@
 																		(parcella)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD16'">
-																		(integrazione fattura 
+																		(integrazione fattura
 																		reverse charge interno)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD17'">
-																		(integrazione/autofattura per 
+																		(integrazione/autofattura per
 																		acquisto servizi da estero)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD18'">
-																		(integrazione per acquisto 
+																		(integrazione per acquisto
 																		beni intracomunitari)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD19'">
-																		(integrazione/autofattura per 
+																		(integrazione/autofattura per
 																		acquisto beni ex art.17 c.2 DPR 633/72)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD20'">
-																		(autofattura per regolarizzazione e 
-																		integrazione delle fatture - 
+																		(autofattura per regolarizzazione e
+																		integrazione delle fatture -
 																		art.6 c.8 d.lgs.471/97 o art.46 c.5 D.L.331/93)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD21'">
@@ -1141,22 +1141,25 @@
 																		(estrazione beni da Deposito IVA)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD23'">
-																		(estrazione beni da Deposito IVA 
+																		(estrazione beni da Deposito IVA
 																		con versamento IVA)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD24'">
-																		(fattura differita - art.21 c.4 lett. a)
+																		(fattura differita - art.21 c.4 terzo periodo lett. a - DPR 633/72)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD25'">
-																		(fattura differita - art.21 c.4 terzo periodo lett. b)
+																		(fattura differita - art.21 c.4 terzo periodo lett. b - DPR 633/72)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD26'">
-																		(cessione di beni ammortizzabili e per 
+																		(cessione di beni ammortizzabili e per
 																		passaggi interni - art.36 DPR 633/72)
 																	</xsl:when>
 																	<xsl:when test="$TD='TD27'">
-																		(fattura per autoconsumo o per cessioni 
+																		(fattura per autoconsumo o per cessioni
 																		gratuite senza rivalsa)
+																	</xsl:when>
+																	<xsl:when test="$TD='TD28'">
+																		(acquisti da San Marino con IVA - Fattura Cartacea)
 																	</xsl:when>
 																	<xsl:when test="$TD=''">
 																	</xsl:when>
@@ -1210,14 +1213,14 @@
 															</li>
 														</xsl:if>
 														<xsl:for-each select="DatiGenerali/DatiGeneraliDocumento/Causale">
-															
+
 															<li>
 																Causale:
 																<span>
 																	<xsl:value-of select="current()" />
 																</span>
 															</li>
-															
+
 														</xsl:for-each>
 														<xsl:if test="DatiGenerali/DatiGeneraliDocumento/Art73">
 															<li>
@@ -1500,7 +1503,7 @@
 																					(non soggette)
 																				</xsl:when>
 																				<xsl:when test="$NT='N2.1'">
-																					(non soggette ad IVA - artt. da 7 a 7-septies 
+																					(non soggette ad IVA - artt. da 7 a 7-septies
 																					del DPR 633/72)
 																				</xsl:when>
 																				<xsl:when test="$NT='N2.2'">
@@ -1519,15 +1522,15 @@
 																					(non imponibili - cessioni verso S.Marino)
 																				</xsl:when>
 																				<xsl:when test="$NT='N3.4'">
-																					(non imponibili - operazioni assimilate alle 
+																					(non imponibili - operazioni assimilate alle
 																					cessioni all'esportazione)
 																				</xsl:when>
 																				<xsl:when test="$NT='N3.5'">
-																					(non imponibili - a seguito di dichiarazioni 
+																					(non imponibili - a seguito di dichiarazioni
 																					d'intento)
 																				</xsl:when>
 																				<xsl:when test="$NT='N3.6'">
-																					(non imponibili - altre operazioni che non 
+																					(non imponibili - altre operazioni che non
 																					concorrono alla formazione del plafond)
 																				</xsl:when>
 																				<xsl:when test="$NT='N4'">
@@ -1537,51 +1540,50 @@
 																					(regime del margine / IVA non esposta in fattura)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6'">
-																					(inversione contabile per le operazioni in reverse 
-																					charge ovvero nei casi di autofatturazione per 
-																					acquisti extra UE di servizi ovvero per importazioni 
+																					(inversione contabile per le operazioni in reverse
+																					charge ovvero nei casi di autofatturazione per
+																					acquisti extra UE di servizi ovvero per importazioni
 																					di beni nei soli casi previsti)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6.1'">
-																					(inversione contabile - cessione di rottami e 
+																					(inversione contabile - cessione di rottami e
 																					altri materiali di recupero)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6.2'">
-																					(inversione contabile - cessione di oro e 
-																					argento puro)
+																					(inversione contabile - cessione di oro e
+																					argento ai sensi della legge 7/2000 nonché di oreficeria
+                                                                                                                                                                        usata ad OPO)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6.3'">
-																					(inversione contabile - subappalto nel settore 
+																					(inversione contabile - subappalto nel settore
 																					edile)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6.4'">
 																					(inversione contabile - cessione di fabbricati)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6.5'">
-																					(inversione contabile - cessione di telefoni 
+																					(inversione contabile - cessione di telefoni
 																					cellulari)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6.6'">
-																					(inversione contabile - cessione di prodotti 
+																					(inversione contabile - cessione di prodotti
 																					elettronici)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6.7'">
-																					(inversione contabile - prestazioni comparto 
+																					(inversione contabile - prestazioni comparto
 																					edile e settori connessi)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6.8'">
-																					(inversione contabile - operazioni settore 
+																					(inversione contabile - operazioni settore
 																					energetico)
 																				</xsl:when>
 																				<xsl:when test="$NT='N6.9'">
 																					(inversione contabile - altri casi)
 																				</xsl:when>
 																				<xsl:when test="$NT='N7'">
-																					(IVA assolta in altro stato UE - vendite a distanza 
-																					ex art.40 c.3 e 4 e art.41 c.1 lett. b DL 331/93; 
-																					prestazione di servizi di telecomunicazioni, 
-																					tele-radiodiffusione ed elettronici ex art.7-sexies 
-																					lett. f, g, e art.74-sexies DPR 633/72)
+																					(IVA assolta in altro stato UE - prestazione di servizi di
+																					telecomunicazioni, tele-radiodiffusione ed elettronici ex
+																					art. 7-octies, comma 1 lett. a, b, art. 74-sexies DPR 633/72)
 																				</xsl:when>
 																				<xsl:when test="$NT=''">
 																				</xsl:when>
@@ -2592,7 +2594,7 @@
 																			(non soggetta)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N2.1'">
-																			(non soggette ad IVA - artt. da 7 a 7-septies 
+																			(non soggette ad IVA - artt. da 7 a 7-septies
 																			del DPR 633/72)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N2.2'">
@@ -2611,15 +2613,15 @@
 																			(non imponibili - cessioni verso S.Marino)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N3.4'">
-																			(non imponibili - operazioni assimilate alle 
+																			(non imponibili - operazioni assimilate alle
 																			cessioni all'esportazione)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N3.5'">
-																			(non imponibili - a seguito di dichiarazioni 
+																			(non imponibili - a seguito di dichiarazioni
 																			d'intento)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N3.6'">
-																			(non imponibili - altre operazioni che non 
+																			(non imponibili - altre operazioni che non
 																			concorrono alla formazione del plafond)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N4'">
@@ -2629,50 +2631,51 @@
 																			(regime del margine / IVA non esposta in fattura)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6'">
-																			(inversione contabile per le operazioni in reverse 
-																			charge ovvero nei casi di autofatturazione per 
-																			acquisti extra UE di servizi ovvero per importazioni 
+																			(inversione contabile per le operazioni in reverse
+																			charge ovvero nei casi di autofatturazione per
+																			acquisti extra UE di servizi ovvero per importazioni
 																			di beni nei soli casi previsti)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6.1'">
-																			(inversione contabile - cessione di rottami e 
+																			(inversione contabile - cessione di rottami e
 																			altri materiali di recupero)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6.2'">
-																			(inversione contabile - cessione di oro e 
-																			argento puro)
+																			(inversione contabile - cessione di oro e
+																			argento ai sensi della legge 7/2000 nonché di oreficeria
+                                                                                                                                                        usata ad OPO)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6.3'">
-																			(inversione contabile - subappalto nel settore 
+																			(inversione contabile - subappalto nel settore
 																			edile)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6.4'">
 																			(inversione contabile - cessione di fabbricati)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6.5'">
-																			(inversione contabile - cessione di telefoni 
+																			(inversione contabile - cessione di telefoni
 																			cellulari)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6.6'">
-																			(inversione contabile - cessione di prodotti 
+																			(inversione contabile - cessione di prodotti
 																			elettronici)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6.7'">
-																			(inversione contabile - prestazioni comparto 
+																			(inversione contabile - prestazioni comparto
 																			edile e settori connessi)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6.8'">
-																			(inversione contabile - operazioni settore 
+																			(inversione contabile - operazioni settore
 																			energetico)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N6.9'">
 																			(inversione contabile - altri casi)
 																		</xsl:when>
 																		<xsl:when test="$NAT='N7'">
-																			(IVA assolta in altro stato UE - vendite a distanza 
-																			ex art.40 c.3 e 4 e art.41 c.1 lett. b DL 331/93; 
-																			prestazione di servizi di telecomunicazioni, 
-																			tele-radiodiffusione ed elettronici ex art.7-sexies 
+																			(IVA assolta in altro stato UE - vendite a distanza
+																			ex art.40 c.3 e 4 e art.41 c.1 lett. b DL 331/93;
+																			prestazione di servizi di telecomunicazioni,
+																			tele-radiodiffusione ed elettronici ex art.7-sexies
 																			lett. f, g, e art.74-sexies DPR 633/72)
 																		</xsl:when>
 																		<xsl:otherwise>
@@ -2770,7 +2773,7 @@
 																			(non soggette)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N2.1'">
-																			(non soggette ad IVA - artt. da 7 a 7-septies 
+																			(non soggette ad IVA - artt. da 7 a 7-septies
 																			del DPR 633/72)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N2.2'">
@@ -2789,15 +2792,15 @@
 																			(non imponibili - cessioni verso S.Marino)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N3.4'">
-																			(non imponibili - operazioni assimilate alle 
+																			(non imponibili - operazioni assimilate alle
 																			cessioni all'esportazione)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N3.5'">
-																			(non imponibili - a seguito di dichiarazioni 
+																			(non imponibili - a seguito di dichiarazioni
 																			d'intento)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N3.6'">
-																			(non imponibili - altre operazioni che non 
+																			(non imponibili - altre operazioni che non
 																			concorrono alla formazione del plafond)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N4'">
@@ -2807,18 +2810,19 @@
 																			(regime del margine / IVA non esposta in fattura)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N6'">
-																			(inversione contabile per le operazioni in reverse 
-																			charge ovvero nei casi di autofatturazione per 
-																			acquisti extra UE di servizi ovvero per importazioni 
+																			(inversione contabile per le operazioni in reverse
+																			charge ovvero nei casi di autofatturazione per
+																			acquisti extra UE di servizi ovvero per importazioni
 																			di beni nei soli casi previsti)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N6.1'">
-																			(inversione contabile - cessione di rottami e 
+																			(inversione contabile - cessione di rottami e
 																			altri materiali di recupero)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N6.2'">
-																			(inversione contabile - cessione di oro e 
-																			argento puro)
+																			(inversione contabile - cessione di oro e
+																			argento ai sensi della legge 7/2000 nonché di oreficeria
+                                                                                                                                                        usata ad OPO)
 																		</xsl:when>
 																		<xsl:when test="$NAT1='N6.3'">
 																			(inversione contabile - subappalto nel settore 

--- a/l10n_it_fiscal_document_type/data/fiscal.document.type.csv
+++ b/l10n_it_fiscal_document_type/data/fiscal.document.type.csv
@@ -23,3 +23,4 @@ id,code,name,out_invoice,in_invoice,out_refund,in_refund,priority,refund_fiscal_
 22,TD25,"fattura differita di cui all'art. 21, comma 4, terzo periodo lett. b)",True,False,False,False,3,TD04
 23,TD26,"cessione di beni ammortizzabili e per passaggi interni (ex art.36 DPR 633/72)",True,False,False,False,3,TD04
 24,TD27,fattura per autoconsumo o per cessioni gratuite senza rivalsa,True,False,False,False,3,TD04
+25,TD28,Acquisti da San Marino con IVA (fattura cartacea),False,True,False,False,3,TD04


### PR DESCRIPTION
Implementazione di https://github.com/OCA/l10n-italy/issues/2926 per `12.0`.

Sources:

- nuovo schema: https://www.agenziaentrate.gov.it/portale/documents/20143/4631413/Schema_VFPR12.xsd/a985cc3a-178d-f3d7-2f00-0227b66086ff (accessibile da https://www.agenziaentrate.gov.it/portale/web/guest/specifiche-tecniche-versione-1.7.1)
- nuovo XSL https://www.fatturapa.gov.it/export/documenti/fatturapa/v1.2.2/Foglio_di_stile_fatturaordinaria_v1.2.2.xsl (accessibile da https://www.fatturapa.gov.it/it/norme-e-regole/documentazione-fattura-elettronica/formato-fatturapa)
- nuovo XSL AssoSoftware http://www.assosoftware.it/allegati/assoinvoice/FoglioStileAssoSoftware.zip (accessibile da http://www.assosoftware.it/assoinvoice)