### PR TITLE
[FIX][l10n_it_fatturapa_export_zip] fix export zip

### DIFF
--- a/l10n_it_fatturapa_export_zip/wizard/export_fatturapa.py
+++ b/l10n_it_fatturapa_export_zip/wizard/export_fatturapa.py
@@ -44,7 +44,7 @@ class WizardAccountInvoiceExport(models.TransientModel):
         data = fp.read()
         attach_vals = {
             "name": self.name + ".zip",
-            "datas": base64.encodestring(data),
+            "datas": base64.encodebytes(data),
         }
         zip_att = self.env["ir.attachment"].create(attach_vals)
         for att in attachments:


### PR DESCRIPTION
encodestring è deprecato in favore di encodebytes

risolve: https://github.com/OCA/l10n-italy/issues/2955