### PR TITLE
[12.0][FIX] - l10n_it_sdi_channel : user error for unset ES channel in a company record

### DIFF
--- a/l10n_it_sdi_channel/models/fatturapa_attachment_out.py
+++ b/l10n_it_sdi_channel/models/fatturapa_attachment_out.py
@@ -38,6 +38,12 @@ class FatturaPAAttachmentOut (models.Model):
 
         company = self.env.user.company_id
         sdi_channel = company.sdi_channel_id
+        if not sdi_channel:
+            raise UserError(_(
+                "You can only send files if you have set an "
+                "ES channel for the respective company: %s."
+                % (company.name))
+            )
         send_result = sdi_channel.send(self)
         return send_result
 

--- a/l10n_it_sdi_channel/models/sdi.py
+++ b/l10n_it_sdi_channel/models/sdi.py
@@ -34,7 +34,7 @@ class SdiChannel(models.Model):
         default=lambda self:
         self.env['res.company']._company_default_get('sdi.channel'))
     channel_type = fields.Selection(
-        string='ES channel type', selection=[], required=True,
+        string='ES channel type', selection=[],
         help='Channels (Pec, Web, Sftp) could be provided by external modules.',
     )
 
@@ -53,10 +53,14 @@ class SdiChannel(models.Model):
         of each Electronic Invoice that has managed to send.
         """
         self.ensure_one()
-        channel_type = self.channel_type
+        channel_type = self.channel_type or 'no_channel_type'
         send_method_name = "send_via_" + channel_type
         send_method = getattr(self, send_method_name)
         return send_method(attachment_out_ids)
+
+    def send_via_no_channel_type(self, attachment_out_ids):
+        """Override this method to send the attachments to the web service."""
+        pass
 
     @api.model
     def _prepare_attachment_in_values(

--- a/l10n_it_sdi_channel/tests/test_account_invoice.py
+++ b/l10n_it_sdi_channel/tests/test_account_invoice.py
@@ -7,12 +7,19 @@ from odoo.addons.l10n_it_fatturapa_out.tests.fatturapa_common import \
 
 class TestAccountInvoice (FatturaPACommon):
 
+    def setUp(self):
+        super().setUp()
+        self.sdi_coop_channel = self.env['sdi.channel'].create([{
+            'name': "Test channel"
+        }])
+
     def test_action_open_export_send_sdi(self):
         """
         Check that the "Validate, export and send to SdI" button
         validates the invoice and exports the attachment.
         """
-        # Arrange: create a draft invoice with no attachment
+        # Arrange: set the SdI channel and create a draft invoice with no attachment
+        self.env.user.company_id.sdi_channel_id = self.sdi_coop_channel
         invoice = self._create_invoice()
         self.assertEqual(invoice.state, 'draft')
         self.assertFalse(invoice.fatturapa_attachment_out_id)


### PR DESCRIPTION
- Informing the user what actually went wrong.
- Instead of showing the message _ValueError: Expected singleton: sdi.channel()_