### PR TITLE
[14.0][FIX] l10n_it_fatturapa_out_rc: fix tests

### DIFF
--- a/l10n_it_fatturapa_out_rc/tests/data/IT10538570960_00002.xml
+++ b/l10n_it_fatturapa_out_rc/tests/data/IT10538570960_00002.xml
@@ -78,7 +78,7 @@
             <NumeroLinea>1</NumeroLinea>
             <CodiceArticolo>
                <CodiceTipo>ODOO</CodiceTipo>
-               <CodiceValore>DESK0004</CodiceValore>
+               <CodiceValore>FURN_0098</CodiceValore>
             </CodiceArticolo>
             <Descrizione>Invoice for sample product</Descrizione>
             <Quantita>1.000</Quantita>

--- a/l10n_it_fatturapa_out_rc/tests/data/IT10538570960_00003.xml
+++ b/l10n_it_fatturapa_out_rc/tests/data/IT10538570960_00003.xml
@@ -78,7 +78,7 @@
             <NumeroLinea>1</NumeroLinea>
             <CodiceArticolo>
                <CodiceTipo>ODOO</CodiceTipo>
-               <CodiceValore>DESK0004</CodiceValore>
+               <CodiceValore>FURN_0098</CodiceValore>
             </CodiceArticolo>
             <Descrizione>Invoice for sample product</Descrizione>
             <Quantita>1.000</Quantita>

--- a/l10n_it_fatturapa_out_rc/tests/data/IT10538570960_00004.xml
+++ b/l10n_it_fatturapa_out_rc/tests/data/IT10538570960_00004.xml
@@ -78,7 +78,7 @@
             <NumeroLinea>1</NumeroLinea>
             <CodiceArticolo>
                <CodiceTipo>ODOO</CodiceTipo>
-               <CodiceValore>DESK0004</CodiceValore>
+               <CodiceValore>FURN_0098</CodiceValore>
             </CodiceArticolo>
             <Descrizione>Invoice for sample product</Descrizione>
             <Quantita>1.000</Quantita>

--- a/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py
@@ -68,7 +68,7 @@ class TestFatturaPAXMLValidation(ReverseChargeCommon, FatturaPACommon):
         invoice_form.date = fields.Date.from_string(invoice_date)
         invoice_form.ref = ref
         with invoice_form.line_ids.new() as line_form:
-            line_form.product_id = cls.env.ref("product.product_product_4d")
+            line_form.product_id = cls.env.ref("product.product_product_4c")
             line_form.name = "Invoice for sample product"
             line_form.price_unit = 100
             line_form.tax_ids.clear()


### PR DESCRIPTION
Change product demo reference due to https://github.com/odoo/odoo/commit/ab1d7caefa910197579b12ae934fb572f9cff50d

Otherwise tests fail raising the following errors (https://github.com/OCA/l10n-italy/actions/runs/3295568347/jobs/5434248480#step:8:957):

```
2022-10-21 07:38:51,491 253 ERROR odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: ERROR: TestFatturaPAXMLValidation.test_extra_EU Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/cache.py", line 85, in lookup
    r = d[key]
  File "/opt/odoo/odoo/tools/func.py", line 71, in wrapper
    return func(self, *args, **kwargs)
  File "/opt/odoo/odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
KeyError: ('ir.model.data', <function IrModelData.xmlid_lookup at 0x7f81573e0158>, 'product.product_product_4d')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 213, in test_extra_EU
    taxes=self.tax_22ae,
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 71, in _create_invoice
    line_form.product_id = cls.env.ref("product.product_product_4d")
  File "/opt/odoo/odoo/api.py", line 514, in ref
    return self['ir.model.data'].xmlid_to_object(xml_id, raise_if_not_found=raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1954, in xmlid_to_object
    t = self.xmlid_to_res_model_res_id(xmlid, raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1938, in xmlid_to_res_model_res_id
    return self.xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-35>", line 2, in xmlid_lookup
  File "/opt/odoo/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1931, in xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
ValueError: External ID not found in the system: product.product_product_4d

2022-10-21 07:38:51,495 253 INFO odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: Starting TestFatturaPAXMLValidation.test_intra_EU ... 2022-10-21 07:38:53,109 253 INFO odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: ====================================================================== 2022-10-21 07:38:53,109 253 ERROR odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: ERROR: TestFatturaPAXMLValidation.test_intra_EU Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/cache.py", line 85, in lookup
    r = d[key]
  File "/opt/odoo/odoo/tools/func.py", line 71, in wrapper
    return func(self, *args, **kwargs)
  File "/opt/odoo/odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
KeyError: ('ir.model.data', <function IrModelData.xmlid_lookup at 0x7f81573e0158>, 'product.product_product_4d')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 91, in test_intra_EU
    taxes=self.tax_22ai,
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 71, in _create_invoice
    line_form.product_id = cls.env.ref("product.product_product_4d")
  File "/opt/odoo/odoo/api.py", line 514, in ref
    return self['ir.model.data'].xmlid_to_object(xml_id, raise_if_not_found=raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1954, in xmlid_to_object
    t = self.xmlid_to_res_model_res_id(xmlid, raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1938, in xmlid_to_res_model_res_id
    return self.xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-35>", line 2, in xmlid_lookup
  File "/opt/odoo/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1931, in xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
ValueError: External ID not found in the system: product.product_product_4d

2022-10-21 07:38:53,111 253 INFO odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: Starting TestFatturaPAXMLValidation.test_intra_EU_customer ... 2022-10-21 07:38:54,674 253 INFO odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: ====================================================================== 2022-10-21 07:38:54,674 253 ERROR odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: ERROR: TestFatturaPAXMLValidation.test_intra_EU_customer Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/cache.py", line 85, in lookup
    r = d[key]
  File "/opt/odoo/odoo/tools/func.py", line 71, in wrapper
    return func(self, *args, **kwargs)
  File "/opt/odoo/odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
KeyError: ('ir.model.data', <function IrModelData.xmlid_lookup at 0x7f81573e0158>, 'product.product_product_4d')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 132, in test_intra_EU_customer
    taxes=self.tax_22vi,
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 71, in _create_invoice
    line_form.product_id = cls.env.ref("product.product_product_4d")
  File "/opt/odoo/odoo/api.py", line 514, in ref
    return self['ir.model.data'].xmlid_to_object(xml_id, raise_if_not_found=raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1954, in xmlid_to_object
    t = self.xmlid_to_res_model_res_id(xmlid, raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1938, in xmlid_to_res_model_res_id
    return self.xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-35>", line 2, in xmlid_lookup
  File "/opt/odoo/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1931, in xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
ValueError: External ID not found in the system: product.product_product_4d

2022-10-21 07:38:54,676 253 INFO odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: Starting TestFatturaPAXMLValidation.test_intra_EU_draft ... 2022-10-21 07:38:56,177 253 INFO odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: ====================================================================== 2022-10-21 07:38:56,178 253 ERROR odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: ERROR: TestFatturaPAXMLValidation.test_intra_EU_draft Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/cache.py", line 85, in lookup
    r = d[key]
  File "/opt/odoo/odoo/tools/func.py", line 71, in wrapper
    return func(self, *args, **kwargs)
  File "/opt/odoo/odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
KeyError: ('ir.model.data', <function IrModelData.xmlid_lookup at 0x7f81573e0158>, 'product.product_product_4d')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 151, in test_intra_EU_draft
    taxes=self.tax_22ai,
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 71, in _create_invoice
    line_form.product_id = cls.env.ref("product.product_product_4d")
  File "/opt/odoo/odoo/api.py", line 514, in ref
    return self['ir.model.data'].xmlid_to_object(xml_id, raise_if_not_found=raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1954, in xmlid_to_object
    t = self.xmlid_to_res_model_res_id(xmlid, raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1938, in xmlid_to_res_model_res_id
    return self.xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-35>", line 2, in xmlid_lookup
  File "/opt/odoo/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1931, in xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
ValueError: External ID not found in the system: product.product_product_4d

2022-10-21 07:38:56,179 253 INFO odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: Starting TestFatturaPAXMLValidation.test_intra_EU_supplier_refund ... 2022-10-21 07:38:57,722 253 INFO odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: ====================================================================== 2022-10-21 07:38:57,723 253 ERROR odoo odoo.addons.l10n_it_fatturapa_out_rc.tests.test_fatturapa_xml_validation: ERROR: TestFatturaPAXMLValidation.test_intra_EU_supplier_refund Traceback (most recent call last):
  File "/opt/odoo/odoo/tools/cache.py", line 85, in lookup
    r = d[key]
  File "/opt/odoo/odoo/tools/func.py", line 71, in wrapper
    return func(self, *args, **kwargs)
  File "/opt/odoo/odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
KeyError: ('ir.model.data', <function IrModelData.xmlid_lookup at 0x7f81573e0158>, 'product.product_product_4d')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 175, in test_intra_EU_supplier_refund
    taxes=self.tax_22ai,
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_out_rc/tests/test_fatturapa_xml_validation.py", line 71, in _create_invoice
    line_form.product_id = cls.env.ref("product.product_product_4d")
  File "/opt/odoo/odoo/api.py", line 514, in ref
    return self['ir.model.data'].xmlid_to_object(xml_id, raise_if_not_found=raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1954, in xmlid_to_object
    t = self.xmlid_to_res_model_res_id(xmlid, raise_if_not_found)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1938, in xmlid_to_res_model_res_id
    return self.xmlid_lookup(xmlid)[1:3]
  File "<decorator-gen-35>", line 2, in xmlid_lookup
  File "/opt/odoo/odoo/tools/cache.py", line 90, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "/opt/odoo/odoo/addons/base/models/ir_model.py", line 1931, in xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
ValueError: External ID not found in the system: product.product_product_4d
```