### PR TITLE
[14.0][IMP]l10n_it_abicab: Remove unnecessary method "onchange_bank_id"

### DIFF
--- a/l10n_it_abicab/models/abicab.py
+++ b/l10n_it_abicab/models/abicab.py
@@ -3,7 +3,7 @@
 # Copyright 2018 Sergio Zanchetta (Associazione PNLUG - Gruppo Odoo)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ResBank(models.Model):
@@ -20,9 +20,3 @@ class ResPartnerBank(models.Model):
 
     bank_abi = fields.Char(size=5, string="ABI", related="bank_id.abi", store=True)
     bank_cab = fields.Char(size=5, string="CAB", related="bank_id.cab", store=True)
-
-    @api.onchange("bank_id")
-    def onchange_bank_id(self):
-        if self.bank_id:
-            self.bank_abi = self.bank_id.abi
-            self.bank_cab = self.bank_id.cab

--- a/l10n_it_abicab/tests/test_abicab.py
+++ b/l10n_it_abicab/tests/test_abicab.py
@@ -26,6 +26,6 @@ class BankCase(TransactionCase):
                 "bank_id": bank1.id,
             }
         )
-        pbank1.onchange_bank_id()
+
         self.assertEqual(pbank1.bank_abi, "abi_1")
         self.assertEqual(pbank1.bank_cab, "cab_1")


### PR DESCRIPTION
Removed method because there is a "related" attribute in fields bank_abi & bank_cab which makes the method unnecessary