### PR TITLE
[FIX][14.0] delivery note invoice status

### DIFF
--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -285,7 +285,7 @@ class StockDeliveryNote(models.Model):
     @api.depends("state", "line_ids", "line_ids.invoice_status")
     def _compute_invoice_status(self):
         for note in self:
-            lines = note.line_ids.filtered(lambda l: l.sale_line_id)
+            lines = note.line_ids.filtered(lambda l: l.move_id.sale_line_id)
             invoice_status = DOMAIN_INVOICE_STATUSES[0]
             if lines:
                 if all(
@@ -797,8 +797,8 @@ class StockDeliveryNoteLine(models.Model):
         return super().write(vals)
 
     def sync_invoice_status(self):
-        for line in self.filtered(lambda l: l.sale_line_id):
-            invoice_status = line.sale_line_id.invoice_status
+        for line in self.filtered(lambda l: l.move_id.sale_line_id):
+            invoice_status = line.move_id.sale_line_id.invoice_status
             line.invoice_status = (
                 DOMAIN_INVOICE_STATUSES[1]
                 if invoice_status == "upselling"


### PR DESCRIPTION
Il campo `sale_line_id` [qui](https://github.com/OCA/l10n-italy/blob/9e548595e73a4b12389e93f042555dcea34a51b0/l10n_it_delivery_note/models/stock_delivery_note.py#L695) non risulta corretto per il calcolo del campo `invoice_status`: utilizzando il campo originale direttamente il test fallisce.

Il test in ogni caso mi risulta funzionalmente errato, in quanto il ddt dovrebbe risultare fatturato quando l'ordine di vendita è fatturato, sia che il ddt sia confermato o in bozza (oppure non ho capito il senso).

Si dovrebbe quindi correggere il test da:
`self.assertEqual(delivery_note.invoice_status, "no")`
a
`self.assertEqual(delivery_note.invoice_status, "invoiced")`