### PR TITLE
[14.0] [FIX] l10n_it_declaration_of_intent: change module dependency

### DIFF
--- a/l10n_it_declaration_of_intent/__manifest__.py
+++ b/l10n_it_declaration_of_intent/__manifest__.py
@@ -13,7 +13,7 @@
     "website": "https://github.com/OCA/l10n-italy",
     "depends": [
         "account",
-        "sale_management",
+        "sale",
     ],
     "data": [
         "security/declaration_security.xml",


### PR DESCRIPTION
Ripristina `sale` come dipendenza del modulo (come nella versione 12.0).

Attualmente l'installazione di `l10n_it_declaration_of intent` installa l'applicazione "Vendite" (`sale_management`).