### PR TITLE
[12.0][FIX] l10n_it_delivery_note sequenza multi anno

### DIFF
--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -430,7 +430,9 @@ class StockDeliveryNote(models.Model):
                 note.date = datetime.date.today()
 
             if not note.name:
-                note.name = sequence.next_by_id()
+                note.name = sequence.with_context(
+                    ir_sequence_date=note.date
+                ).next_by_id()
                 note.sequence_id = sequence
 
     def _fix_quantities_to_invoice(self, lines):

--- a/l10n_it_delivery_note/tests/__init__.py
+++ b/l10n_it_delivery_note/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import delivery_note_common
 from . import test_stock_delivery_note_invoicing
 from . import test_stock_delivery_note
+from . import test_stock_delivery_note_sequence

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note_sequence.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note_sequence.py
@@ -1,0 +1,60 @@
+# Copyright 2022 Sergio Corato
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tests import Form
+from odoo.tools.date_utils import relativedelta
+from .delivery_note_common import StockDeliveryNoteCommon
+from datetime import date, datetime, timedelta
+
+
+class StockDeliveryNoteSequence(StockDeliveryNoteCommon):
+
+    def test_complete_invoicing_sequence(self):
+        sequence = self.env.ref('l10n_it_delivery_note_base.delivery_note_sequence_ddt')
+        current_year = datetime.today().year
+        old_year = (datetime.today() - relativedelta(years=1)).year
+        for sequence_year in [current_year, old_year]:
+            sequence.write({
+                "use_date_range": True,
+                "date_range_ids": [
+                    (0, 0, {
+                        'date_from': date.today().replace(
+                            month=1, day=1, year=sequence_year),
+                        'date_to': date.today().replace(
+                            month=12, day=31, year=sequence_year),
+                    })
+                ],
+            })
+        date_range_sequence = sequence.date_range_ids.filtered(
+            lambda x: x.date_from == date.today().replace(
+                month=1, day=1, year=old_year)
+        )
+        date_range_sequence.write({'number_next_actual': 50})
+        sale_order = self.create_sales_order([
+            self.desk_combination_line,
+        ])
+        self.assertEqual(len(sale_order.order_line), 1)
+        sale_order.action_confirm()
+        picking = sale_order.picking_ids
+        self.assertEqual(len(picking), 1)
+        self.assertEqual(len(picking.move_lines), 1)
+
+        picking.move_lines[0].quantity_done = 1
+        result = picking.button_validate()
+        self.assertIsNone(result)
+
+        dn_form = Form(
+            self.env["stock.delivery.note.create.wizard"].with_context(
+                active_ids=picking.ids,
+            )
+        )
+        wizard = dn_form.save()
+        wizard.confirm()
+        delivery_note = picking.delivery_note_id
+        delivery_note.transport_datetime = \
+            datetime.now() + timedelta(days=1, hours=3)
+        delivery_note.date = date.today().replace(year=old_year)
+        delivery_note.action_confirm()
+
+        self.assertEqual(delivery_note.type_id.sequence_id, sequence)
+        self.assertEqual(delivery_note.name,
+                         sequence.prefix + '%%0%sd' % sequence.padding % 50)


### PR DESCRIPTION
Descrizione del problema o della funzionalità: la sequenza del dn non considera la data

Comportamento attuale prima di questa PR: una dn in data diversa dall'anno in corso prende la sequenza errata

Comportamento desiderato dopo questa PR: la dn prende la sequenza relativa all'anno




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing