### PR TITLE
[12.0][IMP] show distinta riba line already reconciled alert

### DIFF
--- a/l10n_it_ricevute_bancarie/models/riba.py
+++ b/l10n_it_ricevute_bancarie/models/riba.py
@@ -222,6 +222,21 @@ class RibaListLine(models.Model):
         compute='_get_cig_cup_values', string="CIG", size=256)
     cup = fields.Char(
         compute='_get_cig_cup_values', string="CUP", size=256)
+    is_already_reconciled = fields.Boolean(
+        compute='_compute_is_already_reconciled'
+    )
+
+    @api.multi
+    def _compute_is_already_reconciled(self):
+        for line in self:
+            if any([x.reconciled for x in line.mapped('move_line_ids.move_line_id')]):
+                line.is_already_reconciled = True
+
+    @api.multi
+    def action_reconciled_alert(self):
+        raise UserError(_(
+            'This line is already reconciled!')
+        )
 
     @api.multi
     def _get_cig_cup_values(self):

--- a/l10n_it_ricevute_bancarie/views/riba_view.xml
+++ b/l10n_it_ricevute_bancarie/views/riba_view.xml
@@ -144,6 +144,14 @@
                                 <button name="%(riba_unsolved_action)d" type='action' attrs="{'invisible':['|',('type','=','incasso'),('state','!=','accredited')]}" string="Mark as Past Due" icon="fa-exclamation-triangle"/>
                                 <button name="riba_line_settlement" type='object' attrs="{'invisible':['|',('type','=','incasso'),('state','!=','accredited')]}" string="Mark as Settled" icon="fa-check"/>
                                 <field name="type" invisible="1" />
+                                <field name="is_already_reconciled" invisible="1"/>
+                                <button
+                                    string="Reconciled Alert"
+                                    name="action_reconciled_alert"
+                                    type="object"
+                                    class="badge badge-danger"
+                                    attrs="{'invisible': ['|', ('is_already_reconciled', '=', False), ('state', '!=', 'draft')]}"
+                                />
                             </tree>
                         </field>
                         <field name="type" invisible="1" />


### PR DESCRIPTION
Descrizione del problema o della funzionalità: una riba non può essere emessa se la fattura relativa è riconciliata

Comportamento attuale prima di questa PR: l'utente deve ricercare manualmente quale fattura è riconciliata

Comportamento desiderato dopo questa PR: viene mostrato un alert sulla riba già riconciliata

![Screenshot(138)](https://user-images.githubusercontent.com/7657311/209375865-f60d1d3b-c00f-47a4-9e47-0d969e4cee33.png)



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing