### PR TITLE
[12.0] [FIX] l10n_it_account_stamp_sale: change module dependency

### DIFF
--- a/l10n_it_account_stamp_sale/__manifest__.py
+++ b/l10n_it_account_stamp_sale/__manifest__.py
@@ -13,7 +13,7 @@
                '/tree/12.0/l10n_it_account_stamp_sale',
     'depends': [
         'l10n_it_account_stamp',
-        'sale',
+        'sale_management',
     ],
     'auto_install': True,
     'installable': True,


### PR DESCRIPTION
Il modulo `l10n_it_account_stamp_sale` permette di gestire l'applicabilità dell'imposta di bollo nelle fatture provenienti da un ordine di vendita.
Dato che gli ordini di vendita vengono aggiunti installando `sale_management` (applicazione "Vendite"), il modulo dovrebbe di conseguenza dipendendere da quest'ultimo e non da `sale`.

La situazione attuale porta al seguente problema.
In una installazione Odoo con ad es. fatturazione elettronica, imposta di bollo e dichiarazione di intento (per obbligo dei clienti), il modulo  `l10n_it_account_stamp_sale` viene installato in modo automatico anche se non necessario.

Questa PR corregge il problema.

Vedi anche https://github.com/OCA/l10n-italy/pull/3106