### PR TITLE
[12.0] [FIX] l10n_it_fiscalcode_sale: change module dependency

### DIFF
--- a/l10n_it_fiscalcode_sale/__manifest__.py
+++ b/l10n_it_fiscalcode_sale/__manifest__.py
@@ -15,7 +15,7 @@
     "installable": True,
     "auto_install": True,
     "depends": [
-        "sale",
+        "sale_management",
         "l10n_it_fiscalcode",
     ],
     "data": [


### PR DESCRIPTION
Il modulo `l10n_it_fiscalcode_sale` permette di mostrare il codice fiscale del cliente nella stampa del preventivo / ordine di vendita.
Dato che i preventivi/ordini di vendita vengono aggiunti installando `sale_management` (applicazione "Vendite"), il modulo dovrebbe di conseguenza dipendendere da quest'ultimo e non da `sale`.

La situazione attuale porta al seguente problema.
In una installazione Odoo con ad es. fatturazione elettronica, imposta di bollo e dichiarazione di intento (per obbligo dei clienti), il modulo  `l10n_it_fiscalcode_sale` viene installato in modo automatico anche se non necessario.

Questa PR corregge il problema.

Vedi anche https://github.com/OCA/l10n-italy/pull/3105