### PR TITLE
[16.0][FIX] l10n_it_fatturapa_out: piva in tests

### DIFF
--- a/l10n_it_fatturapa_out/tests/fatturapa_common.py
+++ b/l10n_it_fatturapa_out/tests/fatturapa_common.py
@@ -159,7 +159,7 @@ class FatturaPACommon(AccountTestInvoicingCommon):
             .create(
                 {
                     "name": "YourCompany 2",
-                    "vat": "IT06363391002",
+                    "vat": "IT06363381002",
                     "email": "info@yourcompany.example.com",
                     "fatturapa_fiscal_position_id": fatturapa_fiscal_position_id,
                     "country_id": self.env.company.country_id.id,


### PR DESCRIPTION
Per qualche ragione adesso la PIVA fallisce il controllo, prima no.
È corretto, il checksum non torna.

La funzione è questa: https://github.com/arthurdejong/python-stdnum/blob/master/stdnum/luhn.py#L61

Per comprendere la stranezza, ca. 10 ore fa `l10n_it_fatturapa_out` è stata mergiata, per cui i test erano tutti verdi. 1 ora fa i test di `l10n_it_fatturapa_in` erano rossi per il problema risolto da questa PR. https://github.com/OCA/l10n-italy/actions/runs/3808776252/jobs/6479633754  (è `l10n_it_fatturapa_out` che fallisce).

Notare che i test di https://github.com/OCA/l10n-italy/pull/3000 prima di questa PR erano rossi, includendo questa, sono verdi.
