### PR TITLE
Pulsante per validare e inviare le fatture a SdI

### DIFF
--- a/l10n_it_fatturapa_out/tests/fatturapa_common.py
+++ b/l10n_it_fatturapa_out/tests/fatturapa_common.py
@@ -233,28 +233,12 @@ class FatturaPACommon(AccountTestInvoicingCommon):
         return self.getFilePath(path)
 
     def _create_invoice(self):
-        return self.invoice_model.create(
-            {
-                "name": "Test Invoice",
-                "journal_id": self.sales_journal.id,
-                "partner_id": self.res_partner_fatturapa_0.id,
-                "move_type": "out_invoice",
-                "invoice_line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "account_id": self.a_sale.id,
-                            "product_id": self.product_product_10.id,
-                            "name": self.product_product_10.name,
-                            "quantity": 1,
-                            "price_unit": 1,
-                            "tax_ids": [(6, 0, {self.tax_22.id})],
-                        },
-                    ),
-                ],
-            }
+        invoice = self.init_invoice(
+            "out_invoice",
+            partner=self.res_partner_fatturapa_0,
+            products=self.product_product_10,
         )
+        return invoice
 
     def _create_e_invoice(self):
         invoice = self._create_invoice()

--- a/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
@@ -947,3 +947,15 @@ class TestFatturaPAXMLValidation(FatturaPACommon):
         self.set_e_invoice_file_id(attachment, "IT03297040366_00019.xml")
         xml_content = base64.decodebytes(attachment.datas)
         self.check_content(xml_content, "IT03297040366_00019.xml")
+
+    def test_validate_invoice(self):
+        """
+        Check that the invoice used for tests
+        is posted when validated.
+        """
+        invoice = self._create_invoice()
+        self.assertEqual(invoice.state, "draft")
+
+        invoice.action_post()
+
+        self.assertEqual(invoice.state, "posted")

--- a/l10n_it_fatturapa_pec/tests/test_e_invoice_send.py
+++ b/l10n_it_fatturapa_pec/tests/test_e_invoice_send.py
@@ -108,3 +108,20 @@ class TestEInvoiceSend(EInvoiceCommon):
         # Send it again
         e_invoice.send_to_sdi()
         self.assertEqual(e_invoice.state, "sent")
+
+    def test_action_open_export_send_sdi(self):
+        """
+        Check that the "Validate, export and send to SdI" button
+        sends the e-invoice.
+        """
+        # Arrange: create a draft invoice with no attachment
+        invoice = self._create_invoice()
+        self._create_fetchmail_pec_server()
+        self.assertEqual(invoice.state, "draft")
+        self.assertFalse(invoice.fatturapa_attachment_out_id)
+
+        # Act: open, export and send the invoice
+        invoice.action_open_export_send_sdi()
+        e_invoice = invoice.fatturapa_attachment_out_id
+
+        self.assertEqual(e_invoice.state, "sent")

--- a/l10n_it_sdi_channel/__manifest__.py
+++ b/l10n_it_sdi_channel/__manifest__.py
@@ -25,6 +25,7 @@
     "data": [
         "security/ir.model.access.csv",
         "security/security.xml",
+        "views/account_move_views.xml",
         "views/sdi_view.xml",
         "views/company_view.xml",
         "views/fatturapa_attachment_views.xml",

--- a/l10n_it_sdi_channel/models/__init__.py
+++ b/l10n_it_sdi_channel/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import account_move
 from . import fatturapa_attachment_out
 from . import company
 from . import sdi

--- a/l10n_it_sdi_channel/models/account_move.py
+++ b/l10n_it_sdi_channel/models/account_move.py
@@ -1,0 +1,51 @@
+#  Copyright 2022 Simone Rubino - TAKOBI
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def action_open_export_send_sdi(self):
+        """Validate, export and send to SdI the invoices."""
+        # Validate
+        self.action_post()
+
+        # Export
+        export_action = self.env["ir.actions.act_window"]._for_xml_id(
+            "l10n_it_fatturapa_out.action_wizard_export_fatturapa",
+        )
+        export_wizard_model = export_action.get("res_model")
+        export_wizard = (
+            self.env[export_wizard_model]
+            .with_context(
+                active_model=self._name,
+                active_ids=self.ids,
+            )
+            .create([{}])
+        )
+        export_result = export_wizard.exportFatturaPA()
+        # Ensure the link of the invoice to its attachment before exporting:
+        # otherwise an error during the export might break the link
+        self.flush(
+            fnames=[
+                "fatturapa_attachment_out_id",
+            ],
+            records=self,
+        )
+
+        # Get the exported attachments
+        attachment_model = self.env[export_result.get("res_model")]
+        exported_attachments_domain = export_result.get("domain")
+        if not exported_attachments_domain:
+            exported_attachments_domain = [
+                ("id", "=", export_result.get("res_id")),
+            ]
+        exported_attachments = attachment_model.search(
+            exported_attachments_domain,
+        )
+
+        # Send
+        send_result = exported_attachments.send_to_sdi()
+        return send_result

--- a/l10n_it_sdi_channel/models/company.py
+++ b/l10n_it_sdi_channel/models/company.py
@@ -32,3 +32,9 @@ class AccountConfigSettings(models.TransientModel):
         related="company_id.e_invoice_user_id",
         readonly=False,
     )
+    group_sdi_channel_validate_send = fields.Boolean(
+        string="Validate, export and send invoices",
+        help="Allow users to validate, export and send invoices to SdI "
+        "in one click.",
+        implied_group="l10n_it_sdi_channel.res_groups_validate_send",
+    )

--- a/l10n_it_sdi_channel/security/security.xml
+++ b/l10n_it_sdi_channel/security/security.xml
@@ -10,4 +10,7 @@
         >['|',('company_id','=',False),('company_id','in',company_ids)]</field>
     </record>
 
+    <record model="res.groups" id="res_groups_validate_send">
+        <field name="name">Validate, export and send invoices</field>
+    </record>
 </odoo>

--- a/l10n_it_sdi_channel/tests/__init__.py
+++ b/l10n_it_sdi_channel/tests/__init__.py
@@ -1,0 +1,3 @@
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_account_invoice

--- a/l10n_it_sdi_channel/tests/test_account_invoice.py
+++ b/l10n_it_sdi_channel/tests/test_account_invoice.py
@@ -1,0 +1,81 @@
+#  Copyright 2022 Simone Rubino - TAKOBI
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import tagged
+
+from odoo.addons.l10n_it_fatturapa_out.tests.fatturapa_common import FatturaPACommon
+
+
+@tagged("post_install", "-at_install")
+class TestAccountInvoice(FatturaPACommon):
+    def setUp(self):
+        super().setUp()
+        # XXX - a company named "YourCompany" alread exists
+        # we move it out of the way but we should do better here
+        self.env.company.sudo().search([("name", "=", "YourCompany")]).write(
+            {"name": "YourCompany_"}
+        )
+        self.env.company.name = "YourCompany"
+        self.env.company.vat = "IT06363391001"
+        self.env.company.fatturapa_art73 = True
+        self.env.company.partner_id.street = "Via Milano, 1"
+        self.env.company.partner_id.city = "Roma"
+        self.env.company.partner_id.state_id = self.env.ref("base.state_us_2").id
+        self.env.company.partner_id.zip = "00100"
+        self.env.company.partner_id.phone = "06543534343"
+        self.env.company.email = "info@yourcompany.example.com"
+        self.env.company.partner_id.country_id = self.env.ref("base.it").id
+        self.env.company.fatturapa_fiscal_position_id = self.env.ref(
+            "l10n_it_fatturapa.fatturapa_RF01"
+        ).id
+
+    def test_action_open_export_send_sdi(self):
+        """
+        Check that the "Validate, export and send to SdI" button
+        validates the invoice and exports the attachment.
+        """
+        # Arrange: create a draft invoice with no attachment
+        invoice = self._create_invoice()
+        self.assertEqual(invoice.state, "draft")
+        self.assertFalse(invoice.fatturapa_attachment_out_id)
+
+        # Act: open, export and send.
+        # This raises an exception because there is no channel,
+        # we can't create a channel yet
+        # because channel types are defined by depending modules
+        with self.assertRaises(ValueError) as ve:
+            invoice.action_open_export_send_sdi()
+        exc_message = ve.exception.args[0]
+
+        # Assert: we are missing the SdI channel,
+        # but invoice is validated and attachment has been created
+        self.assertIn("Expected singleton", exc_message)
+        self.assertIn("sdi.channel", exc_message)
+        self.assertEqual(invoice.state, "posted")
+        self.assertTrue(invoice.fatturapa_attachment_out_id)
+
+    def test_action_open_export_send_sdi_ui(self):
+        """
+        Check that the "Validate, export and send to SdI" button
+        clicked in the UI (where an exception causes a ROLLBACK)
+        does not validate the invoice or export the attachment.
+        """
+        # Arrange: create a draft invoice with no attachment
+        invoice = self._create_invoice()
+        self.assertEqual(invoice.state, "draft")
+        self.assertFalse(invoice.fatturapa_attachment_out_id)
+
+        # Act: open, export and send.
+        # This raises an exception because there is no channel,
+        # we can't create a channel yet
+        # because channel types are defined by depending modules
+        with self.assertRaises(ValueError) as ve, self.env.cr.savepoint():
+            invoice.action_open_export_send_sdi()
+        exc_message = ve.exception.args[0]
+
+        # Assert: we are missing the SdI channel,
+        # but invoice is still in draft and attachment has not been created
+        self.assertIn("Expected singleton", exc_message)
+        self.assertIn("sdi.channel", exc_message)
+        self.assertEqual(invoice.state, "draft")
+        self.assertFalse(invoice.fatturapa_attachment_out_id)

--- a/l10n_it_sdi_channel/views/account_move_views.xml
+++ b/l10n_it_sdi_channel/views/account_move_views.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2022 Simone Rubino - TAKOBI
+  ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+  -->
+<odoo>
+    <record id="view_invoice_form_fatturapa" model="ir.ui.view">
+        <field name="name">Add SdI channel edits to invoice's form view</field>
+        <field name="model">account.move</field>
+        <field
+            name="inherit_id"
+            ref="l10n_it_fatturapa_out.view_invoice_form_fatturapa"
+        />
+        <field name="arch" type="xml">
+            <button
+                name="%(l10n_it_fatturapa_out.action_wizard_export_fatturapa)d"
+                position="after"
+            >
+                <button
+                    name="action_open_export_send_sdi"
+                    type="object"
+                    string="Validate, export and send to SdI"
+                    groups="l10n_it_sdi_channel.res_groups_validate_send"
+                    attrs="{
+                            'invisible': [
+                                '|',
+                                    '|',
+                                        ('fatturapa_attachment_out_id', '!=', False),
+                                        ('state' ,'not in', ['draft']),
+                                    ('electronic_invoice_subjected', '=', False),
+                            ]}"
+                />
+            </button>
+        </field>
+    </record>
+</odoo>

--- a/l10n_it_sdi_channel/views/company_view.xml
+++ b/l10n_it_sdi_channel/views/company_view.xml
@@ -43,6 +43,15 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="o_setting_left_pane">
+                            <field name="group_sdi_channel_validate_send" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="group_sdi_channel_validate_send" />
+                            <div class="text-muted">
+                                Allow users to validate, export and send invoices to SdI in one click.
+                            </div>
+                        </div>
                     </div>
                 </div>
             </xpath>


### PR DESCRIPTION
Implementa parzialmente https://github.com/OCA/l10n-italy/issues/2875 per `14.0`.
Forward port di https://github.com/OCA/l10n-italy/pull/2876.
Ho escluso i commit relativi al nuovo modulo **l10n_it_fatturapa_sdicoop** perché sono nella PR di migrazione https://github.com/OCA/l10n-italy/pull/3122.

~~Include https://github.com/OCA/l10n-italy/pull/3118.~~