### PR TITLE
[16.0] [FIX] l10n_it_fatturapa_out: TypeError: format requires a mapping

### DIFF
--- a/l10n_it_fatturapa_out/models/account.py
+++ b/l10n_it_fatturapa_out/models/account.py
@@ -62,10 +62,12 @@ class AccountInvoice(models.Model):
                 raise UserError(
                     _(
                         "Invoice %(name)s fiscal payment term must be"
-                        " set for the selected payment term %(term)s",
-                        invoice.name,
-                        invoice.invoice_payment_term_id.name,
+                        " set for the selected payment term %(term)s"
                     )
+                    % {
+                        "name": invoice.name,
+                        "term": invoice.invoice_payment_term_id.name,
+                    },
                 )
 
             if (
@@ -75,12 +77,12 @@ class AccountInvoice(models.Model):
                 raise UserError(
                     _(
                         "Invoice %(name)s fiscal payment method must be"
-                        " set for the selected payment term %(term)s",
-                        {
-                            "name": invoice.name,
-                            "term": invoice.invoice_payment_term_id.name,
-                        },
+                        " set for the selected payment term %(term)s"
                     )
+                    % {
+                        "name": invoice.name,
+                        "term": invoice.invoice_payment_term_id.name,
+                    },
                 )
 
             if not all(


### PR DESCRIPTION
Vedi https://www.odoo-italia.org/forum/forum-1/question/odoo16-fatturapa-out-3457

Traceback (most recent call last):
  File "/opt/odoo16/odoo/odoo/http.py", line 1534, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo16/odoo/odoo/service/model.py", line 134, in retrying
    result = func()
  File "/opt/odoo16/odoo/odoo/http.py", line 1563, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo16/odoo/odoo/http.py", line 1760, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo16/odoo/addons/website/models/ir_http.py", line 222, in _dispatch
    response = super()._dispatch(endpoint)
  File "/opt/odoo16/odoo/odoo/addons/base/models/ir_http.py", line 138, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo16/odoo/odoo/http.py", line 673, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo16/odoo/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo16/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo16/odoo/odoo/api.py", line 461, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo16/odoo/odoo/api.py", line 448, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo16/odoo-custom-addons/l10n-italy-16.0/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py", line 262, in exportFatturaPA
    fatturapa, progressivo_invio = self.exportInvoiceXML(
  File "/opt/odoo16/odoo-custom-addons/l10n-italy-16.0/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py", line 240, in exportInvoiceXML
    invoice_ids.preventive_checks()
  File "/opt/odoo16/odoo-custom-addons/l10n-italy-16.0/l10n_it_fatturapa_out/models/account.py", line 63, in preventive_checks
    _(
  File "/opt/odoo16/odoo/odoo/tools/translate.py", line 451, in __call__
    translation = source % (args or kwargs)
TypeError: format requires a mapping


