### PR TITLE
[10.0][FIX] l10n_it_vat_registries: negative tax line in supplier invoice, must be negative in vat register line

### DIFF
--- a/l10n_it_vat_registries/models/vat_registry.py
+++ b/l10n_it_vat_registries/models/vat_registry.py
@@ -112,7 +112,7 @@ class ReportRegistroIva(models.AbstractModel):
 
             if (
                 'receivable' in move.move_type or
-                ('payable_refund' == move.move_type and tax_amount > 0)
+                'payable_refund' == move.move_type
             ):
                 # otherwise refund would be positive and invoices
                 # negative.


### PR DESCRIPTION
Negative tax line in supplier invoice, must be negative in vat register line