### PR TITLE
[14.0][l10n_it_fatturapa_out] Fix sul codice IVA generato nell'XML de…

### DIFF
--- a/l10n_it_fatturapa_out/wizard/efattura.py
+++ b/l10n_it_fatturapa_out/wizard/efattura.py
@@ -110,7 +110,7 @@ class EFatturaOut:
         def get_id_fiscale_iva(partner, prefer_fiscalcode=False):
             id_paese = partner.country_id.code
             if partner.vat:
-                if id_paese == "IT" and partner.vat.startswith("IT"):
+                if partner.vat.startswith(id_paese):
                     id_codice = partner.vat[2:]
                 else:
                     id_codice = partner.vat


### PR DESCRIPTION
…lla fattura elettronica per un cliente estero che riportava il codice del paese come prefisso

Il file xml generato per le fatture in uscita, setta la partita iva del cliente estero con il prefisso della nazione. 

La copia cortesia della fattura emessa visualizza la partita iva con doppio prefisso della nazione