### PR TITLE
[14.0][FIX] l10n_it_intrastat_statement: report doesn't show the right origin country for the good

### DIFF
--- a/l10n_it_intrastat_statement/report/report_intrastat_mod2_bis.xml
+++ b/l10n_it_intrastat_statement/report/report_intrastat_mod2_bis.xml
@@ -161,7 +161,7 @@
                                                     t-field="l.country_origin_id.code"
                                                 /></td>
                                         <td><span
-                                                    t-field="l.country_origin_id.code"
+                                                    t-field="l.country_good_origin_id.code"
                                                 /></td>
                                         <td><span
                                                     t-field="l.province_destination_id.code"


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/3157 per `14.0`