### PR TITLE
[12.0][FIX] l10n_it_intrastat and statement VAT partner different from VAT passed from VIES

### DIFF
--- a/l10n_it_intrastat/__manifest__.py
+++ b/l10n_it_intrastat/__manifest__.py
@@ -33,5 +33,10 @@
     ],
     'demo': [
         'demo/product_demo.xml'
-    ]
+    ],
+    'external_dependencies': {
+        'python': [
+            'stdnum',
+        ],
+    }
 }

--- a/l10n_it_intrastat/models/__init__.py
+++ b/l10n_it_intrastat/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import partner
 from . import product
 from . import account
 from . import intrastat

--- a/l10n_it_intrastat/models/account.py
+++ b/l10n_it_intrastat/models/account.py
@@ -544,7 +544,7 @@ class AccountInvoiceIntrastat(models.Model):
         """
         res = {
             'country_partner_id': partner.country_id.id,
-            'vat_code': partner.vat and partner.vat[2:] or False,
+            'vat_code': partner.compact_vat(),
             'country_origin_id': partner.country_id.id,
             'country_good_origin_id': partner.country_id.id,
             'country_destination_id': partner.country_id.id,

--- a/l10n_it_intrastat/models/partner.py
+++ b/l10n_it_intrastat/models/partner.py
@@ -1,0 +1,20 @@
+from odoo import api, models
+from stdnum.eu.vat import compact
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.multi
+    def compact_vat(self):
+        # VIES check is made on 'compacted' VAT with function stdnum.eu.vat.compact(),
+        # so it is possibly different from VAT in this field. Make sure to set correct
+        # VAT in intrastat declaration.
+        self.ensure_one()
+        if not self.vat:
+            return False
+        res = self.vat[2:]
+        vat_normalized = compact(self.vat)[2:]
+        if vat_normalized != res:
+            res = vat_normalized
+        return res

--- a/l10n_it_intrastat/models/partner.py
+++ b/l10n_it_intrastat/models/partner.py
@@ -1,5 +1,7 @@
-from odoo import api, models
+from odoo import api, models, _
+from odoo.exceptions import ValidationError
 from stdnum.eu.vat import compact
+from stdnum.exceptions import InvalidComponent
 
 
 class ResPartner(models.Model):
@@ -14,7 +16,11 @@ class ResPartner(models.Model):
         if not self.vat:
             return False
         res = self.vat[2:]
-        vat_normalized = compact(self.vat)[2:]
+        try:
+            vat_normalized = compact(self.vat)[2:]
+        except InvalidComponent:
+            raise ValidationError(
+                _("%s is not a EU valid VAT!") % self.vat)
         if vat_normalized != res:
             res = vat_normalized
         return res

--- a/l10n_it_intrastat_statement/models/intrastat_statement_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_section.py
@@ -65,7 +65,7 @@ class IntrastatStatementSection(models.AbstractModel):
             'invoice_id': invoice_id.id,
             'partner_id': partner_id.id,
             'country_partner_id': inv_intra_line.country_partner_id.id,
-            'vat_code': partner_id.vat and partner_id.vat[2:],
+            'vat_code': partner_id.compact_vat(),
             'amount_euro': amount_euro,
             'intrastat_code_id': inv_intra_line.intrastat_code_id.id,
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # generated from manifests external_dependencies
 asn1crypto
 codicefiscale
+python-stdnum
 pyxb
 PyXB==1.2.6
 unidecode


### PR DESCRIPTION
Descrizione del problema o della funzionalità: la partita IVA viene controllata dal servizio VIES previo compattamento tramite una funzione che rimuove segni di interpunzione per cui può essere diversa da quella a video

Comportamento attuale prima di questa PR: la dichiarazione Intrastat ha un valore di partita IVA diversa da quella del partner

Comportamento desiderato dopo questa PR: la dichiarazione Intrastat ha un valore corretto




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing