### PR TITLE
[FIX] Stampa registro IVA tagliata

### DIFF
--- a/l10n_it_account/reports/account_reports_view.xml
+++ b/l10n_it_account/reports/account_reports_view.xml
@@ -52,7 +52,7 @@
 
           <div class="header">
               <div class="row">
-                  <div class="col-xs-4">
+                  <div class="col-8">
                       <h3><span t-esc="company.name" /></h3>
                       <span t-esc="company.street" class="" /><br />
                       <span t-esc="company.zip" class="" /> - <span
@@ -64,10 +64,7 @@
                             class=""
                         /><br />
                   </div>
-                  <div
-                        class="col-xs-4 col-xs-offset-4 text-right"
-                        style="margin-left:10px"
-                    >
+                  <div class="col-4 text-right">
                       <h3 t-esc="title" />
                   </div>
               </div>


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/3217 per `14.0`.
La correzione non è definitiva perché dà solamente più spazio al nome dell'azienda: nomi più lunghi causerebbero di nuovo il verificarsi della issue linkata.
Per ora non ho trovato altri modi di correggere.