### PR TITLE
[16.0][FIX] l10n_it_withholding_tax: document_tax_totals needs to be declared primary in oder to be inherited

### DIFF
--- a/l10n_it_withholding_tax/readme/CONTRIBUTORS.rst
+++ b/l10n_it_withholding_tax/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Alessandro Camilli <alessandrocamilli@openforce.it>
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Marco Colombo <https://github.com/TheMule71>
+* Alex Comba <alex.comba@agilebg.com>

--- a/l10n_it_withholding_tax/views/report_invoice.xml
+++ b/l10n_it_withholding_tax/views/report_invoice.xml
@@ -1,80 +1,90 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2023 Alex Comba - Agile Business Group
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+  -->
 <odoo>
-    <record id="print_withholding_tax" model="ir.ui.view">
-        <field name="name">print_withholding_tax</field>
-        <field name="inherit_id" ref="account.report_invoice_document" />
-        <field name="arch" type="xml">
-            <xpath
-                expr="//table[@name='invoice_line_table']/thead/tr/th[6]"
-                position="after"
-            >
-                <t t-if="o.withholding_tax_in_print and o.withholding_tax">
-                    <th class="text-right">
-                        Withholding Tax
-                    </th>
-                </t>
-            </xpath>
 
-            <xpath
-                expr="//table[@name='invoice_line_table']/tbody[hasclass('invoice_tbody')]//td[6]"
-                position="after"
-            >
-                <t t-if="o.withholding_tax_in_print and o.withholding_tax">
+    <template id="print_withholding_tax" inherit_id="account.report_invoice_document">
+        <xpath
+            expr="//table[@name='invoice_line_table']/thead/tr/th[6]"
+            position="after"
+        >
+            <t t-if="o.withholding_tax_in_print and o.withholding_tax">
+                <th class="text-right">
+                    Withholding Tax
+                </th>
+            </t>
+        </xpath>
+
+        <xpath
+            expr="//table[@name='invoice_line_table']/tbody[hasclass('invoice_tbody')]//td[6]"
+            position="after"
+        >
+            <t t-if="o.withholding_tax_in_print and o.withholding_tax">
+                <td class="text-right">
+                    <span
+                        t-esc="', '.join(map(lambda x: (x.name), line.invoice_line_tax_wt_ids))"
+                    />
+                </td>
+            </t>
+        </xpath>
+
+        <xpath expr="//t[@t-if='print_with_payments']/t" position="inside">
+            <t t-if="o.withholding_tax_in_print and len(payments_vals) > 0">
+                <tr class="border-black">
+                    <td>
+                        <strong>Residual Net To Pay</strong>
+                    </td>
                     <td class="text-right">
                         <span
-                            t-esc="', '.join(map(lambda x: (x.name), line.invoice_line_tax_wt_ids))"
+                            t-field="o.amount_net_pay_residual"
+                            t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
                         />
                     </td>
-                </t>
-            </xpath>
+                </tr>
+            </t>
+        </xpath>
 
-            <xpath expr="//t[@t-if='print_with_payments']/t" position="inside">
-                <t t-if="o.withholding_tax_in_print and len(payments_vals) > 0">
-                    <tr class="border-black">
-                        <td>
-                            <strong>Residual Net To Pay</strong>
-                        </td>
-                        <td class="text-right">
-                            <span
-                                t-field="o.amount_net_pay_residual"
-                                t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
-                            />
-                        </td>
-                    </tr>
-                </t>
-            </xpath>
-        </field>
-    </record>
-    <record id="document_tax_totals_wt" model="ir.ui.view">
-        <field name="name">document_tax_totals_wt</field>
-        <field name="inherit_id" ref="account.document_tax_totals" />
-        <field name="arch" type="xml">
+        <xpath expr="//t[@t-call='account.document_tax_totals']" position="attributes">
+            <attribute
+                name="t-call"
+            >l10n_it_withholding_tax.document_tax_totals_wt</attribute>
+        </xpath>
+
+    </template>
+
+    <template
+        id="document_tax_totals_wt"
+        inherit_id="account.document_tax_totals"
+        primary="True"
+    >
             <xpath expr="//tr[hasclass('o_total')]" position="after">
                 <t t-if="o.withholding_tax_in_print and o.withholding_tax">
                     <tr>
                         <td>
                             <span>Withholding Tax</span>
                         </td>
-                        <td class="text-right">
+                        <td class="text-end">
                             <span
-                                t-field="o.withholding_tax_amount"
-                                t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
-                            />
+                            t-field="o.withholding_tax_amount"
+                            t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
+                        />
                         </td>
                     </tr>
                     <tr class="border-black">
                         <td>
                             <strong>Net To Pay</strong>
                         </td>
-                        <td class="text-right">
+                        <td class="text-end">
                             <span
-                                t-field="o.amount_net_pay"
-                                t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
-                            />
+                            t-field="o.amount_net_pay"
+                            t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
+                        />
                         </td>
                     </tr>
                 </t>
             </xpath>
-        </field>
-    </record>
+    </template>
+
 </odoo>

--- a/l10n_it_withholding_tax/views/withholding_tax.xml
+++ b/l10n_it_withholding_tax/views/withholding_tax.xml
@@ -65,7 +65,7 @@
                     <field name="comment" />
                     <newline />
                     <group string="Rates">
-                        <field name="rate_ids" nolabel="1">
+                        <field name="rate_ids" nolabel="1" colspan="2">
                             <tree>
                                 <field name="base" />
                                 <field name="tax" />


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/3160

Inoltre migliora la visualizzazione del campo `Rates` . 
Attualmente viene mostrato come segue:
![image](https://user-images.githubusercontent.com/3512779/226556009-9c778705-a765-4602-8feb-5bced178cf74.png)

Mentre con https://github.com/OCA/l10n-italy/commit/2df89d6373ac2ec5d3fd9f44235e33f24e48f3df viene mostrato così:

![image](https://user-images.githubusercontent.com/3512779/226556205-ce08c953-9a70-4727-a14c-a9f03717612e.png)
