### PR TITLE
[14.0][FIX] Various fix on assets_management

### DIFF
--- a/assets_management/models/asset_depreciation.py
+++ b/assets_management/models/asset_depreciation.py
@@ -11,12 +11,12 @@ class AssetDepreciation(models.Model):
     _name = "asset.depreciation"
     _description = "Assets Depreciations"
 
-    amount_depreciable = fields.Monetary(string="Depreciable Amount")
+    amount_depreciable = fields.Monetary(string="Initial Depreciable Amount")
 
     amount_depreciable_updated = fields.Monetary(
         compute="_compute_amounts",
         store=True,
-        string="Updated Amount",
+        string="Updated Depreciable Amount",
     )
 
     amount_depreciated = fields.Monetary(

--- a/assets_management/models/asset_depreciation_line.py
+++ b/assets_management/models/asset_depreciation_line.py
@@ -227,11 +227,12 @@ class AssetDepreciationLine(models.Model):
         return self.asset_accounting_info_ids
 
     def get_balances_grouped(self):
-        """Groups balances of line in `self` by line.move_type"""
-        balances_grouped = {}
+        """Groups balances of line in `self` by line.move_type, adding all
+        possible type to ensure values are computed always."""
+        balances_grouped = {
+            x: 0 for x in dict(self._fields["move_type"].selection).keys()
+        }
         for line in self:
-            if line.move_type not in balances_grouped:
-                balances_grouped[line.move_type] = 0
             balances_grouped[line.move_type] += line.balance
         return balances_grouped
 

--- a/assets_management/report/asset_journal_xlsx.py
+++ b/assets_management/report/asset_journal_xlsx.py
@@ -255,7 +255,7 @@ class AssetJournalXslx(models.AbstractModel):
                 "vstyle": report_data["formats"]["format_depreciation_value"],
             },
             {
-                "title": _("Depreciable Amount"),
+                "title": _("Initial Depreciable Amount"),
                 "field": "dep_amount_depreciable",
                 "type": "amount",
                 "tstyle": report_data["formats"]["format_depreciation_header"],

--- a/assets_management/report/asset_previsional_xlsx.py
+++ b/assets_management/report/asset_previsional_xlsx.py
@@ -249,7 +249,7 @@ class AssetJournalXslx(models.AbstractModel):
                 "vstyle": report_data["formats"]["format_depreciation_value"],
             },
             {
-                "title": _("Depreciable Amount"),
+                "title": _("Initial Depreciable Amount"),
                 "field": "dep_amount_depreciable",
                 "type": "amount",
                 "tstyle": report_data["formats"]["format_depreciation_header"],


### PR DESCRIPTION
1. Rinominato i campi per essere più chiari:

-  `Depreciable Amount` in `Initial Depreciable Amount`
-  `Updated Amount` in `Updated Depreciable Amount`

2. Forzato il calcolo di tutti i valori sull'ammortamento, per evitare disallineamenti (ad es. nel caso venga eliminata una riga di un tipo non presente in altre righe, l'attuale funzione non aggiorna il valore in quanto non trova alcun valore di quel tipo)