### PR TITLE
[14.0][IMP][assets_management] Rimosso errore inutile quando si cancella un ammortamento

### DIFF
--- a/assets_management/models/asset.py
+++ b/assets_management/models/asset.py
@@ -121,17 +121,7 @@ class Asset(models.Model):
         return super().write(vals)
 
     def unlink(self):
-        if self.mapped("asset_accounting_info_ids"):
-            assets = self.filtered("asset_accounting_info_ids")
-            name_list = "\n".join([a[-1] for a in assets.name_get()])
-            raise ValidationError(
-                _(
-                    "The assets you are trying to delete are currently linked"
-                    " to accounting info. Please remove them if necessary"
-                    " before removing these assets:\n"
-                )
-                + name_list
-            )
+        self.mapped("asset_accounting_info_ids").unlink()
         self.mapped("depreciation_ids").unlink()
         return super().unlink()
 

--- a/assets_management/models/asset_depreciation_line.py
+++ b/assets_management/models/asset_depreciation_line.py
@@ -145,17 +145,6 @@ class AssetDepreciationLine(models.Model):
         return res
 
     def unlink(self):
-        if self.mapped("asset_accounting_info_ids"):
-            lines = self.filtered("asset_accounting_info_ids")
-            name_list = "\n".join([line[-1] for line in lines.name_get()])
-            raise ValidationError(
-                _(
-                    "The lines you you are trying to delete are currently"
-                    " linked to accounting info. Please remove them if"
-                    " necessary before removing these lines:\n"
-                )
-                + name_list
-            )
         if any([m.state != "draft" for m in self.mapped("move_id")]):
             lines = self.filtered(
                 lambda line: line.move_id and line.move_id.state != "draft"
@@ -168,6 +157,7 @@ class AssetDepreciationLine(models.Model):
                 )
                 + name_list
             )
+        self.mapped("asset_accounting_info_ids").unlink()
         self.mapped("move_id").unlink()
         return super().unlink()
 


### PR DESCRIPTION
Quando una `asset.depreciation.line` è collegata a dei movimenti contabili, se si prova ad eliminarla compare un messaggio di errore che invita ad eliminare il collegamento ai movimenti contabili.
Non è chiara l'utilità di questo doppio passaggio.

Aggiornamento: inoltre all'eliminazione della fattura l'informazione contabile inserita nel cespite viene adesso eliminata, in quanto non ha più significato. Aggiornamento 1: quest'ultimo test è fattibile solo con l'installazione del modulo aggiuntivo account_move_force_removal, quindi non su questa PR.