### PR TITLE
[FIX] l10_it_fatturapa_out: In generazione xml nota credito, l'import…

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -138,7 +138,7 @@ class WizardExportFatturapa(models.TransientModel):
                 "Natura": tax_line_id.kind_id.code,
                 # 'Arrotondamento':'',
                 "ImponibileImporto": tax_id.tax_base_amount,
-                "Imposta": tax_id.credit,
+                "Imposta": abs(tax_id.balance),
                 "EsigibilitaIVA": tax_line_id.payability,
             }
             if tax_line_id.law_reference:


### PR DESCRIPTION
…o dell'imposta era a 0 perchè veniva preso campo credit(Avere) dalle righe di movimenti contabili. Ma, in note credito, l'importo dell'imposta è nel campo debit(Dare). Adesso se la registrazione contabile è una fattura di vendita, viene preso credit, altrimenti viene preso debit.