### PR TITLE
[FIX] l10n_it_delivery_note: fix error access to ir.actions.act_window when clicking smart button on invoice and delivery note

### DIFF
--- a/l10n_it_delivery_note/models/account_invoice.py
+++ b/l10n_it_delivery_note/models/account_invoice.py
@@ -31,9 +31,11 @@ class AccountInvoice(models.Model):
 
     def goto_delivery_notes(self, **kwargs):
         delivery_notes = self.mapped("delivery_note_ids")
-        action = self.env.ref(
+        action = self.env['ir.actions.actions']._for_xml_id(
             "l10n_it_delivery_note.stock_delivery_note_action"
-        ).read()[0]
+        )
+
+
         action.update(kwargs)
 
         if len(delivery_notes) > 1:

--- a/l10n_it_delivery_note/models/sale_order.py
+++ b/l10n_it_delivery_note/models/sale_order.py
@@ -124,9 +124,9 @@ class SaleOrder(models.Model):
 
     def goto_delivery_notes(self, **kwargs):
         delivery_notes = self.mapped("delivery_note_ids")
-        action = self.env.ref(
+        action = self.env['ir.actions.actions']._for_xml_id(
             "l10n_it_delivery_note.stock_delivery_note_action"
-        ).read()[0]
+        )
         action.update(kwargs)
 
         if len(delivery_notes) > 1:

--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -553,7 +553,9 @@ class StockDeliveryNote(models.Model):
 
     def goto_sales(self, **kwargs):
         sales = self.mapped("sale_ids")
-        action = self.env.ref("sale.action_orders").read()[0]
+        action = self.env['ir.actions.actions']._for_xml_id(
+            "sale.action_orders"
+        )
         action.update(kwargs)
 
         if len(sales) > 1:


### PR DESCRIPTION

In l10n_it_delivery_note was used the self.env.ref().read()[0] to access to the act_window by xmlid.
If an user is not Administrator, the error "You are not allowed to access 'ActionWindow' records".
https://imgur.com/a/9nigr2h
Should be used _for_xml_id instead of self.env.ref that returns a dict of the fields of the action window and does not return the record 

--------
In l10n_it_delivery_note è usato self.env.ref per ricavare l'azione , se non sei utente ti dà errore di permessi su ir.actions.act_window .
Sarebbe più corretto, come fatto nella presente PR, usare _for_xml_id per ricavare la dict con i field della act_window(implicitamente _for_xml_id travasa con .sudo() i valori della action dentro una nuova var) anzicchè il puntamento al record. 