### PR TITLE
[14.0] l10n_it_fatturapa: fix preview style unwanted reset

### DIFF
--- a/l10n_it_fatturapa/models/company.py
+++ b/l10n_it_fatturapa/models/company.py
@@ -108,7 +108,6 @@ class AccountConfigSettings(models.TransientModel):
         related="company_id.fatturapa_preview_style",
         string="Preview Format Style",
         required=True,
-        default="Foglio_di_stile_fatturaordinaria_v1.2.2.xsl",
         readonly=False,
     )
 


### PR DESCRIPTION
Salvando qualsiasi impostazione, lo stile di preview della f.e. veniva resettato al default.