### PR TITLE
[FIX] l10n_it_intrastat_statement: fix check to export amount currency

### DIFF
--- a/l10n_it_intrastat/tests/test_intrastat.py
+++ b/l10n_it_intrastat/tests/test_intrastat.py
@@ -1,6 +1,11 @@
 # Copyright 2019 Simone Rubino - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import datetime
+
+from odoo import fields
+from odoo.exceptions import UserError
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 from odoo.addons.account.tests.account_test_classes import AccountingTestCase
 
 
@@ -14,6 +19,8 @@ class TestIntrastat(AccountingTestCase):
         self.account_account_model = self.env['account.account']
         self.so_model = self.env['sale.order']
         self.fp_model = self.env['account.fiscal.position']
+        self.partner_model = self.env['res.partner']
+        self.res_currency_rate_model = self.env['res.currency.rate']
 
         self.account_account_receivable = self.account_account_model.create({
             'code': '1',
@@ -29,6 +36,28 @@ class TestIntrastat(AccountingTestCase):
 
         self.partner01.property_account_receivable_id = self.account_account_receivable
         self.partner01.property_account_payable_id = self.account_account_payable
+
+        partner_not_euro_country = self.env['res.country'].search(
+            [
+                ('name', 'ilike', 'poland')
+            ],
+            limit=1
+        )
+        partner_not_euro_country.currency_id.active = True
+        self.partner_not_euro = self.partner_model.create({
+            'name': "AMAZON EU s.a.r.l. (Poland)",
+            'vat': "PL5262907815",
+            'street': "Ul. Rondo Daszynskiego 1",
+            'city': "Warsav",
+            'zip': '00000',
+            'country_id': partner_not_euro_country.id
+        })
+
+        self.res_currency_rate_model.create({
+            'currency_id': partner_not_euro_country.currency_id.id,
+            'name': fields.Date.to_string(fields.Date.today()),
+            'rate': "1.0"
+        })
 
         self.sales_journal = self.env['account.journal'].search(
             [('type', '=', 'sale')])[0]
@@ -49,11 +78,58 @@ class TestIntrastat(AccountingTestCase):
         invoice = self.env['account.invoice'].browse(res['res_id'])
         return invoice
 
+    def test_get_currency_rate_on_invoice_without_date_raise_exception(self):
+        with self.assertRaises(UserError):
+            invoice = self.invoice_model.create({
+                'partner_id': self.partner01.id,
+                'journal_id': self.sales_journal.id,
+                'account_id': self.account_account_receivable.id,
+                'intrastat': True,
+                'invoice_line_ids': [(0, 0, {
+                    'name': 'service',
+                    'product_id': self.product01.id,
+                    'account_id': self.account_account_receivable.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'invoice_line_tax_ids': [(6, 0, {
+                        self.tax22.id
+                    })]
+                })]
+            })
+
+            invoice.get_currency_rate_at_invoice_date()
+
+    def test_no_invoice_date_raise_exception_on_intrastat_line_compute(self):
+        with self.assertRaises(UserError):
+            invoice = self.invoice_model.create({
+                'partner_id': self.partner01.id,
+                'journal_id': self.sales_journal.id,
+                'account_id': self.account_account_receivable.id,
+                'intrastat': True,
+                'invoice_line_ids': [(0, 0, {
+                    'name': 'service',
+                    'product_id': self.product01.id,
+                    'account_id': self.account_account_receivable.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'invoice_line_tax_ids': [(6, 0, {
+                        self.tax22.id
+                    })]
+                })]
+            })
+
+            invoice.compute_taxes()
+            invoice.action_invoice_open()
+
+            # Compute intrastat lines
+            invoice.compute_intrastat_lines()
+
     def test_invoice_totals(self):
         invoice = self.invoice_model.create({
             'partner_id': self.partner01.id,
             'journal_id': self.sales_journal.id,
             'account_id': self.account_account_receivable.id,
+            'date_invoice': fields.Date.today(),
             'intrastat': True,
             'invoice_line_ids': [(0, 0, {
                 'name': 'service',
@@ -75,8 +151,117 @@ class TestIntrastat(AccountingTestCase):
         self.assertEqual(invoice.intrastat, True)
         # Amount Control
         total_intrastat_amount = sum(
-            l.amount_currency for l in invoice.intrastat_line_ids)
+            line.amount_currency for line in invoice.intrastat_line_ids)
         self.assertEqual(total_intrastat_amount, invoice.amount_untaxed)
+
+    def test_invoice_partner_no_euro_need_amount_currency(self):
+        invoice = self.invoice_model.create({
+            'partner_id': self.partner_not_euro.id,
+            'journal_id': self.sales_journal.id,
+            'account_id': self.account_account_receivable.id,
+            'date_invoice': fields.Date.today(),
+            'intrastat': True,
+            'invoice_line_ids': [(0, 0, {
+                'name': 'service',
+                'product_id': self.product01.id,
+                'account_id': self.account_account_receivable.id,
+                'quantity': 1,
+                'price_unit': 100,
+                'invoice_line_tax_ids': [(6, 0, {
+                    self.tax22.id
+                })]
+            })]
+        })
+        self.assertTrue(invoice.need_amount_currency)
+
+    def test_currency_not_active_raise_exception(self):
+        with self.assertRaises(UserError):
+            invoice = self.invoice_model.create({
+                'partner_id': self.partner_not_euro.id,
+                'journal_id': self.sales_journal.id,
+                'account_id': self.account_account_receivable.id,
+                'date_invoice': fields.Date.today(),
+                'intrastat': True,
+                'invoice_line_ids': [(0, 0, {
+                    'name': 'service',
+                    'product_id': self.product01.id,
+                    'account_id': self.account_account_receivable.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'invoice_line_tax_ids': [(6, 0, {
+                        self.tax22.id
+                    })]
+                })]
+            })
+
+        invoice.compute_taxes()
+        invoice.action_invoice_open()
+        invoice.partner_id.country_id.currency_id.active = False
+        # Compute intrastat lines
+        invoice.compute_intrastat_lines()
+
+    def test_no_currency_rate_raise_exception(self):
+        currency_rate_date = fields.Date.today() - datetime.timedelta(days=1)
+        with self.assertRaises(UserError):
+            invoice = self.invoice_model.create({
+                'partner_id': self.partner_not_euro.id,
+                'journal_id': self.sales_journal.id,
+                'account_id': self.account_account_receivable.id,
+                'date_invoice': currency_rate_date,
+                'intrastat': True,
+                'invoice_line_ids': [(0, 0, {
+                    'name': 'service',
+                    'product_id': self.product01.id,
+                    'account_id': self.account_account_receivable.id,
+                    'quantity': 1,
+                    'price_unit': 100,
+                    'invoice_line_tax_ids': [(6, 0, {
+                        self.tax22.id
+                    })]
+                })]
+            })
+
+            invoice.compute_taxes()
+            invoice.action_invoice_open()
+
+            # Compute intrastat lines
+            invoice.compute_intrastat_lines()
+
+    def test_invoice_totals_partner_no_euro(self):
+        invoice = self.invoice_model.create({
+            'partner_id': self.partner_not_euro.id,
+            'journal_id': self.sales_journal.id,
+            'account_id': self.account_account_receivable.id,
+            'date_invoice': fields.Date.today(),
+            'intrastat': True,
+            'invoice_line_ids': [(0, 0, {
+                'name': 'service',
+                'product_id': self.product01.id,
+                'account_id': self.account_account_receivable.id,
+                'quantity': 1,
+                'price_unit': 100,
+                'invoice_line_tax_ids': [(6, 0, {
+                    self.tax22.id
+                })]
+            })]
+        })
+
+        invoice.compute_taxes()
+        invoice.action_invoice_open()
+
+        # Compute intrastat lines
+        invoice.compute_intrastat_lines()
+        self.assertEqual(invoice.intrastat, True)
+        # Amount Control
+        total_intrastat_amount = sum(
+            line.amount_currency for line in invoice.intrastat_line_ids)
+        invoice_amount_currency = invoice.currency_id._convert(
+            invoice.amount_untaxed,
+            self.partner_not_euro.country_id.currency_id,
+            invoice.company_id,
+            invoice.date_invoice or fields.Date.today()
+        )
+        self.assertEqual(total_intrastat_amount, invoice_amount_currency)
 
     def test_invoice_from_sale(self):
         self.product01.invoice_policy = 'order'

--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
@@ -28,8 +28,7 @@ class IntrastatStatementPurchaseSection(models.AbstractModel):
 
         # Amounts
         amount_currency = 0
-        if invoice_id.currency_id != invoice_id.company_id.currency_id \
-           and invoice_id.currency_id != self.env.ref("base.EUR"):
+        if invoice_id.need_amount_currency():
             # Only for non-Euro countries
             dp_model = self.env['decimal.precision']
             amount_currency = statement_id.round_min_amount(
@@ -342,10 +341,8 @@ class IntrastatStatementPurchaseSection2(models.Model):
         # Ammontare delle operazioni in valuta
         # >> da valorizzare solo per operazione Paesi non Euro
         amount_currency = 0
-        if not (
-                self.invoice_id.company_id.currency_id.id ==
-                self.invoice_id.currency_id.id
-        ):
+        invoice = self.invoice_id
+        if invoice.need_amount_currency():
             amount_currency = self.amount_currency
         rcd += format_9(amount_currency, 13)
         # Codice della natura della transazione
@@ -561,10 +558,7 @@ class IntrastatStatementPurchaseSection4(models.Model):
         # Ammontare delle operazioni in valuta
         # >> da valorizzare solo per operazione Paesi non Euro
         amount_currency = 0
-        if not (
-                self.invoice_id.company_id.currency_id.id ==
-                self.invoice_id.currency_id.id
-        ):
+        if self.invoice_id.need_amount_currency():
             amount_currency = self.amount_currency
         rcd += format_9(amount_currency, 13)
         # Numero Fattura

--- a/l10n_it_intrastat_statement/models/intrastat_statement_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_section.py
@@ -57,7 +57,7 @@ class IntrastatStatementSection(models.AbstractModel):
 
         # Amounts
         amount_euro = statement_id.round_min_amount(
-            inv_intra_line.amount_euro,
+            inv_intra_line.invoice_id.amount_untaxed,
             statement_id.company_id or company_id,
             0)
 

--- a/l10n_it_intrastat_statement/views/intrastat.xml
+++ b/l10n_it_intrastat_statement/views/intrastat.xml
@@ -248,7 +248,8 @@
                             <field name="statistic_amount_euro"/>
                         </group>
                         <group>
-                            <field name="country_origin_id"/>
+                            <field name="invoice_id" invisible="1"/>
+                            <field name="country_origin_id" attrs="{'invisible':[('invoice_id', '!=', False)], 'required':[('invoice_id', '!=', False)]}"/>
                             <field name="delivery_code_id"/>
                             <field name="transport_code_id"/>
                             <field name="country_destination_id" required="1"/>
@@ -443,6 +444,7 @@
             <field name="arch" type="xml">
                 <form>
                     <field name="additional_units_required" invisible="1"/>
+                    <field name="invoice_id" invisible="1"/>
                     <group>
                         <group>
                             <field name="partner_id" string="Supplier" required="1"/>
@@ -465,8 +467,12 @@
                                 />
                             <field name="additional_units_uom"/>
                             <field name="amount_euro"/>
+                            <div class="alert alert-warning col-12" role="alert" attrs="{'invisible': [('invoice_id', '!=', False)]}" colspan="2">
+                                <p>Attention, the amount currency value is expressed in partner country currency</p>
+                                <p>Get invoice amount and convert it, with currency rate at invoice date</p>
+                            </div>
+                            <field name="amount_currency" attrs="{'invisible': [('invoice_id', '!=', False)]}"/>
                             <field name="statistic_amount_euro"/>
-                            <field name="amount_currency"/>
                         </group>
                         <group>
                             <field name="country_origin_id" required="1"/>
@@ -505,6 +511,7 @@
             <field name="model">account.intrastat.statement.purchase.section2</field>
             <field name="arch" type="xml">
                 <form>
+                    <field name="invoice_id" invisible="1"/>
                     <group>
                         <group>
                             <field name="partner_id" string="Supplier" required="1"/>
@@ -521,8 +528,12 @@
                             <field name="intrastat_code_id" string="Goods Code" required="1"/>
                             <field name="sign_variation" required="1"/>
                             <field name="amount_euro"/>
+                            <div class="alert alert-warning col-12" role="alert" attrs="{'invisible': [('invoice_id', '!=', False)]}" colspan="2">
+                                <p>Attention, the amount currency value is expressed in partner country currency</p>
+                                <p>Get invoice amount and convert it, with currency rate at invoice date</p>
+                            </div>
+                            <field name="amount_currency" attrs="{'invisible': [('invoice_id', '!=', False)]}"/>
                             <field name="statistic_amount_euro"/>
-                            <field name="amount_currency"/>
                         </group>
                         <group>
                             <field name="year_id" required="1"/>
@@ -557,6 +568,7 @@
             <field name="model">account.intrastat.statement.purchase.section3</field>
             <field name="arch" type="xml">
                 <form>
+                    <field name="invoice_id" invisible="1"/>
                     <group>
                         <group>
                             <field name="partner_id" string="Supplier"/>
@@ -571,7 +583,11 @@
                         <group>
                             <field name="intrastat_code_id" string="Service Code"/>
                             <field name="amount_euro"/>
-                            <field name="amount_currency"/>
+                            <div class="alert alert-warning col-12" role="alert" attrs="{'invisible': [('invoice_id', '!=', False)]}" colspan="2">
+                                <p>Attention, the amount currency value is expressed in partner country currency</p>
+                                <p>Get invoice amount and convert it, with currency rate at invoice date</p>
+                            </div>
+                            <field name="amount_currency" attrs="{'invisible': [('invoice_id', '!=', False)]}"/>
                         </group>
                         <group>
                             <field name="invoice_number"/>
@@ -609,6 +625,7 @@
             <field name="model">account.intrastat.statement.purchase.section4</field>
             <field name="arch" type="xml">
                 <form>
+                    <field name="invoice_id" invisible="1"/>
                     <group>
                         <group>
                             <field name="partner_id" string="Supplier" required="1"/>
@@ -627,7 +644,11 @@
                         <group>
                             <field name="intrastat_code_id" string="Service Code" required="1" />
                             <field name="amount_euro"/>
-                            <field name="amount_currency"/>
+                            <div class="alert alert-warning col-12" role="alert" attrs="{'invisible': [('invoice_id', '!=', False)]}" colspan="2">
+                                <p>Attention, the amount currency value is expressed in partner country currency</p>
+                                <p>Get invoice amount and convert it, with currency rate at invoice date</p>
+                            </div>
+                            <field name="amount_currency" attrs="{'invisible': [('invoice_id', '!=', False)]}"/>
                         </group>
                         <group>
                             <field name="invoice_number"/>


### PR DESCRIPTION
Current check condition to export amount currency is based on difference between invoice company currency and invoice currency. But if invoice partner has country that not use EUR, the amount currency need to be exported