### PR TITLE
[FIX] l10n_it_intrastat_statement: fix check to export amount currency

### DIFF
--- a/l10n_it_intrastat/models/account.py
+++ b/l10n_it_intrastat/models/account.py
@@ -1,9 +1,11 @@
 # Copyright 2019 Simone Rubino - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import datetime
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_is_zero
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, float_is_zero
 
 
 class AccountFiscalPosition(models.Model):
@@ -239,14 +241,37 @@ class AccountMoveLine(models.Model):
 
     def _prepare_intrastat_line_amount(self, res):
         self.ensure_one()
-        amount_currency = self.price_subtotal
-        company_currency = self.move_id.company_id.currency_id
-        invoice_currency = self.move_id.currency_id
-        amount_euro = invoice_currency._convert(
-            amount_currency,
-            company_currency,
-            self.move_id.company_id,
-            fields.Date.today(),
+        amount_euro = self.price_subtotal
+        invoice = self.move_id
+        invoice_currency = invoice.currency_id
+        invoice_partner = invoice.partner_id
+        invoice_partner_currency = invoice_partner.country_id.currency_id
+        partner_currency_rate = invoice.get_currency_rate_at_invoice_date()
+
+        if (
+            not (invoice_partner_currency.active or partner_currency_rate)
+            and invoice.need_amount_currency()
+        ):
+            raise UserError(
+                _(
+                    "Enable currency '{curr}' of '{country}', and set the "
+                    "conversion rate at date {inv_date}. Conversion rate can be "
+                    "found at:\n\n"
+                    "https://www.bancaditalia.it/compiti/operazioni-cambi/cambio"
+                    "\n\nChoosing the day from the list, if invoice date is on "
+                    "Saturday, Sunday or today and the rate isn't available, use "
+                    "the last value before invoice date."
+                ).format(
+                    curr=invoice_partner_currency.name,
+                    country=invoice_partner.country_id.name,
+                    inv_date=self._convert_to_user_date(invoice.invoice_date),
+                )
+            )
+        amount_currency = invoice_currency._convert(
+            amount_euro,
+            invoice_partner_currency,
+            invoice.company_id,
+            invoice.invoice_date or fields.Date.today(),
         )
         statistic_amount_euro = amount_euro
         res.update(
@@ -267,6 +292,12 @@ class AccountMoveLine(models.Model):
                 company_id.intrastat_purchase_transaction_nature_b_id
             )
             res.update({"transaction_nature_b_id": p_transaction_nature_b.id})
+
+    def _convert_to_user_date(self, invoice_date):
+        lang_obj = self.env["res.lang"].search(
+            [("code", "=", self.env.user.lang)], limit=1
+        )
+        return datetime.date.strftime(invoice_date, lang_obj.date_format)
 
 
 class AccountMove(models.Model):
@@ -329,7 +360,13 @@ class AccountMove(models.Model):
                 total_amount = sum(
                     line.amount_currency for line in invoice.intrastat_line_ids
                 )
-                subtotal = abs(invoice.amount_untaxed - excluded_amount)
+                invoice_partner_currency = invoice.partner_id.country_id.currency_id
+                subtotal = invoice.currency_id._convert(
+                    abs(invoice.amount_untaxed - excluded_amount),
+                    invoice_partner_currency,
+                    invoice.company_id,
+                    invoice.invoice_date or fields.Date.today(),
+                )
                 if not float_is_zero(
                     total_amount - subtotal, precision_digits=precision_digits
                 ):
@@ -430,6 +467,54 @@ class AccountMove(models.Model):
                 ].compute_statement_section(i_code_type, self.move_type)
                 i_line_by_code[i_code_id] = intra_line
         return i_line_by_code, lines_to_split
+
+    def get_currency_rate_at_invoice_date(self):
+        self.ensure_one()
+        if not self.invoice_date:
+            raise UserError(_("Set invoice date"))
+        # Because no change rate is published on weekend, if the weekday of
+        # invoice date is a Saturday or Sunday, need to get rate of Friday
+        # Weekday(Saturday == 5, Sunday == 6)
+        date_delta = self.get_date_delta(self.invoice_date)
+        inv_date_obj = self.invoice_date - date_delta
+        str_inv_date = inv_date_obj.strftime(DEFAULT_SERVER_DATE_FORMAT)
+        partner_currency = self.partner_id.country_id.currency_id
+        part_curr_rate = self.get_rate_currency(partner_currency, str_inv_date)
+        # If no rate found for invoice date, try to find nearest previous date
+        # value
+        if not part_curr_rate:
+            prev_day_date_obj = self.invoice_date - datetime.timedelta(days=1)
+            date_delta = self.get_date_delta(prev_day_date_obj)
+            str_inv_date = (prev_day_date_obj - date_delta).strftime(
+                DEFAULT_SERVER_DATE_FORMAT
+            )
+            part_curr_rate = self.get_rate_currency(partner_currency, str_inv_date)
+
+        return part_curr_rate
+
+    def get_date_delta(self, date_obj):
+        if date_obj.weekday() == 6:
+            date_delta = datetime.timedelta(days=2)
+        elif date_obj.weekday() == 5:
+            date_delta = datetime.timedelta(days=1)
+        else:
+            date_delta = datetime.timedelta(days=0)
+
+        return date_delta
+
+    def get_rate_currency(self, currency, date_str):
+        return currency.rate_ids.filtered(lambda c, i_dt=date_str: c.name == i_dt)
+
+    def need_amount_currency(self):
+        self.ensure_one()
+        inv_partner_currency = self.partner_id.country_id.currency_id
+        base_currency = self.env.ref("base.EUR")
+        return all(
+            [
+                self.move_type in ("in_invoice", "in_refund"),
+                inv_partner_currency != base_currency,
+            ]
+        )
 
 
 class AccountInvoiceIntrastat(models.Model):

--- a/l10n_it_intrastat/tests/test_intrastat.py
+++ b/l10n_it_intrastat/tests/test_intrastat.py
@@ -1,6 +1,10 @@
 # Copyright 2019 Simone Rubino - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import datetime
+
+from odoo import fields
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -15,6 +19,8 @@ class TestIntrastat(AccountTestInvoicingCommon):
         cls.product01 = cls.env.ref("product.product_product_10")
         cls.account_account_model = cls.env["account.account"]
         cls.fp_model = cls.env["account.fiscal.position"]
+        cls.partner_model = cls.env["res.partner"]
+        cls.res_currency_rate_model = cls.env["res.currency.rate"]
 
         cls.account_account_receivable = cls.account_account_model.create(
             {
@@ -36,6 +42,29 @@ class TestIntrastat(AccountTestInvoicingCommon):
 
         cls.partner01.property_account_receivable_id = cls.account_account_receivable
         cls.partner01.property_account_payable_id = cls.account_account_payable
+
+        partner_not_euro_country = cls.env["res.country"].search(
+            [("name", "ilike", "poland")], limit=1
+        )
+        partner_not_euro_country.currency_id.active = True
+        cls.partner_not_euro = cls.partner_model.create(
+            {
+                "name": "AMAZON EU s.a.r.l. (Poland)",
+                "vat": "PL5262907815",
+                "street": "Ul. Rondo Daszynskiego 1",
+                "city": "Warsav",
+                "zip": "00000",
+                "country_id": partner_not_euro_country.id,
+            }
+        )
+
+        cls.res_currency_rate_model.create(
+            {
+                "currency_id": partner_not_euro_country.currency_id.id,
+                "name": fields.Date.to_string(fields.Date.today()),
+                "rate": "1.0",
+            }
+        )
 
         # Demo tax is in another company than current user's company.
         # We can't change this tax's company because
@@ -82,3 +111,112 @@ class TestIntrastat(AccountTestInvoicingCommon):
         invoice.action_post()
         invoice.compute_intrastat_lines()
         self.assertEqual(invoice.intrastat, True)
+
+    def test_currency_not_active_raise_exception(self):
+        self.partner_not_euro.country_id.currency_id.active = False
+        with self.assertRaises(UserError):
+            invoice = self.invoice_model.create(
+                {
+                    "partner_id": self.partner_not_euro.id,
+                    "journal_id": self.sales_journal.id,
+                    "account_id": self.account_account_receivable.id,
+                    "date_invoice": fields.Date.today(),
+                    "intrastat": True,
+                    "invoice_line_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "name": "service",
+                                "product_id": self.product01.id,
+                                "account_id": self.account_account_receivable.id,
+                                "quantity": 1,
+                                "price_unit": 100,
+                                "invoice_line_tax_ids": [(6, 0, {self.tax22.id})],
+                            },
+                        )
+                    ],
+                }
+            )
+
+        invoice.compute_taxes()
+        invoice.action_invoice_open()
+
+        # Compute intrastat lines
+        invoice.compute_intrastat_lines()
+
+    def test_no_currency_rate_raise_exception(self):
+        currency_rate_date = fields.Date.today() - datetime.timedelta(days=1)
+        with self.assertRaises(UserError):
+            invoice = self.invoice_model.create(
+                {
+                    "partner_id": self.partner_not_euro.id,
+                    "journal_id": self.sales_journal.id,
+                    "account_id": self.account_account_receivable.id,
+                    "date_invoice": currency_rate_date,
+                    "intrastat": True,
+                    "invoice_line_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "name": "service",
+                                "product_id": self.product01.id,
+                                "account_id": self.account_account_receivable.id,
+                                "quantity": 1,
+                                "price_unit": 100,
+                                "invoice_line_tax_ids": [(6, 0, {self.tax22.id})],
+                            },
+                        )
+                    ],
+                }
+            )
+
+            invoice.compute_taxes()
+            invoice.action_invoice_open()
+
+            # Compute intrastat lines
+            invoice.compute_intrastat_lines()
+
+    def test_invoice_totals_partner_no_euro(self):
+        invoice = self.invoice_model.create(
+            {
+                "partner_id": self.partner_not_euro.id,
+                "journal_id": self.sales_journal.id,
+                "account_id": self.account_account_receivable.id,
+                "date_invoice": fields.Date.today(),
+                "intrastat": True,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "service",
+                            "product_id": self.product01.id,
+                            "account_id": self.account_account_receivable.id,
+                            "quantity": 1,
+                            "price_unit": 100,
+                            "invoice_line_tax_ids": [(6, 0, {self.tax22.id})],
+                        },
+                    )
+                ],
+            }
+        )
+
+        invoice.compute_taxes()
+        invoice.action_invoice_open()
+
+        # Compute intrastat lines
+        invoice.compute_intrastat_lines()
+        self.assertEqual(invoice.intrastat, True)
+        # Amount Control
+        total_intrastat_amount = sum(
+            line.amount_currency for line in invoice.intrastat_line_ids
+        )
+        invoice_amount_currency = invoice.currency_id._convert(
+            invoice.amount_untaxed,
+            self.partner_not_euro.country_id.currency_id,
+            invoice.company_id,
+            invoice.date_invoice or fields.Date.today(),
+        )
+        self.assertEqual(total_intrastat_amount, invoice_amount_currency)

--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section.py
@@ -21,10 +21,7 @@ class IntrastatStatementPurchaseSection(models.AbstractModel):
 
         # Amounts
         amount_currency = 0
-        if (
-            invoice_id.currency_id != invoice_id.company_id.currency_id
-            and invoice_id.currency_id != self.env.ref("base.EUR")
-        ):
+        if invoice_id.need_account_currency():
             # Only for non-Euro countries
             dp_model = self.env["decimal.precision"]
             amount_currency = statement_id.round_min_amount(

--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section2.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section2.py
@@ -126,9 +126,7 @@ class IntrastatStatementPurchaseSection2(models.Model):
         # Ammontare delle operazioni in valuta
         # >> da valorizzare solo per operazione Paesi non Euro
         amount_currency = 0
-        if not (
-            self.invoice_id.company_id.currency_id.id == self.invoice_id.currency_id.id
-        ):
+        if self.invoice_id and self.invoice_id.need_amount_currency():
             amount_currency = self.amount_currency
         rcd += format_9(amount_currency, 13)
         # Codice della natura della transazione

--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section4.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section4.py
@@ -113,9 +113,7 @@ class IntrastatStatementPurchaseSection4(models.Model):
         # Ammontare delle operazioni in valuta
         # >> da valorizzare solo per operazione Paesi non Euro
         amount_currency = 0
-        if not (
-            self.invoice_id.company_id.currency_id.id == self.invoice_id.currency_id.id
-        ):
+        if self.invoice_id and self.invoice_id.need_amount_currency():
             amount_currency = self.amount_currency
         rcd += format_9(amount_currency, 13)
         # Numero Fattura

--- a/l10n_it_intrastat_statement/models/intrastat_statement_section.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_section.py
@@ -50,7 +50,9 @@ class IntrastatStatementSection(models.AbstractModel):
 
         # Amounts
         amount_euro = statement_id.round_min_amount(
-            inv_intra_line.amount_euro, statement_id.company_id or company_id, 0
+            inv_intra_line.invoice_id.amount_untaxed,
+            statement_id.company_id or company_id,
+            0,
         )
 
         return {

--- a/l10n_it_intrastat_statement/tests/test_intrastat_statement.py
+++ b/l10n_it_intrastat_statement/tests/test_intrastat_statement.py
@@ -511,6 +511,7 @@ class TestIntrastatStatement(TransactionCase):
         move_form.invoice_date = invoice_date or fields.Date.from_string("2019-01-01")
         move_form.partner_id = partner or self.partner_a
         move_form.intrastat = True
+        move_form.invoice_date = fields.Date.today()
 
         with move_form.invoice_line_ids.new() as line_form:
             line_form.product_id = product

--- a/l10n_it_intrastat_statement/views/intrastat.xml
+++ b/l10n_it_intrastat_statement/views/intrastat.xml
@@ -337,7 +337,11 @@
                             <field name="statistic_amount_euro" />
                         </group>
                         <group>
-                            <field name="country_origin_id" />
+                            <field name="invoice_id" invisible="1" />
+                            <field
+                            name="country_origin_id"
+                            attrs="{'invisible':[('invoice_id', '!=', False)], 'required':[('invoice_id', '!=', False)]}"
+                        />
                             <field name="delivery_code_id" />
                             <field name="transport_code_id" />
                             <field name="country_destination_id" required="1" />
@@ -575,6 +579,7 @@
             <field name="arch" type="xml">
                 <form>
                     <field name="additional_units_required" invisible="1" />
+                    <field name="invoice_id" invisible="1" />
                     <group>
                         <group>
                             <field name="partner_id" string="Supplier" required="1" />
@@ -610,8 +615,22 @@
                         />
                             <field name="additional_units_uom" />
                             <field name="amount_euro" />
+                            <div
+                            class="alert alert-warning col-12"
+                            role="alert"
+                            attrs="{'invisible': [('invoice_id', '!=', False)]}"
+                            colspan="2"
+                        >
+                                <p
+                            >Attention, the amount currency value is expressed in partner country currency</p>
+                                <p
+                            >Get invoice amount and convert it, with currency rate at invoice date</p>
+                            </div>
+                            <field
+                            name="amount_currency"
+                            attrs="{'invisible': [('invoice_id', '!=', False)]}"
+                        />
                             <field name="statistic_amount_euro" />
-                            <field name="amount_currency" />
                         </group>
                         <group>
                             <field name="country_origin_id" required="1" />
@@ -650,6 +669,7 @@
             <field name="model">account.intrastat.statement.purchase.section2</field>
             <field name="arch" type="xml">
                 <form>
+                    <field name="invoice_id" invisible="1" />
                     <group>
                         <group>
                             <field name="partner_id" string="Supplier" required="1" />
@@ -678,8 +698,22 @@
                         />
                             <field name="sign_variation" required="1" />
                             <field name="amount_euro" />
+                            <div
+                            class="alert alert-warning col-12"
+                            role="alert"
+                            attrs="{'invisible': [('invoice_id', '!=', False)]}"
+                            colspan="2"
+                        >
+                                <p
+                            >Attention, the amount currency value is expressed in partner country currency</p>
+                                <p
+                            >Get invoice amount and convert it, with currency rate at invoice date</p>
+                            </div>
+                            <field
+                            name="amount_currency"
+                            attrs="{'invisible': [('invoice_id', '!=', False)]}"
+                        />
                             <field name="statistic_amount_euro" />
-                            <field name="amount_currency" />
                         </group>
                         <group>
                             <field name="year_id" required="1" />
@@ -714,6 +748,7 @@
             <field name="model">account.intrastat.statement.purchase.section3</field>
             <field name="arch" type="xml">
                 <form>
+                    <field name="invoice_id" invisible="1" />
                     <group>
                         <group>
                             <field name="partner_id" string="Supplier" />
@@ -728,7 +763,21 @@
                         <group>
                             <field name="intrastat_code_id" string="Service Code" />
                             <field name="amount_euro" />
-                            <field name="amount_currency" />
+                            <div
+                            class="alert alert-warning col-12"
+                            role="alert"
+                            attrs="{'invisible': [('invoice_id', '!=', False)]}"
+                            colspan="2"
+                        >
+                                <p
+                            >Attention, the amount currency value is expressed in partner country currency</p>
+                                <p
+                            >Get invoice amount and convert it, with currency rate at invoice date</p>
+                            </div>
+                            <field
+                            name="amount_currency"
+                            attrs="{'invisible': [('invoice_id', '!=', False)]}"
+                        />
                         </group>
                         <group>
                             <field name="invoice_number" />
@@ -766,6 +815,7 @@
             <field name="model">account.intrastat.statement.purchase.section4</field>
             <field name="arch" type="xml">
                 <form>
+                    <field name="invoice_id" invisible="1" />
                     <group>
                         <group>
                             <field name="partner_id" string="Supplier" required="1" />
@@ -796,7 +846,22 @@
                             required="1"
                         />
                             <field name="amount_euro" />
-                            <field name="amount_currency" />
+                            <div
+                            class="alert alert-warning col-12"
+                            role="alert"
+                            attrs="{'invisible': [('invoice_id', '!=', False)]}"
+                            colspan="2"
+                        >
+                                <p
+                            >Attention, the amount currency value is expressed in partner country currency</p>
+                                <p
+                            >Get invoice amount and convert it, with currency rate at invoice date</p>
+                            </div>
+                            <field
+                            name="amount_currency"
+                            attrs="{'invisible': [('invoice_id', '!=', False)]}"
+                        />
+
                         </group>
                         <group>
                             <field name="invoice_number" />


### PR DESCRIPTION
Current check condition to export amount currency is based on difference between invoice company currency and invoice currency. But if invoice partner has country that not use EUR, the amount currency need to be exported