### PR TITLE
[16.0] [IMP] l10n_it_fatturapa_out: EUR values from journal

### DIFF
--- a/l10n_it_fatturapa_out/data/invoice_it_template.xml
+++ b/l10n_it_fatturapa_out/data/invoice_it_template.xml
@@ -170,7 +170,7 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
                 t-call="l10n_it_fatturapa_out.account_invoice_line_it_sconto_maggiorazione"
             />
                 <PrezzoTotale
-                t-out="format_monetary(fpa_to_eur(line.price_subtotal, record), euro)"
+                t-out="format_monetary(fpa_to_eur(line.price_subtotal, line=line, field='credit'), euro)"
             />
                 <AliquotaIVA
                 t-if="not line_is_section_note"
@@ -534,7 +534,7 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
                     />
                         <ImportoTotaleDocumento
                         t-if="not record.company_id.xml_divisa_value == 'keep_orig'"
-                        t-out="format_numbers_two(fpa_to_eur(get_importo_totale(record), record))"
+                        t-out="format_numbers_two(fpa_to_eur(get_importo_totale(record), invoice=record))"
                     />
                         <!--                        <Arrotondamento t-out=""/>-->
                         <t t-foreach="get_causale(record)" t-as="causale">
@@ -580,10 +580,10 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
                               <!--                <SpeseAccessorie t-out=""/>-->
                               <!--                <Arrotondamento t-out=""/>-->
                               <ImponibileImporto
-                            t-out="format_monetary(fpa_to_eur(tax_data['ImponibileImporto'], record), euro)"
+                            t-out="format_monetary(fpa_to_eur(tax_data['ImponibileImporto'], invoice=record), euro)"
                         />
                               <Imposta
-                            t-out="format_monetary(fpa_to_eur(tax_data['Imposta'], record), euro)"
+                            t-out="format_monetary(fpa_to_eur(tax_data['Imposta'], invoice=record), euro)"
                         />
                                 <EsigibilitaIVA
                             t-if="tax_data.get('EsigibilitaIVA', False)"
@@ -628,7 +628,7 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
                         />
                             <ImportoPagamento
                             t-if="not record.company_id.xml_divisa_value == 'keep_orig'"
-                            t-out="format_numbers_two(fpa_to_eur(payment.amount_currency or payment.debit, record))"
+                            t-out="format_numbers_two(fpa_to_eur(payment.amount_currency or payment.debit, invoice=record))"
                         />
 
                             <!--                            <CodUfficioPostale t-out=""/>-->

--- a/l10n_it_fatturapa_out/data/invoice_it_template.xml
+++ b/l10n_it_fatturapa_out/data/invoice_it_template.xml
@@ -219,27 +219,6 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
             </DettaglioLinee>
         </template>
 
-        <template id="account_invoice_line_it_dati_riepilogo">
-            <t t-set="tax" t-value="tax_line.tax_line_id" />
-            <DatiRiepilogo>
-                <!--2.2.2-->
-                <AliquotaIVA t-out="format_numbers(tax.amount)" />
-                <Natura t-if="tax.kind_id.code" t-out="tax.kind_id.code" />
-                <!--                <SpeseAccessorie t-out=""/>-->
-                <!--                <Arrotondamento t-out=""/>-->
-                <ImponibileImporto
-                t-out="format_monetary(fpa_to_eur(tax_line.tax_base_amount, record), euro)"
-            />
-                <Imposta
-                t-out="format_monetary(fpa_to_eur(tax_line.price_total, record), euro)"
-            />
-                <EsigibilitaIVA t-if="tax.payability" t-out="tax.payability" />
-                <RiferimentoNormativo
-                t-if="tax.law_reference"
-                t-out="encode_for_export(tax.law_reference, 100)"
-            />
-            </DatiRiepilogo>
-        </template>
         <template id="account_invoice_it_FatturaPA_sede">
             <t t-set="indirizzo"><t
                 t-if="partner_id.street2"

--- a/l10n_it_fatturapa_out/wizard/efattura.py
+++ b/l10n_it_fatturapa_out/wizard/efattura.py
@@ -78,7 +78,7 @@ class EFatturaOut:
 
             # force EUR unless we want the original currency
             if not original_currency:
-                res = fpa_to_eur(res, line.move_id)
+                res = fpa_to_eur(res, line=line)
 
             # XXX arrotondamento?
             res = "{prezzo:.{precision}f}".format(
@@ -205,11 +205,17 @@ class EFatturaOut:
             wiz = self.env["wizard.export.fatturapa"]
             return wiz.getPayments(invoice)
 
-        def fpa_to_eur(amount, invoice):
+        def fpa_to_eur(amount, invoice=None, line=None, field=None):
+            if not invoice and not line:
+                return amount
+            if line and line.move_id:
+                invoice = line.move_id
             currency = invoice.currency_id
             euro = self.env.ref("base.EUR")
             if currency == euro:
                 return amount
+            if line and field and field in line._fields is not None:
+                return line[field]
             return currency._convert(
                 amount, euro, invoice.company_id, invoice.date, False
             )


### PR DESCRIPTION
Su suggerimento di @As400it , invece di convertire da valuta estera a EUR si va a prendere il valore nelle righe contabili.


Visto a posteriori il codice, non saprei dire quanto ne vale la pena, visto che la maggior parte dei valori convertiti non viene da righe contabili direttamente. Il riepilogo tasse viene ricalcolato, l'importo totale lo stesso, rimangono solo i subtotali di riga.

Vedi https://github.com/OCA/l10n-italy/issues/3295