### PR TITLE
[14.0] [IMP] l10n_it_delivery_note_base: creazione dinamica dei tipi di DN e delle loro sequenze

### DIFF
--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -156,6 +156,7 @@ class StockDeliveryNote(models.Model):
         readonly=True,
         required=True,
         index=True,
+        check_company=True,
     )
 
     sequence_id = fields.Many2one("ir.sequence", readonly=True, copy=False)

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -328,12 +328,18 @@ class StockPicking(models.Model):
     def _create_delivery_note(self):
         partners = self._get_partners()
         type_id = self.env["stock.delivery.note.type"].search(
-            [("code", "=", self.picking_type_code)], limit=1
+            [
+                ("code", "=", self.picking_type_code),
+                ("company_id", "=", self.company_id.id),
+            ],
+            limit=1,
         )
         return self.env["stock.delivery.note"].create(
             {
                 "partner_sender_id": partners[0].id,
-                "partner_id": self.sale_id.partner_id.id,
+                "partner_id": self.sale_id.partner_id.id
+                if self.sale_id
+                else partners[0].id,
                 "partner_shipping_id": partners[1].id,
                 "type_id": type_id.id,
                 "date": self.date_done,

--- a/l10n_it_delivery_note/tests/delivery_note_common.py
+++ b/l10n_it_delivery_note/tests/delivery_note_common.py
@@ -1,5 +1,7 @@
 from odoo.tests.common import TransactionCase
 
+from odoo.addons.mail.tests.common import mail_new_test_user
+
 DOWNPAYMENT_METHODS = ["fixed", "percentage"]
 
 
@@ -70,6 +72,16 @@ class StockDeliveryNoteCommon(TransactionCase):
                     )
                 ]
             }
+        )
+
+        self.account_manager = mail_new_test_user(
+            self.env,
+            name="Adviser",
+            login="fm",
+            email="accountmanager@yourcompany.com",
+            groups="account.group_account_manager,base.group_partner_manager,"
+            "base.group_system,sales_team.group_sale_manager,stock.group_stock_manager",
+            company_ids=[(6, 0, [c.id for c in self.env["res.company"].search([])])],
         )
 
         self.sender = self.env.ref("base.main_partner")

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note.py
@@ -63,15 +63,13 @@ class StockDeliveryNote(StockDeliveryNoteCommon):
         #     Picking ┐
         #             └ DdT
         #
-
         user = new_test_user(
             self.env,
             login="test",
             groups="stock.group_stock_manager,"
             "l10n_it_delivery_note.use_advanced_delivery_notes",
         )
-        # change user in order to automatically create delivery note
-        # when picking is validated
+        # change user in order to activate DN advanced settings
         self.env.user = user
 
         picking = self.env["stock.picking"].create(

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note_invoicing.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note_invoicing.py
@@ -542,6 +542,11 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
         #     SO ┘
         #
 
+        # Activate advanced setting to allow more picking in one DN
+        self.env["ir.config_parameter"].sudo().set_param(
+            "l10n_it_delivery_note.group_use_advanced_delivery_notes", True
+        )
+
         first_sales_order = self.create_sales_order(
             [
                 self.desk_combination_line,

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note_sequence.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note_sequence.py
@@ -1,16 +1,146 @@
 # Copyright 2022 Sergio Corato
+# Copyright 2023 Nextev Srl
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from datetime import date, datetime, timedelta
 
-from odoo.tests import Form
+from odoo import _
+from odoo.tests.common import users
 from odoo.tools.date_utils import relativedelta
 
 from .delivery_note_common import StockDeliveryNoteCommon
 
 
 class StockDeliveryNoteSequence(StockDeliveryNoteCommon):
+    def test_new_company_dn_type_creation(self):
+        """
+        This test is for checking dn_types and sequence creation after
+        creating a new company
+        """
+        company = self.env["res.company"].create(
+            {
+                "name": "New company",
+            }
+        )
+        dn_types = self.env["stock.delivery.note.type"].search(
+            [("company_id", "=", company.id)]
+        )
+        self.assertTrue(
+            dn_types.filtered(
+                lambda d: d.name == _("Incoming")
+                and d.sequence_id
+                == self.env["ir.sequence"].search(
+                    [
+                        ("code", "=", f"stock.delivery.note.din.c{company.id}"),
+                        ("company_id", "=", company.id),
+                    ]
+                )
+            )
+        )
+        self.assertTrue(
+            dn_types.filtered(
+                lambda d: d.name == _("Outgoing")
+                and d.sequence_id
+                == self.env["ir.sequence"].search(
+                    [
+                        ("code", "=", f"stock.delivery.note.ddt.c{company.id}"),
+                        ("company_id", "=", company.id),
+                    ]
+                )
+            )
+        )
+        self.assertTrue(
+            dn_types.filtered(
+                lambda d: d.name == _("Outgoing (with prices)")
+                and d.sequence_id
+                == self.env["ir.sequence"].search(
+                    [
+                        ("code", "=", f"stock.delivery.note.ddt.c{company.id}"),
+                        ("company_id", "=", company.id),
+                    ]
+                )
+            )
+        )
+        self.assertTrue(
+            dn_types.filtered(
+                lambda d: d.name == _("Internal transfer")
+                and d.sequence_id
+                == self.env["ir.sequence"].search(
+                    [
+                        ("code", "=", f"stock.delivery.note.int.c{company.id}"),
+                        ("company_id", "=", company.id),
+                    ]
+                )
+            )
+        )
+
+    def test_initial_dn_type_creation(self):
+        """
+        This test is for checking dn_types and sequence creation by
+        l10n_it_delivery_note_base post_init_hook
+        """
+        companies = self.env["res.company"].search([])
+        for company in companies:
+            dn_types = self.env["stock.delivery.note.type"].search(
+                [("company_id", "=", company.id)]
+            )
+            self.assertTrue(
+                dn_types.filtered(
+                    lambda d: d.name == _("Incoming")
+                    and d.sequence_id
+                    == self.env["ir.sequence"].search(
+                        [
+                            ("code", "=", f"stock.delivery.note.din.c{company.id}"),
+                            ("company_id", "=", company.id),
+                        ]
+                    )
+                )
+            )
+            self.assertTrue(
+                dn_types.filtered(
+                    lambda d: d.name == _("Outgoing")
+                    and d.sequence_id
+                    == self.env["ir.sequence"].search(
+                        [
+                            ("code", "=", f"stock.delivery.note.ddt.c{company.id}"),
+                            ("company_id", "=", company.id),
+                        ]
+                    )
+                )
+            )
+            self.assertTrue(
+                dn_types.filtered(
+                    lambda d: d.name == _("Outgoing (with prices)")
+                    and d.sequence_id
+                    == self.env["ir.sequence"].search(
+                        [
+                            ("code", "=", f"stock.delivery.note.ddt.c{company.id}"),
+                            ("company_id", "=", company.id),
+                        ]
+                    )
+                )
+            )
+            self.assertTrue(
+                dn_types.filtered(
+                    lambda d: d.name == _("Internal transfer")
+                    and d.sequence_id
+                    == self.env["ir.sequence"].search(
+                        [
+                            ("code", "=", f"stock.delivery.note.int.c{company.id}"),
+                            ("company_id", "=", company.id),
+                        ]
+                    )
+                )
+            )
+
+    @users("fm")
     def test_complete_invoicing_sequence(self):
-        sequence = self.env.ref("l10n_it_delivery_note_base.delivery_note_sequence_ddt")
+        company_id = self.env.company.id
+        sequence = self.env["ir.sequence"].search(
+            [
+                ("code", "=", f"stock.delivery.note.ddt.c{company_id}"),
+                ("company_id", "=", company_id),
+            ]
+        )
         current_year = datetime.today().year
         old_year = (datetime.today() - relativedelta(years=1)).year
         for sequence_year in [current_year, old_year]:
@@ -52,18 +182,10 @@ class StockDeliveryNoteSequence(StockDeliveryNoteCommon):
         result = picking.button_validate()
         self.assertTrue(result)
 
-        dn_form = Form(
-            self.env["stock.delivery.note.create.wizard"].with_context(
-                active_ids=picking.ids,
-            )
-        )
-        wizard = dn_form.save()
-        wizard.confirm()
         delivery_note = picking.delivery_note_id
         delivery_note.transport_datetime = datetime.now() + timedelta(days=1, hours=3)
         delivery_note.date = date.today().replace(year=old_year)
         delivery_note.action_confirm()
-
         self.assertEqual(delivery_note.type_id.sequence_id, sequence)
         self.assertEqual(
             delivery_note.name, sequence.prefix + "%%0%sd" % sequence.padding % 50

--- a/l10n_it_delivery_note_base/__init__.py
+++ b/l10n_it_delivery_note_base/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/l10n_it_delivery_note_base/__manifest__.py
+++ b/l10n_it_delivery_note_base/__manifest__.py
@@ -31,4 +31,5 @@
         "views/stock_picking_transport_method.xml",
         "views/stock_picking_transport_reason.xml",
     ],
+    "post_init_hook": "post_init_hook",
 }

--- a/l10n_it_delivery_note_base/data/delivery_note_data.xml
+++ b/l10n_it_delivery_note_base/data/delivery_note_data.xml
@@ -5,55 +5,6 @@
   -->
 <odoo noupdate="1">
 
-    <!-- Delivery note sequences -->
-    <record id="delivery_note_sequence_ddt_incoming" model="ir.sequence">
-        <field name="name">Incoming DdT sequence</field>
-        <field name="code">stock.delivery.note.din</field>
-        <field name="prefix">DIN/</field>
-        <field name="implementation">no_gap</field>
-        <field name="padding" eval="5" />
-    </record>
-    <record id="delivery_note_sequence_ddt" model="ir.sequence">
-        <field name="name">Outgoing DdT sequence</field>
-        <field name="code">stock.delivery.note.ddt</field>
-        <field name="prefix">DDT/</field>
-        <field name="implementation">no_gap</field>
-        <field name="padding" eval="5" />
-    </record>
-    <record id="delivery_note_sequence_ddt_internal" model="ir.sequence">
-        <field name="name">Internal DdT sequence</field>
-        <field name="code">stock.delivery.note.int</field>
-        <field name="prefix">INT/</field>
-        <field name="implementation">no_gap</field>
-        <field name="padding" eval="5" />
-    </record>
-
-    <!-- Delivery note types -->
-    <record id="delivery_note_type_incoming_ddt" model="stock.delivery.note.type">
-        <field name="name">Incoming</field>
-        <field name="sequence_id" ref="delivery_note_sequence_ddt_incoming" />
-        <field name="print_prices" eval="False" />
-        <field name="code">incoming</field>
-    </record>
-    <record id="delivery_note_type_ddt" model="stock.delivery.note.type">
-        <field name="name">Outgoing</field>
-        <field name="sequence_id" ref="delivery_note_sequence_ddt" />
-        <field name="print_prices" eval="False" />
-        <field name="code">outgoing</field>
-    </record>
-    <record id="delivery_note_type_priced_ddt" model="stock.delivery.note.type">
-        <field name="name">Outgoing (with prices)</field>
-        <field name="sequence_id" ref="delivery_note_sequence_ddt" />
-        <field name="print_prices" eval="True" />
-        <field name="code">outgoing</field>
-    </record>
-    <record id="delivery_note_type_internal_ddt" model="stock.delivery.note.type">
-        <field name="name">Internal transfer</field>
-        <field name="sequence_id" ref="delivery_note_sequence_ddt_internal" />
-        <field name="print_prices" eval="False" />
-        <field name="code">internal</field>
-    </record>
-
     <!-- Conditions of transport -->
     <record id="transport_condition_PF" model="stock.picking.transport.condition">
         <field name="name">Carriage paid</field>

--- a/l10n_it_delivery_note_base/hooks.py
+++ b/l10n_it_delivery_note_base/hooks.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Nextev Srl
+from odoo import SUPERUSER_ID, api
+
+
+def post_init_hook(cr, sequence):
+    """
+    Create DN types and their sequences after installing the module
+    if they're not already exist
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    companies = env["res.company"].search([])
+    for company in companies:
+        env["stock.delivery.note.type"].create_dn_types(company)

--- a/l10n_it_delivery_note_base/models/__init__.py
+++ b/l10n_it_delivery_note_base/models/__init__.py
@@ -1,3 +1,4 @@
+from . import res_company
 from . import stock_delivery_note_type
 from . import stock_picking_goods_appearance
 from . import stock_picking_transport_condition

--- a/l10n_it_delivery_note_base/models/res_company.py
+++ b/l10n_it_delivery_note_base/models/res_company.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2023, Nextev Srl
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    @api.model_create_multi
+    def create(self, vals):
+        """
+        Create DN types and their sequences after companies creation
+        if they're not already existing
+        """
+        res = super().create(vals)
+        for company in res:
+            self.env["stock.delivery.note.type"].sudo().create_dn_types(company)
+        return res

--- a/l10n_it_delivery_note_base/readme/CONTRIBUTORS.rst
+++ b/l10n_it_delivery_note_base/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
 * Gianmarco Conte <gconte@dinamicheaziendali.it>
 * Letizia Freda <letizia.freda@netfarm.it>
 * Andrea Piovesana <andrea.m.piovesana@gmail.com>
+* Nextev Srl <odoo@nextev.it>


### PR DESCRIPTION
Attualmente i tipi di delivery note e le loro sequenze sono memorizzati nei data.xml senza impostare l'azienda, quindi vengono associati solo all'azienda attiva al momento dell'installazione.
https://github.com/OCA/l10n-italy/issues/3257

Questa PR rimuove questi dati da XML e sposta la loro creazione lato Python all'installazione del modulo ed alla creazione di nuove aziende permettendo quindi di aggiungere i tipi di DN e le loro sequenze in maniera dinamica se non sono già presenti nel sistema.

Ho dovuto modificare anche il test `l10n_it_delivery_note/tests/test_stock_delivery_note_sequence.py` perchè ora le sequenze vengono create dinamicamente e non hanno più un external ID.
https://github.com/OCA/l10n-italy/pull/3308/commits/b4c6197756a839cbeba370e9a24460bdc8a5e52d