### PR TITLE
[FIX][12.0] negative invoice is not validatable

### DIFF
--- a/l10n_it_intrastat/models/account.py
+++ b/l10n_it_intrastat/models/account.py
@@ -350,7 +350,8 @@ class AccountInvoice(models.Model):
 
                 total_amount = sum(
                     l.amount_currency for l in invoice.intrastat_line_ids)
-                subtotal = abs(invoice.amount_untaxed - excluded_amount)
+                subtotal = invoice.amount_untaxed - excluded_amount * (
+                    1 if invoice.amount_untaxed > 0 else - 1)
                 if not float_is_zero(
                     total_amount - subtotal,
                     precision_digits=precision_digits


### PR DESCRIPTION
Descrizione del problema o della funzionalità: una fattura negativa non è validabile se contiene dati intrastat. [Una fattura negativa viene comunque vietata dal core di Odoo, quindi questa PR non ha effetti pratici]

Comportamento attuale prima di questa PR:

Comportamento desiderato dopo questa PR:




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing