### PR TITLE
[16.0][FIX] l10n_it_fatturapa_in: fix date in fattura

### DIFF
--- a/l10n_it_fatturapa_in/tests/data/IT05979361218_017.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT05979361218_017.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:FatturaElettronica versione="FPA12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>05979361218</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>001</ProgressivoInvio>
+            <FormatoTrasmissione>FPA12</FormatoTrasmissione>
+            <CodiceDestinatario>UFPQ1O</CodiceDestinatario>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>05979361218         </IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>SOCIETA' ALPHA BETA SRL</Denominazione>
+                </Anagrafica>
+                <AlboProfessionale>Albo di test</AlboProfessionale>
+                <ProvinciaAlbo>TO</ProvinciaAlbo>
+                <NumeroIscrizioneAlbo>TO1258B</NumeroIscrizioneAlbo>
+                <DataIscrizioneAlbo>2010-01-16</DataIscrizioneAlbo>
+                <RegimeFiscale>RF02</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIALE ROMA 543B</Indirizzo>
+                <CAP>07100</CAP>
+                <Comune>SASSARI</Comune>
+                <Provincia>SS</Provincia>
+                <Nazione></Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <CodiceFiscale>80213330584</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>AMMINISTRAZIONE BETA</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIA TORINO 38-B</Indirizzo>
+                <CAP>00145</CAP>
+                <Comune>ROMA</Comune>
+                <Provincia>RM</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2015-02-16</Data>
+                <Numero>FT/2015/0006</Numero>
+                <DatiCassaPrevidenziale>
+                    <TipoCassa>TC22</TipoCassa>
+                    <AlCassa>0.00</AlCassa>
+                    <ImportoContributoCassa>3.00</ImportoContributoCassa>
+                    <ImponibileCassa>3.00</ImponibileCassa>
+                    <AliquotaIVA>0.00</AliquotaIVA>
+                    <Natura>N4</Natura>
+                </DatiCassaPrevidenziale>
+                <Causale>Rif ordine MAPA: --- Nr. Identificativo Ordine 1234567</Causale>
+            </DatiGeneraliDocumento>
+            <DatiTrasporto>
+                <PesoLordo>0.00</PesoLordo>
+                <PesoNetto>0.00</PesoNetto>
+            </DatiTrasporto>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>Prodotto di test al giorno</Descrizione>
+                <Quantita>15.00</Quantita>
+                <UnitaMisura>Giorno(i)</UnitaMisura>
+                <PrezzoUnitario>3.60</PrezzoUnitario>
+                <PrezzoTotale>54.00</PrezzoTotale>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N4</Natura>
+                <AltriDatiGestionali>
+                    <TipoDato>Vostro RIF</TipoDato>
+                    <RiferimentoTesto>Riferimento</RiferimentoTesto>
+                    <RiferimentoNumero>3.00</RiferimentoNumero>
+                </AltriDatiGestionali>
+                <AltriDatiGestionali>
+                    <TipoDato>Vostro RIF</TipoDato>
+                    <RiferimentoTesto>Riferimento2</RiferimentoTesto>
+                </AltriDatiGestionali>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N4</Natura>
+                <ImponibileImporto>57.00</ImponibileImporto>
+                <Imposta>0.00</Imposta>
+                <RiferimentoNormativo>Operazioni senza addebito imposta regime contribuenti minimi art.27 c.1-2 DL.98/11</RiferimentoNormativo>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP01</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2015-03-18</DataScadenzaPagamento>
+                <ImportoPagamento>27.00</ImportoPagamento>
+            </DettaglioPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2015-04-17</DataScadenzaPagamento>
+                <ImportoPagamento>27.00</ImportoPagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/fatturapa_common.py
+++ b/l10n_it_fatturapa_in/tests/fatturapa_common.py
@@ -3,6 +3,7 @@ import operator
 import tempfile
 from functools import reduce
 
+from odoo import fields
 from odoo.modules import get_module_resource
 from odoo.tests import Form
 from odoo.tests.common import SingleTransactionCase
@@ -291,6 +292,7 @@ class FatturapaCommon(SingleTransactionCase):
             module_name = "l10n_it_fatturapa_in"
 
         attach = self.create_attachment(name, file_name, module_name=module_name)
+        attach.e_invoice_received_date = fields.Datetime.now()
         attach_id = attach.id
         if mode == "import":
             wizard_form = Form(

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from psycopg2 import IntegrityError
 
+from odoo import fields
 from odoo.exceptions import UserError, ValidationError
 from odoo.modules import get_module_resource
 from odoo.tests import Form
@@ -937,6 +938,13 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
             ),
         )
         self.wizard_model.reset_inconsistencies()
+
+    def test_54_xml_in_invoice_registration_date_rec_date(self):
+        self.env.company.in_invoice_registration_date = "rec_date"
+        res = self.run_wizard("test55", "IT05979361218_017.xml")
+        invoice_id = res.get("domain")[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertEqual(invoice.date, fields.Date.today())
 
     def test_01_xml_link(self):
         """

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1197,6 +1197,7 @@ class WizardImportFatturapa(models.TransientModel):
 
         invoice_data = {
             "e_invoice_received_date": e_invoice_received_date,
+            "invoice_date": e_invoice_date,
             "date": e_invoice_received_date
             if company.in_invoice_registration_date == "rec_date"
             else e_invoice_date,


### PR DESCRIPTION
Quando importo fatture fornitori la data contabile in fattura non è corretta

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing