### PR TITLE
[16.0][FIX]: l10n_it_fatturapa_out: create attachment with res_id not null 

### DIFF
--- a/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
+++ b/l10n_it_fatturapa_out/wizard/wizard_export_fatturapa.py
@@ -52,6 +52,8 @@ class WizardExportFatturapa(models.TransientModel):
 
         attach_str = fatturapa.to_xml(self.env)
         attach_vals = {
+            "res_model": "fatturapa.attachment.out",
+            "res_id": -1,
             "name": "{}_{}.xml".format(vat, number),
             "datas": base64.encodebytes(attach_str),
         }


### PR DESCRIPTION
Fixes: https://github.com/OCA/l10n-italy/issues/3336
