### PR TITLE
[16.0][FIX] l10n_it_fatturapa_out: fix su _validate_max_invoice_in_xml con record multipli

### DIFF
--- a/l10n_it_fatturapa_out/models/partner.py
+++ b/l10n_it_fatturapa_out/models/partner.py
@@ -16,7 +16,11 @@ class ResPartner(models.Model):
 
     @api.constrains("max_invoice_in_xml")
     def _validate_max_invoice_in_xml(self):
-        if self.max_invoice_in_xml < 0:
-            raise ValidationError(
-                _("The max number of invoice to group can't be negative")
-            )
+        for partner in self:
+            if partner.max_invoice_in_xml < 0:
+                raise ValidationError(
+                    _(
+                        "The max number of invoice to group can't be negative for partner %s",
+                        partner.name,
+                    )
+                )


### PR DESCRIPTION
Buonasera,

in fase di creazione dei contatti azienda se vengono aggiunti più di un contatto contemporaneamente allora il codice va in errore con una 

`ValueError: Expected singleton: res.partner`

sulla _validate_max_invoice_in_xml_.

Aggiunto ciclo per  effettuare la verifica su tutte le linee da validare.