### PR TITLE
[14.0] [IMP] Impedire la selezione di pop3 nel fetchmail delle PEC

### DIFF
--- a/l10n_it_fatturapa_pec/tests/e_invoice_common.py
+++ b/l10n_it_fatturapa_pec/tests/e_invoice_common.py
@@ -100,10 +100,10 @@ class EInvoiceCommon(FatturaPACommon):
         return self.env["fetchmail.server"].create(
             {
                 "name": "Test PEC server",
-                "server_type": "pop",
+                "server_type": "imap",
                 "is_fatturapa_pec": True,
                 "server": "dummy",
-                "port": 110,
+                "port": 143,
                 "user": "dummy",
                 "password": "secret",
                 "state": "done",

--- a/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
+++ b/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py
@@ -134,8 +134,8 @@ class TestEInvoiceResponse(EInvoiceCommon):
         error_mails_nbr = outbound_mail_model.search_count(error_mail_domain)
         self.assertFalse(error_mails_nbr)
 
-        with mock.patch("odoo.addons.fetchmail.models.fetchmail.POP3") as mock_pop3:
-            instance = mock_pop3.return_value
+        with mock.patch("odoo.addons.fetchmail.models.fetchmail.IMAP4") as mock_imap4:
+            instance = mock_imap4.return_value
             instance.stat.return_value = (1, 1)
             instance.retr.return_value = ("", [incoming_mail], "")
 


### PR DESCRIPTION
Abbiamo notato dei problemi con il recupero delle fatture via PEC tramite POP3 ed avevo già pronto un fix che aveva implementato Odoo SA nel core tempo fa, ma parlando nel canale sviluppo di Discord abbiamo raccolto le considerazioni anche di @As400it Marco Calcagni che aveva avuto lo stesso problemi con lo scaricamento di fatture tramite POP3 anche risolvendo questo bug.

In effetti non ci sembra molto sicuro l'uso di POP3 a questo scopo perchè potrebbe esserci una perdita di dati, infatti nel caso vengano cancellati dei file delle fatture da Odoo prima che siano validati (operazione permessa), non ci sarebbe più modo di recuperarli dalla casella di posta.

Proponiamo quindi di impedire la configurazione di un server di posta in entrata PEC di tipo POP.

Cito anche @eLBati e @SirTakobi che vedo hanno contribuito ai file che abbiamo modificato.