### PR TITLE
[IMP] Move group_riba in a new group after partner accounting_entries

### DIFF
--- a/l10n_it_ricevute_bancarie/views/partner_view.xml
+++ b/l10n_it_ricevute_bancarie/views/partner_view.xml
@@ -7,13 +7,14 @@
     <record id="view_partner_form_riba" model="ir.ui.view">
         <field name="name">res.parner.form.riba</field>
         <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="inherit_id" ref="account.view_partner_property_form" />
         <field name="groups_id" eval="[(4, ref('account.group_account_user'))]" />
         <field name="arch" type="xml">
-            <field name="parent_id" position="after">
-                <label for="group_riba" />
-                <field name="group_riba" />
-            </field>
+            <group name="accounting_entries" position="after">
+                <group string="C/O" name="riba">
+                    <field name="group_riba" />
+                </group>
+            </group>
         </field>
     </record>
 


### PR DESCRIPTION
Spostare campo "raggruppa riba" v14 (visibile con funzionalità contabili complete)

![image](https://github.com/OCA/l10n-italy/assets/93990941/2c2b3c7f-ace6-4dfb-9f4b-d7acbe6fd6e5)
