### PR TITLE
[12.0] FIX l10n_it_vat_registries: Se si effettuano registrazioni IVA che coinvolgono direttamente la cassa, nel registro IVA corrispettivi gli importi delle imposte sono negativi

### DIFF
--- a/l10n_it_vat_registries/models/vat_registry.py
+++ b/l10n_it_vat_registries/models/vat_registry.py
@@ -113,7 +113,8 @@ class ReportRegistroIva(models.AbstractModel):
 
             if (
                 'receivable' in move.move_type or
-                'payable_refund' == move.move_type
+                'payable_refund' == move.move_type or
+                'liquidity' == move.move_type
             ):
                 # otherwise refund would be positive and invoices
                 # negative.


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/3407