### PR TITLE
[14.0] [IMP] l10n_it_fatturapa_in: creazione riga fattura da xml

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -581,6 +581,7 @@ class WizardImportFatturapa(models.TransientModel):
                 "sequence": nline,
                 "account_id": credit_account_id,
                 "price_unit": float(abs(line.ImponibileImporto)),
+                "exclude_from_invoice_tab": False,
             }
         )
         return retLine
@@ -1522,6 +1523,7 @@ class WizardImportFatturapa(models.TransientModel):
                             "move_id": invoice.id,
                             "account_id": credit_account_id,
                             "quantity": 1,
+                            "exclude_from_invoice_tab": False,
                         }
                     )
                     if welfareLine.Ritenuta:
@@ -1536,6 +1538,7 @@ class WizardImportFatturapa(models.TransientModel):
                         line_vals["invoice_line_tax_wt_ids"] = [
                             (6, 0, [wt.id for wt in wt_founds])
                         ]
+                        line_vals["exclude_from_invoice_tab"] = True
                     if self.env.company.cassa_previdenziale_product_id:
                         cassa_previdenziale_product = (
                             self.env.company.cassa_previdenziale_product_id


### PR DESCRIPTION
alcune righe dopo creazione tramite xml non vengono viste nella `rendicontazione fatture` perché il campo `exclude_from_invoice_tab` non era impostato.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing