### PR TITLE
[16.0] [FIX] l10n_it_declaration_of_intent: fix DOI domain in invoice form

### DIFF
--- a/l10n_it_declaration_of_intent/views/account_invoice_view.xml
+++ b/l10n_it_declaration_of_intent/views/account_invoice_view.xml
@@ -29,7 +29,21 @@
             >
                 <field
                     name="force_declaration_of_intent_id"
-                    domain="[('partner_id', '=', parent.partner_id), ('state', '!=', 'close'), ('date_start', '&lt;=', parent.invoice_date), ('date_end', '&gt;=', parent.invoice_date)]"
+                    attrs="{'column_invisible': [('parent.invoice_date', '=', False)]}"
+                    domain="[
+                    ('partner_id', '=', parent.partner_id),
+                    ('state', '!=', 'close'),
+                    ('date_start', '&lt;=', parent.invoice_date),
+                    ('date_end', '&gt;=', parent.invoice_date),
+                    ]"
+                />
+                <field
+                    name="force_declaration_of_intent_id"
+                    attrs="{'column_invisible': [('parent.invoice_date', '!=', False)]}"
+                    domain="[
+                    ('partner_id', '=', parent.partner_id),
+                    ('state', '!=', 'close'),
+                    ]"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Ref: https://github.com/OCA/l10n-italy/issues/3310

Se la fattura non ha data, vengono mostrati le DDI senza filtro sulla data; Se la fattura ha la data, vengono filtrate per data.