### PR TITLE
[FIX] l10n_it_fatturapa_in: rimosso abs dall'importo imponibile

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -580,7 +580,7 @@ class WizardImportFatturapa(models.TransientModel):
                 "name": "Riepilogo Aliquota {}".format(line.AliquotaIVA),
                 "sequence": nline,
                 "account_id": credit_account_id,
-                "price_unit": float(abs(line.ImponibileImporto)),
+                "price_unit": float(line.ImponibileImporto),
             }
         )
         return retLine


### PR DESCRIPTION
Se in fase di importazione da XML viene utilizzata la modalità “raggruppamento per aliquota” e questa è l’unica riga della fattura con quella particolare imposta, il prezzo del dettaglio inserito in fattura dovrebbe essere negativo (di fatto coincidente con quello del file XML), invece viene inserito in fattura un prezzo con segno positivo (e di conseguenza poi risultano errati il totale IVA e il totale documento).
Il motivo di tale comportamento è legato alla funzione _prepareInvoiceLineAliquota che assegna al campo “price_unit” un valore in valore assoluto con l’istruzione float(abs(line.ImponibileImporto))
Eliminando la funzione “abs” dalla linea di codice il problema si risolve.

@danall59
@mktsrl 

https://github.com/OCA/l10n-italy/issues/2959
https://github.com/OCA/l10n-italy/issues/3358