### PR TITLE
[16.0][FIX] l10n_it_fatturapa_in: Setting Italian timezone by default, otherwise e_invoice_received_date could be set the day before of the actual date

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1094,12 +1094,21 @@ class WizardImportFatturapa(models.TransientModel):
         if comment:
             comment = "<pre>" + comment + "</pre>"
 
+        if (
+            not fatturapa_attachment.env.context.get("tz")
+            and not fatturapa_attachment.env.user.tz
+        ):
+            # Setting Italian timezone, otherwise e_invoice_received_date
+            # could be set the day before of the actual date.
+            fatturapa_attachment = fatturapa_attachment.with_context(tz="Europe/Rome")
         if fatturapa_attachment.e_invoice_received_date:
-            e_invoice_received_date = (
-                fatturapa_attachment.e_invoice_received_date.date()
-            )
+            e_invoice_received_date = fields.Datetime.context_timestamp(
+                fatturapa_attachment, fatturapa_attachment.e_invoice_received_date
+            ).date()
         else:
-            e_invoice_received_date = fatturapa_attachment.create_date.date()
+            e_invoice_received_date = fields.Datetime.context_timestamp(
+                fatturapa_attachment, fatturapa_attachment.create_date
+            ).date()
 
         e_invoice_date = datetime.strptime(
             FatturaBody.DatiGenerali.DatiGeneraliDocumento.Data, "%Y-%m-%d"


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/2778

Example:
receiving date = 2022-04-01 00:16
saved in DB, UTC format, as 2022-03-31 22:16:03
converted to date = 2022-03-31

In this case, the invoice would be registered in the wrong period (month)

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing