### PR TITLE
[IMP] l10n_it_account_stamp: Usability for stamp in invoice.

### DIFF
--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -7,7 +7,16 @@ from odoo.exceptions import UserError
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    tax_stamp = fields.Boolean(readonly=False, compute="_compute_tax_stamp", store=True)
+    tax_stamp = fields.Boolean(
+        help="Tax stamp is applied to this invoice.",
+        readonly=False,
+        compute="_compute_tax_stamp",
+        store=True,
+    )
+    tax_stamp_line_present = fields.Boolean(
+        "Stamp line is present in invoice",
+        compute="_compute_tax_stamp_line_present",
+    )
     auto_compute_stamp = fields.Boolean(
         related="company_id.tax_stamp_product_id.auto_compute"
     )
@@ -86,10 +95,20 @@ class AccountMove(models.Model):
             inv.write({"invoice_line_ids": [(0, 0, invoice_line_vals)]})
 
     def is_tax_stamp_line_present(self):
+        self.ensure_one()
         for line in self.line_ids:
             if line.is_stamp_line:
                 return True
         return False
+
+    @api.depends(
+        "invoice_line_ids",
+        "invoice_line_ids.product_id",
+        "invoice_line_ids.product_id.is_stamp",
+    )
+    def _compute_tax_stamp_line_present(self):
+        for invoice in self:
+            invoice.tax_stamp_line_present = invoice.is_tax_stamp_line_present()
 
     def is_tax_stamp_product_present(self):
         product_stamp = self.invoice_line_ids.filtered(

--- a/l10n_it_account_stamp/views/account_move_view.xml
+++ b/l10n_it_account_stamp/views/account_move_view.xml
@@ -23,22 +23,37 @@
                     name="manually_apply_tax_stamp"
                     attrs="{'invisible': [('auto_compute_stamp', '=', True)]}"
                 />
+                <field name="tax_stamp_line_present" invisible="1" />
             </xpath>
             <field name="narration" position="before">
-                <img
-                    src="/l10n_it_account_stamp/static/description/icon.png"
-                    alt="Tax stamp"
+                <div
+                    name="stamp_applicability"
                     attrs="{'invisible': [('tax_stamp', '=', False)]}"
-                />
-                <button
-                    class="oe_edit_only"
-                    type="object"
-                    string="Add tax stamp line"
-                    name="add_tax_stamp_line"
-                    attrs="{'invisible': ['|',('tax_stamp', '=', False),('state', 'not in', 'draft')]}"
-                />
-                <!--move narration down-->
-                <div />
+                >
+                    <img
+                        src="/l10n_it_account_stamp/static/description/icon.png"
+                        alt="Tax stamp"
+                    />
+                    <span
+                        attrs="{'invisible': [('tax_stamp_line_present', '=', True)]}"
+                    >
+                        <span attrs="{'invisible': [('state', 'not in', 'draft')]}">
+                            <button
+                                type="object"
+                                string="Charge stamp to customer"
+                                name="add_tax_stamp_line"
+                            />
+                        </span>
+                        <span attrs="{'invisible': [('state', '=', 'draft')]}">
+                            Stamp can only be charged to customer when invoice is in draft state
+                        </span>
+                    </span>
+                    <span
+                        attrs="{'invisible': [('tax_stamp_line_present', '=', False)]}"
+                    >
+                        Stamp charged to customer
+                    </span>
+                </div>
             </field>
             <xpath
                 expr="//form/sheet/notebook/page[@id='invoice_tab']/field/form/sheet/group/field[@name='product_id']"


### PR DESCRIPTION
If stamp line can be added (invoice in draft): show button to add stamp line. If stamp line can't be added (invoice not in draft): show message explaining why it can't be added. If stamp line has already been added: show message saying it has already been added (useful if invoice has many lines). Button and messages update live while updating the invoice. Better messages to user for charging stamp to customer