### PR TITLE
[FIX]l10n_it_riba_sale_commission: recupero agent lines correttamente

### DIFF
--- a/l10n_it_riba_sale_commission/__manifest__.py
+++ b/l10n_it_riba_sale_commission/__manifest__.py
@@ -7,6 +7,7 @@
     "category": "Localization/Italy",
     "website": "https://github.com/OCA/l10n-italy",
     "author": "Nextev Srl, Odoo Community Association (OCA)",
+    "maintainers": ["odooNextev"],
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/l10n_it_riba_sale_commission/wizard/wizard_riba_commissions_settle.py
+++ b/l10n_it_riba_sale_commission/wizard/wizard_riba_commissions_settle.py
@@ -17,12 +17,10 @@ class SaleCommissionMakeSettle(models.TransientModel):
         """
         # removes invoice lines with flag "no_commission" and that have
         # payment term set on Ri.Ba from those get with the original method
-        agent_lines = (
-            super()
-            ._get_agent_lines(agent, date_to_agent)
-            .filtered(lambda al: not al.invoice_id.no_commission)
-            .filtered(lambda r: r.invoice_payment_term_id.riba)
-        )
+        all_agent_lines = super()._get_agent_lines(agent, date_to_agent)
+        agent_lines = all_agent_lines.filtered(
+            lambda al: not al.invoice_id.no_commission
+        ).filtered(lambda r: r.invoice_id.invoice_payment_term_id.riba)
         for line in agent_lines:
             # removes lines if RiBa is past due or in case it is subject to collection
             # and at least the safety days have not passed since the payment due date,
@@ -44,5 +42,5 @@ class SaleCommissionMakeSettle(models.TransientModel):
                     and riba_type == "sbf"
                 )
             ):
-                agent_lines -= line
-        return agent_lines
+                all_agent_lines -= line
+        return all_agent_lines


### PR DESCRIPTION
Modifica necessaria per compatibilità con sale_commission_product_criteria, che tornava un errore durante la generazione delle provvigioni