### PR TITLE
[FIX] Righe negative, note e sezioni in fattura fornitore con inversione contabile

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -133,8 +133,11 @@ class AccountMove(models.Model):
         else:
             raise UserError(_("Only inbound and outbound moves are supported"))
 
+        to_reconcile_move_lines = self.line_ids.filtered(
+            lambda ml: ml.account_id.reconcile
+        )
         is_zero = self.currency_id.is_zero
-        for move_line in self.line_ids:
+        for move_line in to_reconcile_move_lines:
             field_value = getattr(move_line, line_field)
             if not is_zero(field_value) and move_line.account_internal_type in (
                 "receivable",

--- a/l10n_it_reverse_charge/tests/test_rc.py
+++ b/l10n_it_reverse_charge/tests/test_rc.py
@@ -175,3 +175,38 @@ class TestReverseCharge(ReverseChargeCommon):
 
         payments_lines = (self_purchase_payment | self_purchase_rc_payment).line_ids
         self.assertTrue(all(payments_lines.mapped("reconciled")))
+
+    def test_description_lines(self):
+        """A Reverse Charge Bill can be confirmed
+        when contains notes and sections."""
+        # Arrange: Create a Reverse Charge Bill with notes and sections
+        bill = self.create_invoice(
+            self.supplier_extraEU,
+            amounts=[100],
+            taxes=self.tax_0_pur,
+            post=False,
+        )
+        bill.invoice_line_ids = [
+            (
+                0,
+                0,
+                {
+                    "display_type": "line_note",
+                    "name": "Test note",
+                },
+            ),
+            (
+                0,
+                0,
+                {
+                    "display_type": "line_section",
+                    "name": "Test section",
+                },
+            ),
+        ]
+
+        # Act
+        bill.action_post()
+
+        # Assert
+        self.assertEqual(bill.state, "posted")

--- a/l10n_it_reverse_charge/tests/test_rc.py
+++ b/l10n_it_reverse_charge/tests/test_rc.py
@@ -210,3 +210,16 @@ class TestReverseCharge(ReverseChargeCommon):
 
         # Assert
         self.assertEqual(bill.state, "posted")
+
+    def test_negative_lines(self):
+        """A Reverse Charge Bill can be confirmed
+        when contains negative lines."""
+        # Arrange: Create a Reverse Charge Bill with negative lines
+        bill = self.create_invoice(
+            self.supplier_extraEU,
+            amounts=[100, -10],
+            taxes=self.tax_0_pur,
+        )
+
+        # Assert
+        self.assertEqual(bill.state, "posted")


### PR DESCRIPTION
Corregge https://github.com/OCA/l10n-italy/issues/3503 e https://github.com/OCA/l10n-italy/issues/3504 per `14.0`.