### PR TITLE
[14.0][FIX] assets_management block creation of depreciation lines in every state

### DIFF
--- a/assets_management/models/asset_depreciation.py
+++ b/assets_management/models/asset_depreciation.py
@@ -260,16 +260,14 @@ class AssetDepreciation(models.Model):
 
         lines = self.mapped("line_ids")
 
-        posted_lines = lines.filtered(
-            lambda line: line.date == dep_date
-            and line.move_id
-            and line.move_id.state != "draft"
+        draft_lines = lines.filtered(
+            lambda line: line.date == dep_date and line.move_type == "depreciated"
         )
-        if posted_lines:
-            posted_names = ", ".join(
+        if draft_lines:
+            draft_names = ", ".join(
                 [
                     asset_name
-                    for asset_id, asset_name in posted_lines.mapped(
+                    for asset_id, asset_name in draft_lines.mapped(
                         "depreciation_id.asset_id"
                     ).name_get()
                 ]
@@ -277,8 +275,8 @@ class AssetDepreciation(models.Model):
             raise ValidationError(
                 _(
                     "Cannot update the following assets which contain"
-                    " posted depreciation for the chosen date and types:\n{}"
-                ).format(posted_names)
+                    " draft depreciation for the chosen date and types:\n{}"
+                ).format(draft_names)
             )
 
     def generate_depreciation_lines(self, dep_date):


### PR DESCRIPTION
Blocca la generazione degli ammortamenti se ci sono già ammortamenti per la data indicata, per evitarne la duplicazione.
Questo presuppone che l'utente nel wizard escluda i cespiti su cui li ha eventualmente già creati manualmente.