### PR TITLE
[FIX] Importo resettato quando si cambia il sezionale nel wizard per la registrazione del pagamento

### DIFF
--- a/l10n_it_withholding_tax/__manifest__.py
+++ b/l10n_it_withholding_tax/__manifest__.py
@@ -12,6 +12,7 @@
     "license": "AGPL-3",
     "depends": [
         "account",
+        "account_payment_register_keep_amount",
         "l10n_it_fatturapa",
     ],
     "data": [

--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -514,7 +514,12 @@ class AccountMove(models.Model):
         if not float_is_zero(amount_net_pay_residual, dp_obj.precision_get("Account")):
             ctx = res.get("context", {})
             if ctx:
-                ctx.update({"default_amount": amount_net_pay_residual})
+                ctx.update(
+                    {
+                        "default_amount": amount_net_pay_residual,
+                        "default_keep_previous_amount": True,
+                    }
+                )
             res.update({"context": ctx})
         return res
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
 pdfminer.six # needed by attachment_indexation module
+# https://github.com/OCA/account-payment/pull/665
+odoo14-addon-account_payment_register_keep_amount @ git+https://github.com/OCA/account-payment.git@refs/pull/665/head#subdirectory=setup/account_payment_register_keep_amount


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/3401 per `14.0`.

Dipende da https://github.com/OCA/account-payment/pull/665.

Implementazione alternativa a https://github.com/OCA/l10n-italy/pull/3400.