### PR TITLE
[FIX] Non deve essere possibile creare o modificare i tipi di documento fiscale

### DIFF
--- a/l10n_it_fiscal_document_type/__manifest__.py
+++ b/l10n_it_fiscal_document_type/__manifest__.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Alessandro Camilli
 # Copyright 2018 Sergio Zanchetta (Associazione PNLUG - Gruppo Odoo)
 # Copyright 2018 Lorenzo Battistini (https://github.com/eLBati)
+# Copyright 2023 Simone Rubino - TAKOBI
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
@@ -12,7 +13,10 @@
     'website': 'https://github.com/OCA/l10n-italy'
                '/tree/12.0/l10n_it_fiscal_document_type',
     'license': 'AGPL-3',
-    'depends': ['l10n_it_account'],
+    'depends': [
+        'l10n_it_account',
+        'mail',
+    ],
     'data': [
         'views/fiscal_document_type_view.xml',
         'views/res_partner_view.xml',

--- a/l10n_it_fiscal_document_type/security/ir.model.access.csv
+++ b/l10n_it_fiscal_document_type/security/ir.model.access.csv
@@ -1,3 +1,2 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_fiscal_document_type_group_all","fiscal_document_type group_user_all","model_fiscal_document_type",,1,0,0,0
-"access_fiscal_document_type_group_user","fiscal_document_type group_user","model_fiscal_document_type","base.group_partner_manager",1,1,1,1


### PR DESCRIPTION
Corregge https://github.com/OCA/l10n-italy/issues/3532 per `12.0`.
Sostituisce https://github.com/OCA/l10n-italy/pull/2819.