### PR TITLE
[14.0][IMP] l10n_it_fatturapa_pec: no server draft on max pec error c…

### DIFF
--- a/l10n_it_fatturapa_pec/tests/__init__.py
+++ b/l10n_it_fatturapa_pec/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import e_invoice_common
 from . import test_e_invoice_response
 from . import test_e_invoice_send
+from . import test_fetchmail_server

--- a/l10n_it_fatturapa_pec/tests/e_invoice_common.py
+++ b/l10n_it_fatturapa_pec/tests/e_invoice_common.py
@@ -107,6 +107,8 @@ class EInvoiceCommon(FatturaPACommon):
                 "user": "dummy",
                 "password": "secret",
                 "state": "done",
+                "pec_error_count": 0,
+                "lock_on_max_pec_error_count": True,
                 "e_inv_notify_partner_ids": [
                     (6, 0, [self.env.ref("base.user_admin").partner_id.id])
                 ],

--- a/l10n_it_fatturapa_pec/tests/test_fetchmail_server.py
+++ b/l10n_it_fatturapa_pec/tests/test_fetchmail_server.py
@@ -1,0 +1,14 @@
+from odoo.tests import tagged
+
+from .e_invoice_common import EInvoiceCommon
+
+
+@tagged("post_install", "-at_install")
+class TestFetchmailPECServer(EInvoiceCommon):
+    def setUp(self):
+        super(TestFetchmailPECServer, self).setUp()
+        self.PEC_server = self._create_fetchmail_pec_server()
+
+    def test_fetch_mail(self):
+        self.assertEqual(self.PEC_server.pec_error_count, 0)
+        self.assertEqual(self.PEC_server.lock_on_max_pec_error_count, True)

--- a/l10n_it_fatturapa_pec/views/fetchmail_view.xml
+++ b/l10n_it_fatturapa_pec/views/fetchmail_view.xml
@@ -20,6 +20,9 @@
                     </group>
                 </page>
             </notebook>
+            <xpath expr="//page[@name='advanced_options']/group" position="inside">
+                <field name="lock_on_max_pec_error_count" />
+            </xpath>
             <xpath expr="//notebook/page[1]/group[1]/group[3]" position="attributes">
                 <!-- Hiding, because it would not be considered. See 'fetch_mail' override -->
                 <attribute


### PR DESCRIPTION
…ount

Implementa https://github.com/OCA/l10n-italy/issues/3554

Ho tenuto le modifiche al minimo:

* aggiunge un boolean `lock_on_max_pec_error_count` nel "tab" Impostazioni Avanzate della configurazione server.

* il boolean è impostato a `True` di default, quindi mantiene il comportamento standard. 

* Il campo deve essere flaggato a mano perché la PR sia attiva

Notare che nonostante il server non venga reimpostato a `draft` il contatore continua ad incrementare, inoltre il campo `last_pec_error_message` viene comunque impostato. Eventualmente possiamo evitare l'incremento e il messaggio mentre il flag è attivo.