### PR TITLE
[16.0][IMP] l10n_it_delivery_note: remove misleading price_unit sum total

### DIFF
--- a/l10n_it_delivery_note/views/stock_delivery_note.xml
+++ b/l10n_it_delivery_note/views/stock_delivery_note.xml
@@ -265,7 +265,6 @@
                                         name="price_unit"
                                         attrs="{'column_invisible': [('parent.show_product_information', '=', False)],
                                                    'readonly': [('sale_line_id', '!=', False)]}"
-                                        sum="Total"
                                     />
                                     <field
                                         name="discount"


### PR DESCRIPTION
Removing the price_unit sum from the list of products in the delivery note since the sum of price_unit is not particularly meaningful and can be misleading (it doesn't take quantity into account)

Cf: #3557