### PR TITLE
[14.0][FIX] l10n_it_declaration_of_intent: separate "in" and "out" declarations in tests

### DIFF
--- a/l10n_it_declaration_of_intent/tests/test_declaration_of_intent.py
+++ b/l10n_it_declaration_of_intent/tests/test_declaration_of_intent.py
@@ -353,8 +353,8 @@ class TestDeclarationOfIntent(AccountTestInvoicingCommon):
 
     def test_all_invoice_types(self):
         """
-        Check that a declaration with all the invoice types
-        computes the totals correctly.
+        Check that declarations with both invoices and refunds compute
+        the totals correctly.
         """
         partner = self.partner1
 
@@ -382,20 +382,30 @@ class TestDeclarationOfIntent(AccountTestInvoicingCommon):
         in_refund_balance = in_refund.line_ids.filtered("tax_ids").balance
         self.assertEqual(in_refund_balance, -100)
 
-        invoices = out_invoice | in_invoice | out_refund | in_refund
+        declaration_out = self._create_declaration(partner, "out")
+        declaration_out.limit_amount = 2000
+        invoices_in = in_invoice | in_refund
+        invoices_in.declaration_of_intent_ids = declaration_out
 
-        declaration = self._create_declaration(partner, "out")
-        declaration.limit_amount = 2000
-        invoices.declaration_of_intent_ids = declaration
+        declaration_in = self._create_declaration(partner, "in")
+        declaration_in.limit_amount = 2000
+        invoices_out = out_invoice | out_refund
+        invoices_out.declaration_of_intent_ids = declaration_in
 
-        invoices.action_post()
-        used_amount = (
-            -out_invoice_balance
-            + in_invoice_balance
-            - out_refund_balance
-            + in_refund_balance
-        )
-        self.assertEqual(declaration.available_amount, 2000 - used_amount)
+        invoices_in.action_post()
+        invoices_out.action_post()
+
+        # balance is positive for in invoices
+        # add "in" invoice and refund and compare with "out" DI available_amount
+        used_amount_in = in_invoice_balance + in_refund_balance
+        self.assertEqual(used_amount_in, 800)
+        self.assertEqual(declaration_out.available_amount, 2000 - used_amount_in)
+
+        # balance is positive for out invoices
+        # add "out" invoice and refund and compare with "in" DI available_amount
+        used_amount_out = -out_invoice_balance - out_refund_balance
+        self.assertEqual(used_amount_out, 800)
+        self.assertEqual(declaration_in.available_amount, 2000 - used_amount_out)
 
     def test_invoice_repost(self):
         invoice = self._create_invoice(


### PR DESCRIPTION
"out" declarations can't be used on "out" invoices, test needs to check "out" declarations with "in" documents (invoices and refunds), and "in" declarations with "out" documents.