### PR TITLE
[14.0][FIX] l10n_it_website_sale_fiscalcode: fix fiscalcode check

### DIFF
--- a/l10n_it_website_sale_fiscalcode/controllers/main.py
+++ b/l10n_it_website_sale_fiscalcode/controllers/main.py
@@ -1,6 +1,6 @@
 # Copyright 2017 Nicola Malcontenti - Agile Business Group
 
-from odoo import _
+from odoo.exceptions import ValidationError
 from odoo.http import request
 
 from odoo.addons.website_sale.controllers.main import WebsiteSale
@@ -22,15 +22,29 @@ class WebsiteSaleFiscalCode(WebsiteSale):
         error, error_message = super().checkout_form_validate(
             mode, all_form_values, data
         )
-        partner_sudo = request.env.user.partner_id.sudo()
+        # Check fiscalcode
+        partner = request.env.user.partner_id
+        # company_type does not come from page form
+        company_type = partner.company_type
+        company_name = False
+        if "company_name" in data:
+            company_name = data.get("company_name")
+        else:
+            # when company_name is not posted (readonly)
+            if partner.company_name:
+                company_name = partner.company_name
+            elif partner.company_type == "company":
+                company_name = partner.name
         dummy_partner = request.env["res.partner"].new(
             {
                 "fiscalcode": data.get("fiscalcode"),
-                "is_company": partner_sudo.is_company,
+                "company_name": company_name,
+                "company_type": company_type,
             }
         )
-        if dummy_partner.fiscalcode:
-            if len(dummy_partner.fiscalcode) != 16:
-                error["fiscalcode"] = "error"
-                error_message.append(_("Fiscal Code not valid"))
+        try:
+            dummy_partner.check_fiscalcode()
+        except ValidationError as e:
+            error["fiscalcode"] = "error"
+            error_message.append(e)
         return error, error_message


### PR DESCRIPTION
Implement

- https://github.com/OCA/l10n-italy/issues/3588
- https://github.com/OCA/l10n-italy/issues/3591

This commit restores the call to the constrains `check_fiscalcode()` in `checkout_form_validate()` method of `WebsiteSale` controller (#3588). The `company_name` will also be added to the dummy partned so the field value will be correctly evaluated on the constrains (#3591).