### PR TITLE
[FIX][14.0] set migration script of l10n_it_appointment_code to same logic of other

### DIFF
--- a/l10n_it_appointment_code/__init__.py
+++ b/l10n_it_appointment_code/__init__.py
@@ -1,2 +1,2 @@
 from . import models
-from .hooks import rename_old_italian_module
+from .hooks import pre_absorb_old_module

--- a/l10n_it_appointment_code/__manifest__.py
+++ b/l10n_it_appointment_code/__manifest__.py
@@ -19,5 +19,5 @@
         "views/appointment_code_view.xml",
     ],
     "installable": True,
-    "pre_init_hook": "rename_old_italian_module",
+    "pre_init_hook": "pre_absorb_old_module",
 }

--- a/l10n_it_appointment_code/hooks.py
+++ b/l10n_it_appointment_code/hooks.py
@@ -3,54 +3,31 @@
 
 from openupgradelib import openupgrade
 
+OLD_MODULE_NAME = "l10n_it_codici_carica"
+NEW_MODULE_NAME = "l10n_it_appointment_code"
+
 
 def rename_old_italian_module(cr):
-
-    if not openupgrade.is_module_installed(cr, "l10n_it_codici_carica"):
-        return
-
     openupgrade.rename_xmlids(
         cr,
         [
             (
-                "l10n_it_codici_carica.view_codice_carica_tree",
+                "l10n_it_appointment_code.view_codice_carica_tree",
                 "l10n_it_appointment_code.view_appointment_code_tree",
             ),
             (
-                "l10n_it_codici_carica.view_codice_carica_form",
+                "l10n_it_appointment_code.view_codice_carica_form",
                 "l10n_it_appointment_code.view_appointment_code_form",
             ),
             (
-                "l10n_it_codici_carica.action_codice_carica",
+                "l10n_it_appointment_code.action_codice_carica",
                 "l10n_it_appointment_code.action_appointment_code",
             ),
             (
-                "l10n_it_codici_carica.menu_codice_carica",
+                "l10n_it_appointment_code.menu_codice_carica",
                 "l10n_it_appointment_code.menu_appointment_code",
             ),
-            ("l10n_it_codici_carica.1", "l10n_it_appointment_code.1"),
-            ("l10n_it_codici_carica.2", "l10n_it_appointment_code.2"),
-            ("l10n_it_codici_carica.3", "l10n_it_appointment_code.3"),
-            ("l10n_it_codici_carica.4", "l10n_it_appointment_code.4"),
-            ("l10n_it_codici_carica.5", "l10n_it_appointment_code.5"),
-            ("l10n_it_codici_carica.6", "l10n_it_appointment_code.6"),
-            ("l10n_it_codici_carica.7", "l10n_it_appointment_code.7"),
-            ("l10n_it_codici_carica.8", "l10n_it_appointment_code.8"),
-            ("l10n_it_codici_carica.9", "l10n_it_appointment_code.9"),
-            ("l10n_it_codici_carica.10", "l10n_it_appointment_code.10"),
-            ("l10n_it_codici_carica.11", "l10n_it_appointment_code.11"),
-            ("l10n_it_codici_carica.12", "l10n_it_appointment_code.12"),
-            ("l10n_it_codici_carica.13", "l10n_it_appointment_code.13"),
-            ("l10n_it_codici_carica.14", "l10n_it_appointment_code.14"),
-            ("l10n_it_codici_carica.15", "l10n_it_appointment_code.15"),
         ],
-    )
-    openupgrade.update_module_names(
-        cr,
-        [
-            ("l10n_it_codici_carica", "l10n_it_appointment_code"),
-        ],
-        merge_modules=True,
     )
     openupgrade.rename_models(
         cr,
@@ -64,3 +41,15 @@ def rename_old_italian_module(cr):
             ("codice_carica", "appointment_code"),
         ],
     )
+
+
+def pre_absorb_old_module(cr):
+    if openupgrade.is_module_installed(cr, OLD_MODULE_NAME):
+        openupgrade.update_module_names(
+            cr,
+            [
+                (OLD_MODULE_NAME, NEW_MODULE_NAME),
+            ],
+            merge_modules=True,
+        )
+        rename_old_italian_module(cr)


### PR DESCRIPTION
Senza questa correzione la migrazione con OpenUpgrade non viene eseguita in quanto il modulo è già presente in `apriori.py'.