### PR TITLE
[14.0] [FIX] l10n_it_delivery_note: recipient/shipping address fixes

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -29,8 +29,20 @@ class StockPicking(models.Model):
         string="DN State", related="delivery_note_id.state", store=True
     )
     delivery_note_partner_ref = fields.Char(related="delivery_note_id.partner_ref")
+    delivery_note_partner_id = fields.Many2one(
+        "res.partner",
+        string="DN Recipient",
+        related="delivery_note_id.partner_id",
+    )
     delivery_note_partner_shipping_id = fields.Many2one(
-        "res.partner", related="delivery_note_id.partner_shipping_id"
+        "res.partner",
+        string="DN Delivery address",
+        related="delivery_note_id.partner_shipping_id",
+    )
+    delivery_note_shipping_from = fields.Many2one(
+        "res.partner",
+        string="DN Shipping from",
+        related="delivery_note_id.partner_sender_id",
     )
 
     delivery_note_carrier_id = fields.Many2one(
@@ -351,12 +363,21 @@ class StockPicking(models.Model):
             ],
             limit=1,
         )
+        partner_id = (
+            self.sale_id.partner_id.id
+            if self.sale_id.partner_id
+            else self.partner_id.id
+        )
+        if not partner_id:
+            raise ValidationError(
+                _("You have to set a contact for internal transfers.")
+            )
         delivery_method_id = self.mapped("carrier_id")[:1]
         return self.env["stock.delivery.note"].create(
             {
                 "company_id": self.company_id.id,
                 "partner_sender_id": partners[0].id,
-                "partner_id": partners[2].id if self.sale_id else partners[0].id,
+                "partner_id": partner_id,
                 "partner_shipping_id": partners[1].id,
                 "type_id": type_id.id,
                 "date": self.date_done,
@@ -382,6 +403,7 @@ class StockPicking(models.Model):
                     or partners[1].default_transport_method_id.id
                     or type_id.default_transport_method_id.id
                 ),
+                "note": type_id.note,
             }
         )
 
@@ -477,3 +499,13 @@ class StockPicking(models.Model):
         for backorder in backorders:
             backorder.backorder_id.delivery_note_id.update_detail_lines()
         return backorders
+
+    @api.onchange("picking_type_id")
+    def _set_partner_if_internal(self):
+        for picking in self:
+            if picking.picking_type_code == "internal" and picking.location_dest_id:
+                wh_id = self.env["stock.warehouse"].search(
+                    [("lot_stock_id", "=", picking.location_dest_id.id)]
+                )
+                if wh_id:
+                    picking.partner_id = wh_id.partner_id

--- a/l10n_it_delivery_note/report/report_delivery_note.xml
+++ b/l10n_it_delivery_note/report/report_delivery_note.xml
@@ -9,24 +9,12 @@
         <t t-call="web.external_layout">
             <t t-set="doc" t-value="doc.with_context(lang=doc.partner_id.lang)" />
 
-            <!--if is an outgoing move -->
-            <t id="partner_outgoing" t-if="doc.type_code=='outgoing'">
-                <t t-set="address">
-                    <h4>
-                        <strong>Delivery address:</strong>
-                    </h4>
-                    <div
-                        t-field="doc.partner_shipping_id"
-                        t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
-                    />
-                    <p t-if="doc.partner_shipping_id.vat"><t
-                            t-esc="doc.company_id.country_id.vat_label or 'Tax ID'"
-                        />: <span t-field="doc.partner_shipping_id.vat" /></p>
-                </t>
-                <t t-set="information_block">
-                    <h4>
-                        <strong>Customer:</strong>
-                    </h4>
+            <t t-set="information_block">
+                <h4>
+                    <strong>Recipient:</strong>
+                </h4>
+                <!--if is an outgoing move -->
+                <t t-if="doc.type_code=='outgoing'">
                     <t t-if="doc.sale_ids">
                         <div
                             t-field="doc.sale_ids[0].partner_id"
@@ -46,46 +34,62 @@
                             />: <span t-field="doc.partner_id.vat" /></p>
                     </t>
                 </t>
+                <!--if is an incoming or internal move -->
+                <t t-else="">
+                    <div
+                        t-field="doc.partner_id"
+                        t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
+                    />
+                    <p t-if="doc.partner_id.vat"><t
+                            t-esc="doc.company_id.country_id.vat_label or 'Tax ID'"
+                        />: <span t-field="doc.partner_id.vat" /></p>
+                </t>
             </t>
 
-            <!--if is an internal move -->
-            <t id="partner_outgoing" t-if="doc.type_code=='internal'">
-                <t t-set="address">
-                    <h4>
-                        <strong>Delivery address:</strong>
-                    </h4>
+            <t t-set="address">
+                <h4>
+                    <strong>Delivery address:</strong>
+                </h4>
+                <!--if is an internal move -->
+                <t t-if="doc.type_code=='internal'">
+                     <t t-if="doc.partner_id.id == doc.partner_sender_id.id">
+                        <div
+                            t-field="doc.partner_shipping_id"
+                            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
+                        />
+                    </t>
+                    <t t-else="">
+                        <t
+                            t-if="doc.partner_sender_id.id != doc.partner_shipping_id.id"
+                        >
+                            <div
+                                t-field="doc.partner_shipping_id"
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
+                            />
+                        </t>
+                        <t t-else="">
+                            <div
+                                t-field="doc.partner_sender_id"
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
+                            />
+                        </t>
+                    </t>
+                </t>
+                <!--if is an outgoing or incoming move -->
+                <t t-else="">
                     <div
                         t-field="doc.partner_shipping_id"
                         t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
                     />
-                    <p t-if="doc.partner_shipping_id.vat"><t
-                            t-esc="doc.company_id.country_id.vat_label or 'Tax ID'"
-                        />: <span t-field="doc.partner_shipping_id.vat" /></p>
-                </t>
-                <t t-if="doc.picking_ids and doc.picking_ids[0].location_id.id">
-                    <t t-set="information_block">
-                        <h4>
-                            <strong>Warehouse:</strong>
-                        </h4>
-                        <p>
-                            <t
-                                t-esc="doc.get_location_address(doc.picking_ids[0].location_id.id)"
-                            />
-                        </p>
-                    </t>
                 </t>
             </t>
 
-            <div class="page">
+            <div class="page pt-2">
                 <div id="warehouse_outgoing">
-                    <div
-                        t-if="doc.type_code=='outgoing' and doc.picking_ids and doc.picking_ids[0].location_id.id"
-                    >
-                        <strong>Warehouse:</strong>
+                    <div>
+                        <strong>Shipping from:</strong>
                         <p>
-                            <t
-                                t-esc="doc.get_location_address(doc.picking_ids[0].location_id.id)"
-                            />
+                            <t t-esc="doc.get_partner_address(doc.partner_sender_id)" />
                         </p>
                     </div>
                 </div>

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note.py
@@ -90,6 +90,22 @@ class StockDeliveryNote(StockDeliveryNoteCommon):
         dn = dn_form.save()
         dn.confirm()
         self.assertTrue(picking.delivery_note_id)
+        picking.delivery_note_id.write(
+            {
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PA"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_CAR"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VIS"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_DES"
+                ).id,
+            }
+        )
         picking.delivery_note_id.action_confirm()
         self.assertEqual(picking.delivery_note_id.state, "confirm")
         self.assertEqual(picking.delivery_note_id.invoice_status, "no")

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note_invoicing.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note_invoicing.py
@@ -58,6 +58,22 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
         delivery_note = self.create_delivery_note()
         delivery_note.transport_datetime = datetime.now() + timedelta(days=1, hours=3)
         delivery_note.picking_ids = picking
+        delivery_note.write(
+            {
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ).id,
+            }
+        )
         delivery_note.action_confirm()
         self.assertEqual(len(delivery_note.line_ids), 4)
         self.assertEqual(delivery_note.state, "confirm")
@@ -268,6 +284,22 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
             days=1, hours=3
         )
         first_delivery_note.picking_ids = picking
+        first_delivery_note.write(
+            {
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ).id,
+            }
+        )
         first_delivery_note.action_confirm()
         self.assertEqual(len(first_delivery_note.line_ids), 4)
         self.assertEqual(first_delivery_note.state, "confirm")
@@ -310,6 +342,22 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
             days=1, hours=3
         )
         second_delivery_note.picking_ids = backorder
+        second_delivery_note.write(
+            {
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ).id,
+            }
+        )
         second_delivery_note.action_confirm()
         self.assertEqual(len(second_delivery_note.line_ids), 3)
         self.assertEqual(second_delivery_note.state, "confirm")
@@ -617,6 +665,22 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
         delivery_note = self.create_delivery_note()
         delivery_note.transport_datetime = datetime.now() + timedelta(days=1, hours=3)
         delivery_note.picking_ids = pickings
+        delivery_note.write(
+            {
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ).id,
+            }
+        )
         delivery_note.action_confirm()
         self.assertEqual(len(delivery_note.line_ids), 6)
         self.assertEqual(delivery_note.state, "confirm")
@@ -911,6 +975,22 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
             days=1, hours=3
         )
         first_delivery_note.picking_ids = pickings
+        first_delivery_note.write(
+            {
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ).id,
+            }
+        )
         first_delivery_note.action_confirm()
         self.assertEqual(len(first_delivery_note.line_ids), 6)
         self.assertEqual(first_delivery_note.state, "confirm")
@@ -983,6 +1063,22 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
             days=1, hours=3
         )
         second_delivery_note.picking_ids = backorders
+        second_delivery_note.write(
+            {
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ).id,
+            }
+        )
         second_delivery_note.action_confirm()
         self.assertEqual(len(second_delivery_note.line_ids), 3)
         self.assertEqual(second_delivery_note.state, "confirm")
@@ -1284,6 +1380,22 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
         ).save()
         result = wizard.confirm()
         delivery_note = self.env["stock.delivery.note"].browse(result["res_id"])
+        delivery_note.write(
+            {
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PAF"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_SFU"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_RES"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_COR"
+                ).id,
+            }
+        )
         delivery_note.action_confirm()
         delivery_note.action_cancel()
         delivery_note.action_draft()

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note_portal.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note_portal.py
@@ -22,6 +22,24 @@ class StockDeliveryNotePortal(StockDeliveryNoteCommon, HttpCase):
         # when picking is validated
         self.env.user = self.user_mr
 
+        # set default transport_condition_id, goods_appearance_id,
+        # transport_reason_id and transport_method_id to pass DN validation checks
+        self.env.ref("l10n_it_delivery_note_base.delivery_note_type_ddt").write(
+            {
+                "default_transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ),
+                "default_goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ),
+                "default_transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ),
+                "default_transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ),
+            }
+        )
         # Mario Rossi SO
         self.sales_order_mr = self.create_sales_order(
             [
@@ -65,6 +83,22 @@ class StockDeliveryNotePortal(StockDeliveryNoteCommon, HttpCase):
         self.picking_ab.button_validate()
         self.delivery_note_ab = self.picking_ab.delivery_note_id
         self.assertTrue(self.delivery_note_ab)
+        self.delivery_note_ab.write(
+            {
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ).id,
+            }
+        )
         self.delivery_note_ab.action_confirm()
 
         # Anna Bianchi fatturazione, Mario Rossi spedizione

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note_sequence.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note_sequence.py
@@ -183,8 +183,24 @@ class StockDeliveryNoteSequence(StockDeliveryNoteCommon):
         self.assertTrue(result)
 
         delivery_note = picking.delivery_note_id
-        delivery_note.transport_datetime = datetime.now() + timedelta(days=1, hours=3)
-        delivery_note.date = date.today().replace(year=old_year)
+        delivery_note.write(
+            {
+                "transport_datetime": datetime.now() + timedelta(days=1, hours=3),
+                "date": date.today().replace(year=old_year),
+                "transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ).id,
+                "goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ).id,
+                "transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ).id,
+                "transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ).id,
+            }
+        )
         delivery_note.action_confirm()
         self.assertEqual(delivery_note.type_id.sequence_id, sequence)
         self.assertEqual(

--- a/l10n_it_delivery_note/views/stock_picking.xml
+++ b/l10n_it_delivery_note/views/stock_picking.xml
@@ -227,46 +227,144 @@
                                         name="delivery_note_date"
                                         attrs="{'readonly': [('delivery_note_draft', '=', False)]}"
                                     />
-                                    <label for="transport_datetime" />
-                                    <div class="o_row">
-                                        <field
-                                            name="transport_datetime"
-                                            attrs="{'readonly': [('delivery_note_readonly', '=', True)]}"
-                                        />
-                                        <button
-                                            type="object"
-                                            name="delivery_note_update_transport_datetime"
-                                            attrs="{'invisible': [('delivery_note_readonly', '=', True)]}"
-                                            class="btn-secondary"
-                                            icon="fa-clock-o"
-                                            aria-label="Update to now"
-                                            title="Update to now"
-                                        />
-                                    </div>
                                 </group>
+                                <div class="statusbar_status">
+                                    <button
+                                        class="btn arrow_button active"
+                                        attrs="{'invisible': [('delivery_note_state', '!=', 'cancel')]}"
+                                    >
+                                        Cancelled
+                                    </button>
+                                    <button
+                                        class="btn arrow_button active"
+                                        attrs="{'invisible': [('delivery_note_state', '!=', 'done')]}"
+                                    >
+                                        Done
+                                    </button>
+                                    <button
+                                        class="btn arrow_button active"
+                                        attrs="{'invisible': [('delivery_note_state', '!=', 'invoiced')]}"
+                                    >
+                                        Invoiced
+                                    </button>
+                                    <button
+                                        class="btn arrow_button active"
+                                        attrs="{'invisible': [('delivery_note_state', '!=', 'confirm')]}"
+                                    >
+                                        Validated
+                                    </button>
+                                    <button
+                                        class="btn arrow_button"
+                                        attrs="{'invisible': [('delivery_note_state', '=', 'confirm')]}"
+                                    >
+                                        Validated
+                                    </button>
+                                    <button
+                                        class="btn arrow_button first_arrow active"
+                                        attrs="{'invisible': [('delivery_note_state', '!=', 'draft')]}"
+                                    >
+                                        Draft
+                                    </button>
+                                    <button
+                                        class="btn arrow_button first_arrow"
+                                        attrs="{'invisible': [('delivery_note_state', '=', 'draft')]}"
+                                    >
+                                        Draft
+                                    </button>
+                                </div>
                             </group>
-                            <group
-                                attrs="{'invisible': [('delivery_note_exists', '=', False)]}"
-                            >
+                            <div class="content">
                                 <group>
-                                    <field
-                                        name="packages"
-                                        attrs="{'readonly': [('delivery_note_readonly', '=', True)]}"
-                                    />
-                                    <label for="delivery_note_volume" />
-                                    <div class="o_row">
+                                    <group>
+                                        <label for="delivery_note_id" />
+                                        <div class="o_row">
+                                            <field
+                                                name="delivery_note_id"
+                                                domain="[('state', '=', 'draft'),
+                                                            ('partner_id', '=', partner_id)]"
+                                                attrs="{'required': [('delivery_note_exists', '=', True)],
+                                                           'readonly': [('delivery_note_draft', '=', False)]}"
+                                                options="{'no_create': True, 'no_open': True}"
+                                            />
+                                            <button
+                                                type="object"
+                                                name="goto_delivery_note"
+                                                class="btn-secondary"
+                                                groups="l10n_it_delivery_note.use_advanced_delivery_notes"
+                                                attrs="{'invisible': ['|', ('use_advanced_behaviour', '=', False),
+                                                                               ('delivery_note_exists', '=', False)]}"
+                                                icon="fa-external-link"
+                                                aria-label="Go to delivery note"
+                                                title="Go to delivery note"
+                                            />
+                                        </div>
                                         <field
-                                            name="delivery_note_volume"
-                                            attrs="{'readonly': [('delivery_note_readonly', '=', True)]}"
-                                            string="Volume"
+                                            name="delivery_note_partner_ref"
+                                            attrs="{'invisible': [('delivery_note_type_code', '!=', 'incoming')],
+                                                       'readonly': [('delivery_note_readonly', '=', True)]}"
+                                        />
+                                        <field
+                                            name="delivery_note_partner_id"
+                                            attrs="{'required': [('delivery_note_exists', '=', True)],
+                                                       'readonly': [('delivery_note_readonly', '=', True)]}"
+                                        />
+                                        <field
+                                            name="delivery_note_partner_shipping_id"
+                                            attrs="{'required': [('delivery_note_exists', '=', True)],
+                                                       'readonly': [('delivery_note_readonly', '=', True)]}"
+                                        />
+                                        <field
+                                            name="delivery_note_shipping_from"
+                                            attrs="{'required': [('delivery_note_exists', '=', True)],
+                                                       'readonly': [('delivery_note_readonly', '=', True)]}"
                                         />
                                         <field
                                             name="delivery_note_volume_uom_id"
                                             groups="uom.group_uom"
                                             widget="selection"
+                                            attrs="{'required': [('delivery_note_exists', '=', True)],
+                                                       'readonly': [('delivery_note_draft', '=', False)]}"
+                                        />
+                                        <field
+                                            name="delivery_note_date"
+                                            attrs="{'readonly': [('delivery_note_draft', '=', False)]}"
+                                        />
+                                        <label for="transport_datetime" />
+                                        <div class="o_row">
+                                            <field
+                                                name="transport_datetime"
+                                                attrs="{'readonly': [('delivery_note_readonly', '=', True)]}"
+                                            />
+                                            <button
+                                                type="object"
+                                                name="delivery_note_update_transport_datetime"
+                                                attrs="{'invisible': [('delivery_note_readonly', '=', True)]}"
+                                                class="btn-secondary"
+                                                icon="fa-clock-o"
+                                                aria-label="Update to now"
+                                                title="Update to now"
+                                            />
+                                        </div>
+                                        <field
+                                            name="delivery_note_carrier_id"
+                                            attrs="{'readonly': [('delivery_note_readonly', '=', True)]}"
+                                            string="Carrier"
+                                        />
+                                        <field
+                                            name="delivery_method_id"
                                             attrs="{'readonly': [('delivery_note_readonly', '=', True)]}"
                                         />
-                                    </div>
+                                    </group>
+                                </group>
+                                <group
+                                    attrs="{'invisible': [('delivery_note_exists', '=', False)]}"
+                                >
+                                    <group>
+                                        <field
+                                            name="packages"
+                                            attrs="{'readonly': [('delivery_note_readonly', '=', True)]}"
+                                        />
+                                    </group>
                                 </group>
                                 <group>
                                     <label for="gross_weight" />
@@ -296,7 +394,7 @@
                                         />
                                     </div>
                                 </group>
-                            </group>
+                            </div>
                             <group>
                                 <group>
                                     <field

--- a/l10n_it_delivery_note/wizard/delivery_note_create.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_create.py
@@ -115,6 +115,7 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
                 or self.partner_id.default_transport_method_id.id
                 or self.type_id.default_transport_method_id.id
             ),
+            "note": self.type_id.note,
         }
 
     def confirm(self):

--- a/l10n_it_delivery_note_base/models/stock_delivery_note_type.py
+++ b/l10n_it_delivery_note_base/models/stock_delivery_note_type.py
@@ -53,7 +53,7 @@ class StockDeliveryNoteType(models.Model):
     company_id = fields.Many2one(
         "res.company", string="Company", default=lambda self: self.env.company
     )
-    note = fields.Html(string="Internal note")
+    note = fields.Html(string="DN Notes")
 
     _sql_constraints = [
         (

--- a/l10n_it_delivery_note_rma/tests/delivery_note_common.py
+++ b/l10n_it_delivery_note_rma/tests/delivery_note_common.py
@@ -35,6 +35,23 @@ class StockDeliveryNoteCommon(TransactionCase):
     def setUp(self):
         super().setUp()
 
+        self.env.ref("l10n_it_delivery_note_base.delivery_note_type_ddt").write(
+            {
+                "default_transport_condition_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_condition_PF"
+                ),
+                "default_goods_appearance_id": self.env.ref(
+                    "l10n_it_delivery_note_base.goods_appearance_BAN"
+                ),
+                "default_transport_reason_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_reason_VEN"
+                ),
+                "default_transport_method_id": self.env.ref(
+                    "l10n_it_delivery_note_base.transport_method_MIT"
+                ),
+            }
+        )
+
         self.env.user.write(
             {
                 "groups_id": [


### PR DESCRIPTION
Come segnalato nella issue, il campo `contact` dei picking viene nascosto se il trasferimento è di tipo interno o consegna, ma viene richiesto quando se ne valida uno creato manualmente (inventory > transfers > create).
https://github.com/OCA/l10n-italy/issues/3597

Per cominciare propongo di lasciarlo sempre visibile e di impostare il partner della DN con il campo "contatto" del picking se non esiste un ordine di vendita collegato, ma si può discutere anche di soluzioni alternative.

Abbiamo anche pensato di aggiungere un campo nel picking correlato al partner della DN per mostrarlo anche nella vista embed della DN nella scheda del picking.

Abbiamo anche voluto correggere un altro comportamento indesiderato nei trasferimenti interni: una volta che si inserisce "contact" e si valida, nel report della DN viene stampato "shipping address" = indirizzo di WH2, ignorando completamente il campo "contact".
Con la modifica invece nel picking viene impostato automaticamente il campo "contact" con l'indirizzo preso dal magazzino della "Destination Location".