### PR TITLE
[14.0] FIX l10n_it_financial_statements_report: use landscape format for PDF

### DIFF
--- a/l10n_it_financial_statements_report/report/financial_statements_report.py
+++ b/l10n_it_financial_statements_report/report/financial_statements_report.py
@@ -253,3 +253,9 @@ class ReportFinancialStatementsReport(models.AbstractModel):
             }
         )
         return report_data
+
+
+class ReportFinancialStatementsReportPDF(models.AbstractModel):
+    _name = "report.l10n_it_financial_statements_report.report_pdf"
+    _description = "Financial Statements QWeb Report PDF"
+    _inherit = "report.l10n_it_financial_statements_report.report"

--- a/l10n_it_financial_statements_report/report/reports.xml
+++ b/l10n_it_financial_statements_report/report/reports.xml
@@ -5,6 +5,10 @@
         <field name="model">trial.balance.report.wizard</field>
         <field name="name">Financial Statements Report HTML</field>
         <field name="report_type">qweb-html</field>
+        <field
+            name="paperformat_id"
+            ref="l10n_it_account.l10n_it_account_a4_landscape"
+        />
         <field name="report_name">l10n_it_financial_statements_report.report</field>
         <field name="report_file">l10n_it_financial_statements_report.report</field>
     </record>
@@ -17,8 +21,8 @@
             name="paperformat_id"
             ref="l10n_it_account.l10n_it_account_a4_landscape"
         />
-        <field name="report_name">l10n_it_financial_statements_report.report</field>
-        <field name="report_file">l10n_it_financial_statements_report.report</field>
+        <field name="report_name">l10n_it_financial_statements_report.report_pdf</field>
+        <field name="report_file">l10n_it_financial_statements_report.report_pdf</field>
     </record>
 
     <record id="report_financial_statements_report_xlsx" model="ir.actions.report">

--- a/l10n_it_financial_statements_report/report/templates/financial_statements_report.xml
+++ b/l10n_it_financial_statements_report/report/templates/financial_statements_report.xml
@@ -22,6 +22,16 @@
         </t>
     </template>
 
+    <template id="report_pdf">
+        <t t-call="web.html_container">
+            <t t-call="account_financial_report.internal_layout">
+                <t
+                    t-call="l10n_it_financial_statements_report.financial_statements_report_base"
+                />
+            </t>
+        </t>
+    </template>
+
     <template id="financial_statements_report_base">
         <div class="page">
             <!-- Display title -->


### PR DESCRIPTION
Senza queste modifiche, il PDF ignora il formato impostato nel report e usa quello verticale