### PR TITLE
[14.0][FIX] l10n_it_declaration_of_intent: check declarations on invoices only

### DIFF
--- a/l10n_it_declaration_of_intent/models/account_move.py
+++ b/l10n_it_declaration_of_intent/models/account_move.py
@@ -81,7 +81,7 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         posted = super()._post(soft)
         # Check if there is enough available amount on declarations
-        for invoice in self:
+        for invoice in self.filtered(lambda m: m.is_invoice()):
             declarations = invoice.get_declarations()
             # If partner has no declarations, do nothing
             if not declarations:


### PR DESCRIPTION
Venivano controllare le dichiarazioni di intento anche per le `entry` (pagamenti).

Resolves: https://github.com/OCA/l10n-italy/issues/3586