### PR TITLE
[16.0] FIX l10n_it_account migration when table account_account_type does not exist

### DIFF
--- a/l10n_it_account/migrations/16.0.1.0.0/post-migrate_balance_sign.py
+++ b/l10n_it_account/migrations/16.0.1.0.0/post-migrate_balance_sign.py
@@ -4,17 +4,21 @@
 from openupgradelib import openupgrade
 
 
-def migrate(cr, installed_version):
+@openupgrade.migrate()
+def migrate(env, installed_version):
     # Assign the sign of the account type to the account
-    openupgrade.logged_query(
-        cr,
-        """
-UPDATE account_account
-SET
-    account_balance_sign = aat.account_balance_sign
-FROM
-    account_account_type aat
-WHERE
-    aat.id = account_account.user_type_id
-""",
-    )
+    if openupgrade.table_exists(env.cr, "account_account_type"):
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE account_account
+            SET
+                account_balance_sign = aat.account_balance_sign
+            FROM
+                account_account_type aat
+            WHERE
+                aat.id = account_account.user_type_id
+            """,
+        )
+    else:
+        env["account.account"].set_account_types_negative_sign()


### PR DESCRIPTION
vedi anche https://github.com/OCA/l10n-italy/commit/c4c3dc02531d26e6259b5b8d7d96f5a3579b997f#commitcomment-106983871