### PR TITLE
[16.0] [FIX] l10n_it_delivery_note: recipient/shipping address fixes

### DIFF
--- a/l10n_it_delivery_note/report/report_delivery_note.xml
+++ b/l10n_it_delivery_note/report/report_delivery_note.xml
@@ -54,18 +54,42 @@
                     <h4>
                         <strong>Delivery address:</strong>
                     </h4>
-                    <div
-                        t-field="doc.partner_shipping_id"
-                        t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
-                    />
-                    <p t-if="doc.partner_shipping_id.vat"><t
-                            t-esc="doc.company_id.country_id.vat_label or 'Tax ID'"
-                        />: <span t-field="doc.partner_shipping_id.vat" /></p>
+                    <t t-if="doc.partner_id.id == doc.partner_sender_id.id">
+                        <div
+                            t-field="doc.partner_shipping_id"
+                            t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
+                        />
+                        <p t-if="doc.partner_shipping_id.vat"><t
+                                t-esc="doc.company_id.country_id.vat_label or 'Tax ID'"
+                            />: <span t-field="doc.partner_shipping_id.vat" /></p>
+                    </t>
+                    <t t-if="doc.partner_id.id != doc.partner_sender_id.id">
+                        <t
+                            t-if="doc.partner_sender_id.id != doc.partner_shipping_id.id"
+                        >
+                            <div
+                                t-field="doc.partner_shipping_id"
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
+                            />
+                            <p t-if="doc.partner_shipping_id.vat"><t
+                                    t-esc="doc.company_id.country_id.vat_label or 'Tax ID'"
+                                />: <span t-field="doc.partner_shipping_id.vat" /></p>
+                        </t>
+                        <t t-else="">
+                            <div
+                                t-field="doc.partner_sender_id"
+                                t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
+                            />
+                            <p t-if="doc.partner_sender_id.vat"><t
+                                    t-esc="doc.company_id.country_id.vat_label or 'Tax ID'"
+                                />: <span t-field="doc.partner_sender_id.vat" /></p>
+                        </t>
+                    </t>
                 </t>
                 <t t-if="doc.picking_ids and doc.picking_ids[0].location_id.id">
                     <t t-set="information_block">
                         <h4>
-                            <strong>Warehouse:</strong>
+                            <strong>Shipping from:</strong>
                         </h4>
                         <p>
                             <t
@@ -81,7 +105,7 @@
                     <div
                         t-if="doc.type_code=='outgoing' and doc.picking_ids and doc.picking_ids[0].location_id.id"
                     >
-                        <strong>Warehouse:</strong>
+                        <strong>Shipping from:</strong>
                         <p>
                             <t
                                 t-esc="doc.get_location_address(doc.picking_ids[0].location_id.id)"

--- a/l10n_it_delivery_note/views/stock_picking.xml
+++ b/l10n_it_delivery_note/views/stock_picking.xml
@@ -25,7 +25,7 @@
                 >
                     <attribute
                         name="attrs"
-                    >{'required': [('picking_type_code', '!=', 'internal')], 'invisible': [('picking_type_code', '=', 'internal')]}</attribute>
+                    >{'required': [('picking_type_code', '!=', 'internal')]}</attribute>
                 </xpath>
                 <xpath
                     expr="//button[@name='%(stock.action_report_delivery)d']"
@@ -200,6 +200,11 @@
                                         <field
                                             name="delivery_note_partner_ref"
                                             attrs="{'invisible': [('delivery_note_type_code', '!=', 'incoming')],
+                                                       'readonly': [('delivery_note_readonly', '=', True)]}"
+                                        />
+                                        <field
+                                            name="delivery_note_partner_id"
+                                            attrs="{'required': [('delivery_note_exists', '=', True)],
                                                        'readonly': [('delivery_note_readonly', '=', True)]}"
                                         />
                                         <field


### PR DESCRIPTION
Come segnalato nella issue, il campo contact dei picking viene nascosto se il trasferimento è di tipo interno o consegna, ma viene richiesto quando se ne valida uno creato manualmente (inventory > transfers > create).
https://github.com/OCA/l10n-italy/issues/3597

Per cominciare propongo di lasciarlo sempre visibile e di impostare il partner della DN con il campo "contatto" del picking se non esiste un ordine di vendita collegato, ma si può discutere anche di soluzioni alternative.

Abbiamo anche pensato di aggiungere un campo nel picking correlato al partner della DN per mostrarlo anche nella vista embed della DN nella scheda del picking.

Abbiamo anche voluto correggere un altro comportamento indesiderato nei trasferimenti interni: una volta che si inserisce "contact" e si valida, nel report della DN viene stampato "shipping address" = indirizzo di WH2, ignorando completamente il campo "contact".
Con la modifica invece nel picking viene impostato automaticamente il campo "contact" con l'indirizzo preso dal magazzino della "Destination Location".