### PR TITLE
[12.0] [FIX] l10n_it_delivery_note: recipient/shipping address fixes

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -26,6 +26,9 @@ class StockPicking(models.Model):
     delivery_note_state = fields.Selection(string="DN State",
                                            related='delivery_note_id.state')
     delivery_note_partner_ref = fields.Char(related='delivery_note_id.partner_ref')
+    delivery_note_partner_id = fields.Many2one(
+        "res.partner", string="DN Customer", related="delivery_note_id.partner_id"
+    )
     delivery_note_partner_shipping_id = \
         fields.Many2one('res.partner',
                         related='delivery_note_id.partner_shipping_id')

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -27,7 +27,7 @@ class StockPicking(models.Model):
                                            related='delivery_note_id.state')
     delivery_note_partner_ref = fields.Char(related='delivery_note_id.partner_ref')
     delivery_note_partner_id = fields.Many2one(
-        "res.partner", string="DN Customer", related="delivery_note_id.partner_id"
+        "res.partner", string="Recipient", related="delivery_note_id.partner_id"
     )
     delivery_note_partner_shipping_id = \
         fields.Many2one('res.partner',

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -251,7 +251,9 @@ class StockPicking(models.Model):
         partners = self.get_partners()
         return self.env['stock.delivery.note'].create({
             'partner_sender_id': partners[0].id,
-            'partner_id': partners[1].id,
+            'partner_id': self.sale_id.partner_id.id
+            if self.sale_id.partner_id
+            else self.partner_id.id,
             'partner_shipping_id': partners[1].id
         })
 

--- a/l10n_it_delivery_note/report/report_delivery_note.xml
+++ b/l10n_it_delivery_note/report/report_delivery_note.xml
@@ -77,7 +77,7 @@
                     <div style="display:table-row;width:100%;">
                         <div class="well" style="display:table-cell;width:49%;padding:10px;vertical-align:top;">
                             <h4>
-                                <strong>Warehouse:</strong>
+                                <strong>Shipping from:</strong>
                             </h4>
                             <t t-foreach="doc.picking_ids" t-as="pick">
                                 <t t-if="location != pick.location_id.id">
@@ -121,7 +121,7 @@
 
                 <div>
                     <div t-if="doc.picking_type=='outgoing'">
-                        <strong>Warehouse:</strong>
+                        <strong>Shipping from:</strong>
                         <t t-foreach="doc.picking_ids" t-as="pick">
                             <p>
                                 <t t-esc="doc.get_location_address(pick.location_id.id)"/><br/>

--- a/l10n_it_delivery_note/views/stock_picking.xml
+++ b/l10n_it_delivery_note/views/stock_picking.xml
@@ -150,6 +150,10 @@
                                         <field name="delivery_note_partner_ref"
                                                attrs="{'invisible': [('delivery_note_type_code', '!=', 'incoming')],
                                                        'readonly': [('delivery_note_readonly', '=', True)]}" />
+                                        <field name="delivery_note_partner_id"
+                                               attrs="{'required': [('delivery_note_exists', '=', True)],
+                                                       'readonly': [('delivery_note_readonly', '=', True)]}"
+                                        />
                                         <field name="delivery_note_partner_shipping_id"
                                                attrs="{'required': [('delivery_note_exists', '=', True)],
                                                        'readonly': [('delivery_note_readonly', '=', True)]}" />

--- a/l10n_it_delivery_note/views/stock_picking.xml
+++ b/l10n_it_delivery_note/views/stock_picking.xml
@@ -16,8 +16,13 @@
                 <xpath expr="//form/sheet" position="before">
                     <field name="picking_type_code" invisible="True" />
                 </xpath>
-                <xpath expr="//form/sheet/group/group/field[@name='partner_id']" position="attributes">
-                    <attribute name="attrs">{'invisible': [('picking_type_code', '=', 'internal')]}</attribute>
+                <xpath
+                    expr="//form/sheet/group/group/field[@name='partner_id']"
+                    position="attributes"
+                >
+                    <attribute
+                        name="attrs"
+                    >{'required': [('picking_type_code', '!=', 'internal')]}</attribute>
                 </xpath>
                 <xpath expr="//button[@name='%(stock.action_report_delivery)d']" position="attributes">
                     <attribute name="attrs">{'invisible': ['|', ('state', '!=', 'done'), '&amp;', ('delivery_note_state', '!=', 'draft')]}</attribute>


### PR DESCRIPTION
Come segnalato nella issue, il campo contact dei picking viene nascosto se il trasferimento è di tipo interno o consegna, ma viene richiesto quando se ne valida uno creato manualmente (inventory > transfers > create).
https://github.com/OCA/l10n-italy/issues/3597

Per cominciare propongo di lasciarlo sempre visibile e di impostare il partner della DN con il campo "contatto" del picking se non esiste un ordine di vendita collegato, ma si può discutere anche di soluzioni alternative.

Abbiamo anche pensato di aggiungere un campo nel picking correlato al partner della DN per mostrarlo anche nella vista embed della DN nella scheda del picking.

Abbiamo anche voluto correggere un altro comportamento indesiderato nei trasferimenti interni: una volta che si inserisce "contact" e si valida, nel report della DN viene stampato "shipping address" = indirizzo di WH2, ignorando completamente il campo "contact".
Con la modifica invece nel picking viene impostato automaticamente il campo "contact" con l'indirizzo preso dal magazzino della "Destination Location".