### PR TITLE
[14.0][IMP] assets_management multicompany

### DIFF
--- a/assets_management/models/asset.py
+++ b/assets_management/models/asset.py
@@ -11,10 +11,11 @@ class Asset(models.Model):
     _description = "Assets"
     _inherit = ["mail.thread", "mail.activity.mixin", "portal.mixin"]
     _order = "purchase_date desc, name asc"
+    _check_company_auto = True
 
     @api.model
     def get_default_company_id(self):
-        return self.env.user.company_id
+        return self.env.company
 
     asset_accounting_info_ids = fields.One2many(
         "asset.accounting.info", "asset_id", string="Accounting Info"
@@ -24,6 +25,7 @@ class Asset(models.Model):
         "asset.category",
         required=True,
         string="Category",
+        check_company=True,
     )
 
     code = fields.Char(
@@ -37,6 +39,7 @@ class Asset(models.Model):
         required=True,
         string="Company",
         tracking=True,
+        readonly=True,
     )
 
     currency_id = fields.Many2one(
@@ -45,12 +48,17 @@ class Asset(models.Model):
         string="Currency",
     )
 
-    customer_id = fields.Many2one("res.partner", string="Customer")
+    customer_id = fields.Many2one(
+        "res.partner",
+        string="Customer",
+        check_company=True,
+    )
 
     depreciation_ids = fields.One2many(
         "asset.depreciation",
         "asset_id",
         string="Depreciations",
+        check_company=True,
     )
 
     name = fields.Char(
@@ -70,7 +78,11 @@ class Asset(models.Model):
         tracking=True,
     )
 
-    purchase_move_id = fields.Many2one("account.move", string="Purchase Move")
+    purchase_move_id = fields.Many2one(
+        "account.move",
+        string="Purchase Move",
+        check_company=True,
+    )
 
     sale_amount = fields.Monetary(
         string="Sale Value",
@@ -80,7 +92,11 @@ class Asset(models.Model):
 
     dismiss_date = fields.Date()
 
-    sale_move_id = fields.Many2one("account.move", string="Sale Move")
+    sale_move_id = fields.Many2one(
+        "account.move",
+        string="Sale Move",
+        check_company=True,
+    )
 
     sold = fields.Boolean(string="Sold")
     dismissed = fields.Boolean(string="Dismissed")
@@ -97,7 +113,11 @@ class Asset(models.Model):
         string="State",
     )
 
-    supplier_id = fields.Many2one("res.partner", string="Supplier")
+    supplier_id = fields.Many2one(
+        "res.partner",
+        string="Supplier",
+        check_company=True,
+    )
 
     supplier_ref = fields.Char(string="Supplier Ref.")
 
@@ -175,6 +195,7 @@ class Asset(models.Model):
     def onchange_company_currency(self):
         if self.company_id:
             self.currency_id = self.company_id.currency_id
+            self.category_id = False
 
     @api.onchange("purchase_amount")
     def onchange_purchase_amount(self):

--- a/assets_management/models/asset_category.py
+++ b/assets_management/models/asset_category.py
@@ -10,10 +10,11 @@ class AssetCategory(models.Model):
     _name = "asset.category"
     _description = "Asset Category"
     _order = "name"
+    _check_company_auto = True
 
     @api.model
     def get_default_company_id(self):
-        return self.env.user.company_id
+        return self.env.company
 
     @api.model
     def get_default_type_ids(self):
@@ -46,6 +47,7 @@ class AssetCategory(models.Model):
         "account.account",
         required=True,
         string="Asset Account",
+        check_company=True,
     )
 
     comment = fields.Text(
@@ -53,33 +55,42 @@ class AssetCategory(models.Model):
     )
 
     company_id = fields.Many2one(
-        "res.company", default=get_default_company_id, string="Company"
+        "res.company", default=get_default_company_id, readonly=True, string="Company"
     )
 
     depreciation_account_id = fields.Many2one(
         "account.account",
         required=True,
         string="Depreciation Account",
+        check_company=True,
     )
 
     fund_account_id = fields.Many2one(
         "account.account",
         required=True,
         string="Fund Account",
+        check_company=True,
     )
 
     gain_account_id = fields.Many2one(
         "account.account",
         required=True,
         string="Capital Gain Account",
+        check_company=True,
     )
 
-    journal_id = fields.Many2one("account.journal", required=True, string="Journal")
+    journal_id = fields.Many2one(
+        "account.journal",
+        required=True,
+        string="Journal",
+        check_company=True,
+    )
 
     loss_account_id = fields.Many2one(
         "account.account",
         required=True,
         string="Capital Loss Account",
+        check_company=True,
     )
 
     name = fields.Char(
@@ -97,6 +108,7 @@ class AssetCategory(models.Model):
     tag_ids = fields.Many2many(
         "asset.tag",
         string="Tag",
+        check_company=True,
     )
 
     type_ids = fields.One2many(
@@ -104,6 +116,7 @@ class AssetCategory(models.Model):
         "category_id",
         default=get_default_type_ids,
         string="Depreciation Types",
+        check_company=True,
     )
 
     def copy(self, default=None):

--- a/assets_management/models/asset_category_depreciation_type.py
+++ b/assets_management/models/asset_category_depreciation_type.py
@@ -8,6 +8,7 @@ from odoo import fields, models
 class AssetCategoryDepreciationType(models.Model):
     _name = "asset.category.depreciation.type"
     _description = "Asset Category - Depreciation Type"
+    _check_company_auto = True
 
     base_coeff = fields.Float(
         default=1,
@@ -21,6 +22,7 @@ class AssetCategoryDepreciationType(models.Model):
         readonly=True,
         required=True,
         string="Category",
+        check_company=True,
     )
 
     company_id = fields.Many2one(
@@ -31,12 +33,14 @@ class AssetCategoryDepreciationType(models.Model):
         "asset.depreciation.type",
         required=True,
         string="Type",
+        check_company=True,
     )
 
     mode_id = fields.Many2one(
         "asset.depreciation.mode",
         required=True,
         string="Dep Mode",
+        check_company=True,
     )
 
     percentage = fields.Float(string="Depreciation %")

--- a/assets_management/models/asset_depreciation.py
+++ b/assets_management/models/asset_depreciation.py
@@ -10,6 +10,7 @@ from odoo.tools import float_compare, float_is_zero
 class AssetDepreciation(models.Model):
     _name = "asset.depreciation"
     _description = "Assets Depreciations"
+    _check_company_auto = True
 
     amount_depreciable = fields.Monetary(string="Initial Depreciable Amount")
 
@@ -85,7 +86,11 @@ class AssetDepreciation(models.Model):
 
     date_start = fields.Date(string="Date Start")
 
-    dismiss_move_id = fields.Many2one("account.move", string="Dismiss Move")
+    dismiss_move_id = fields.Many2one(
+        "account.move",
+        string="Dismiss Move",
+        check_company=True,
+    )
 
     first_dep_nr = fields.Integer(
         default=1,
@@ -103,13 +108,17 @@ class AssetDepreciation(models.Model):
     )
 
     line_ids = fields.One2many(
-        "asset.depreciation.line", "depreciation_id", string="Lines"
+        "asset.depreciation.line",
+        "depreciation_id",
+        string="Lines",
+        check_company=True,
     )
 
     mode_id = fields.Many2one(
         "asset.depreciation.mode",
         required=True,
         string="Mode",
+        check_company=True,
     )
 
     percentage = fields.Float(string="Depreciation (%)")
@@ -134,7 +143,11 @@ class AssetDepreciation(models.Model):
         string="State",
     )
 
-    type_id = fields.Many2one("asset.depreciation.type", string="Depreciation Type")
+    type_id = fields.Many2one(
+        "asset.depreciation.type",
+        string="Depreciation Type",
+        check_company=True,
+    )
 
     zero_depreciation_until = fields.Date(string="Zero Depreciation Up To")
 

--- a/assets_management/models/asset_depreciation_line.py
+++ b/assets_management/models/asset_depreciation_line.py
@@ -10,13 +10,17 @@ class AssetDepreciationLine(models.Model):
     _name = "asset.depreciation.line"
     _description = "Assets Depreciations Lines"
     _order = "date asc, name asc"
+    _check_company_auto = True
 
     amount = fields.Monetary(
         string="Amount",
     )
 
     asset_accounting_info_ids = fields.One2many(
-        "asset.accounting.info", "dep_line_id", string="Accounting Info"
+        "asset.accounting.info",
+        "dep_line_id",
+        string="Accounting Info",
+        check_company=True,
     )
 
     asset_id = fields.Many2one(
@@ -63,7 +67,9 @@ class AssetDepreciationLine(models.Model):
     )
 
     depreciation_line_type_id = fields.Many2one(
-        "asset.depreciation.line.type", string="Depreciation Type"
+        "asset.depreciation.line.type",
+        string="Depreciation Type",
+        check_company=True,
     )
 
     depreciation_nr = fields.Integer(
@@ -84,7 +90,11 @@ class AssetDepreciationLine(models.Model):
         string="Force Dep. Num",
     )
 
-    move_id = fields.Many2one("account.move", string="Move")
+    move_id = fields.Many2one(
+        "account.move",
+        string="Move",
+        check_company=True,
+    )
 
     move_type = fields.Selection(
         [

--- a/assets_management/models/asset_depreciation_line_type.py
+++ b/assets_management/models/asset_depreciation_line_type.py
@@ -14,7 +14,7 @@ class DepLineType(models.Model):
 
     @api.model
     def get_default_company_id(self):
-        return self.env.user.company_id
+        return self.env.company
 
     code = fields.Char(string="Code")
 

--- a/assets_management/models/asset_depreciation_mode.py
+++ b/assets_management/models/asset_depreciation_mode.py
@@ -10,19 +10,23 @@ class AssetDepreciationMode(models.Model):
     _name = "asset.depreciation.mode"
     _description = "Asset Depreciation Mode"
     _order = "name"
+    _check_company_auto = True
 
     @api.model
     def get_default_company_id(self):
-        return self.env.user.company_id
+        return self.env.company
 
     company_id = fields.Many2one(
-        "res.company", default=get_default_company_id, string="Company"
+        "res.company", default=get_default_company_id, readonly=True, string="Company"
     )
 
     default = fields.Boolean(string="Default Mode")
 
     line_ids = fields.One2many(
-        "asset.depreciation.mode.line", "mode_id", string="Lines"
+        "asset.depreciation.mode.line",
+        "mode_id",
+        string="Lines",
+        check_company=True,
     )
 
     name = fields.Char(

--- a/assets_management/models/asset_depreciation_type.py
+++ b/assets_management/models/asset_depreciation_type.py
@@ -13,7 +13,7 @@ class AssetDepreciationType(models.Model):
 
     @api.model
     def get_default_company_id(self):
-        return self.env.user.company_id
+        return self.env.company
 
     company_id = fields.Many2one(
         "res.company", default=get_default_company_id, string="Company"

--- a/assets_management/models/asset_tag.py
+++ b/assets_management/models/asset_tag.py
@@ -11,10 +11,10 @@ class AssetTag(models.Model):
 
     @api.model
     def get_default_company_id(self):
-        return self.env.user.company_id
+        return self.env.company
 
     company_id = fields.Many2one(
-        "res.company", default=get_default_company_id, string="Company"
+        "res.company", default=get_default_company_id, readonly=True, string="Company"
     )
 
     name = fields.Char(string="Name", required=True)

--- a/assets_management/security/rules.xml
+++ b/assets_management/security/rules.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
-
     <record id="asset_multicompany_rule" model="ir.rule">
         <field name="name">Asset multi company rule</field>
         <field name="model_id" ref="model_asset_asset" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -15,7 +14,7 @@
         <field name="model_id" ref="model_asset_accounting_info" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -24,7 +23,7 @@
         <field name="model_id" ref="model_asset_category" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -33,7 +32,7 @@
         <field name="model_id" ref="model_asset_category_depreciation_type" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -42,7 +41,7 @@
         <field name="model_id" ref="model_asset_depreciation" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -51,7 +50,7 @@
         <field name="model_id" ref="model_asset_depreciation_line" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -60,7 +59,7 @@
         <field name="model_id" ref="model_asset_depreciation_line_type" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -69,7 +68,7 @@
         <field name="model_id" ref="model_asset_depreciation_mode" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -78,7 +77,7 @@
         <field name="model_id" ref="model_asset_depreciation_mode_line" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -87,7 +86,7 @@
         <field name="model_id" ref="model_asset_depreciation_type" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 
@@ -96,8 +95,7 @@
         <field name="model_id" ref="model_asset_tag" />
         <field name="global" eval="True" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
-
 </odoo>

--- a/assets_management/tests/__init__.py
+++ b/assets_management/tests/__init__.py
@@ -1,1 +1,3 @@
+from . import test_assets_common
 from . import test_assets_management
+from . import test_assets_multicompany

--- a/assets_management/tests/test_assets_common.py
+++ b/assets_management/tests/test_assets_common.py
@@ -1,0 +1,310 @@
+# Copyright 2021 Sergio Corato <https://github.com/sergiocorato>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests import new_test_user
+from odoo.tests.common import SavepointCase
+
+
+class TestAssets(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Companies
+        cls.company_1 = cls.env.ref("base.main_company")
+        cls.company_2 = cls.env["res.company"].create(
+            {
+                "name": "company 2",
+            }
+        )
+        # User
+        cls.user = new_test_user(
+            cls.env,
+            "user",
+            groups="base.group_multi_company,account.group_account_manager",
+            company_id=cls.company_1.id,
+            company_ids=[(6, 0, [cls.company_1.id, cls.company_2.id])],
+        )
+        # Asset depreciation types
+        cls.ad_type_civ_company_1 = cls.env.ref("assets_management.ad_type_civilistico")
+        cls.ad_type_fis_company_1 = cls.env.ref("assets_management.ad_type_fiscale")
+        cls.ad_type_civ_company_2 = cls.ad_type_civ_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+        cls.ad_type_fis_company_2 = cls.ad_type_fis_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+        # Asset depreciation modes
+        cls.ad_mode_mat_company_1 = cls.env.ref("assets_management.ad_mode_materiale")
+        cls.ad_mode_mat_company_2 = cls.ad_mode_mat_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+        # Account types (non companies related)
+        cls.data_account_type_current_assets = cls.env.ref(
+            "account.data_account_type_current_assets"
+        )
+        cls.data_account_type_current_liabilities = cls.env.ref(
+            "account.data_account_type_current_liabilities"
+        )
+        # Accounts
+        cls.asset_account_company_1 = cls.env["account.account"].search(
+            [
+                (
+                    "user_type_id",
+                    "=",
+                    cls.env.ref("account.data_account_type_fixed_assets").id,
+                ),
+                ("company_id", "=", cls.company_1.id),
+            ],
+            limit=1,
+        )
+        cls.asset_account_company_2 = cls.asset_account_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+
+        cls.depreciation_account_company_1 = cls.env["account.account"].search(
+            [
+                (
+                    "user_type_id",
+                    "=",
+                    cls.env.ref("account.data_account_type_expenses").id,
+                ),
+                ("company_id", "=", cls.company_1.id),
+            ],
+            limit=1,
+        )
+        cls.depreciation_account_company_2 = cls.depreciation_account_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+
+        cls.fund_account_company_1 = cls.env["account.account"].search(
+            [
+                (
+                    "user_type_id",
+                    "=",
+                    cls.env.ref("account.data_account_type_non_current_assets").id,
+                ),
+                ("company_id", "=", cls.company_1.id),
+            ],
+            limit=1,
+        )
+        cls.fund_account_company_2 = cls.fund_account_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+
+        cls.gain_account_company_1 = cls.env["account.account"].search(
+            [
+                (
+                    "user_type_id",
+                    "=",
+                    cls.env.ref("account.data_account_type_revenue").id,
+                ),
+                ("company_id", "=", cls.company_1.id),
+            ],
+            limit=1,
+        )
+        cls.gain_account_company_2 = cls.gain_account_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+
+        cls.loss_account_company_1 = cls.env["account.account"].search(
+            [
+                (
+                    "user_type_id",
+                    "=",
+                    cls.env.ref("account.data_account_type_expenses").id,
+                ),
+                ("company_id", "=", cls.company_1.id),
+            ],
+            limit=1,
+        )
+        cls.loss_account_company_2 = cls.loss_account_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+        # Journals
+        cls.journal_company_1 = cls.env["account.journal"].search(
+            [("type", "=", "general"), ("company_id", "=", cls.company_1.id)],
+            limit=1,
+        )
+        cls.journal_company_2 = cls.journal_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+        # Asset categories
+        cls.asset_category_1_company_1 = cls.env["asset.category"].create(
+            {
+                "name": "Asset category 1 Company 1",
+                "company_id": cls.company_1.id,
+                "asset_account_id": cls.asset_account_company_1.id,
+                "depreciation_account_id": cls.depreciation_account_company_1.id,
+                "fund_account_id": cls.fund_account_company_1.id,
+                "gain_account_id": cls.gain_account_company_1.id,
+                "journal_id": cls.journal_company_1.id,
+                "loss_account_id": cls.loss_account_company_1.id,
+                "type_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "depreciation_type_id": cls.ad_type_civ_company_1.id,
+                            "mode_id": cls.ad_mode_mat_company_1.id,
+                            "company_id": cls.company_1.id,
+                        },
+                    )
+                ],
+            }
+        )
+
+        cls.asset_category_1_company_2 = cls.env["asset.category"].create(
+            {
+                "name": "Asset category 1 Company 2",
+                "company_id": cls.company_2.id,
+                "asset_account_id": cls.asset_account_company_2.id,
+                "depreciation_account_id": cls.depreciation_account_company_2.id,
+                "fund_account_id": cls.fund_account_company_2.id,
+                "gain_account_id": cls.gain_account_company_2.id,
+                "journal_id": cls.journal_company_2.id,
+                "loss_account_id": cls.loss_account_company_2.id,
+                "type_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "depreciation_type_id": cls.ad_type_civ_company_2.id,
+                            "mode_id": cls.ad_mode_mat_company_2.id,
+                            "company_id": cls.company_2.id,
+                        },
+                    )
+                ],
+            }
+        )
+        # Tax accounts
+        cls.tax_account_company_1 = cls.env["account.account"].create(
+            {
+                "name": "Deductable tax",
+                "code": "DEDTAX",
+                "user_type_id": cls.data_account_type_current_assets.id,
+                "company_id": cls.company_1.id,
+            }
+        )
+        cls.tax_account_company_2 = cls.tax_account_company_1.copy(
+            {"company_id": cls.company_2.id}
+        )
+        # Taxes
+        cls.tax_22_partial_60 = cls.env["account.tax"].create(
+            {
+                "name": "22% deductable partial 60%",
+                "type_tax_use": "purchase",
+                "amount_type": "percent",
+                "amount": 22,
+                "invoice_repartition_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "factor_percent": 100,
+                            "repartition_type": "base",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "factor_percent": 60,
+                            "repartition_type": "tax",
+                            "account_id": cls.tax_account_company_1.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "factor_percent": 40,
+                            "repartition_type": "tax",
+                        },
+                    ),
+                ],
+                "refund_repartition_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "factor_percent": 100,
+                            "repartition_type": "base",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "factor_percent": 60,
+                            "repartition_type": "tax",
+                            "account_id": cls.tax_account_company_1.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "factor_percent": 40,
+                            "repartition_type": "tax",
+                        },
+                    ),
+                ],
+            }
+        )
+
+    def _create_asset(self, asset_date):
+        asset = self.env["asset.asset"].create(
+            {
+                "name": "Test asset",
+                "category_id": self.asset_category_1_company_1.id,
+                "company_id": self.env.ref("base.main_company").id,
+                "currency_id": self.env.ref("base.main_company").currency_id.id,
+                "purchase_amount": 1000.0,
+                "purchase_date": asset_date,
+            }
+        )
+        return asset
+
+    def _depreciate_asset(self, asset, date_dep):
+        wiz_vals = asset.with_context(
+            {"allow_reload_window": True}
+        ).launch_wizard_generate_depreciations()
+        wiz = (
+            self.env["wizard.asset.generate.depreciation"]
+            .with_context(wiz_vals["context"])
+            .create({"date_dep": date_dep})
+        )
+        wiz.do_generate()
+
+    def _create_purchase_invoice(self, invoice_date, tax_ids=False, amount=7000):
+        invoice_line_vals = {
+            "account_id": self.asset_category_1_company_1.asset_account_id.id,
+            "quantity": 1,
+            "price_unit": amount,
+        }
+        if tax_ids:
+            invoice_line_vals.update({"tax_ids": tax_ids})
+        purchase_invoice = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "invoice_date": invoice_date,
+                "partner_id": self.env.ref("base.partner_demo").id,
+                "journal_id": self.env["account.journal"]
+                .search(
+                    [
+                        ("type", "=", "purchase"),
+                    ],
+                    limit=1,
+                )
+                .id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        invoice_line_vals,
+                    )
+                ],
+            }
+        )
+        purchase_invoice.action_post()
+        self.assertEqual(purchase_invoice.state, "posted")
+        return purchase_invoice

--- a/assets_management/tests/test_assets_management.py
+++ b/assets_management/tests/test_assets_management.py
@@ -1,239 +1,18 @@
 # Copyright 2021 Sergio Corato <https://github.com/sergiocorato>
 # Copyright 2022 Simone Rubino - TAKOBI
+# Copyright 2023 Nextev Srl <odoo@nextev.it>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from datetime import date
 
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.fields import first
-from odoo.tests.common import SavepointCase
 from odoo.tools.date_utils import relativedelta
 
+from .test_assets_common import TestAssets
 
-class TestAssets(SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.data_account_type_current_assets = cls.env.ref(
-            "account.data_account_type_current_assets"
-        )
-        cls.data_account_type_current_liabilities = cls.env.ref(
-            "account.data_account_type_current_liabilities"
-        )
-        cls.asset_category_1 = cls.env["asset.category"].create(
-            {
-                "name": "Asset category 1",
-                "asset_account_id": cls.env["account.account"]
-                .search(
-                    [
-                        (
-                            "user_type_id",
-                            "=",
-                            cls.env.ref("account.data_account_type_fixed_assets").id,
-                        )
-                    ],
-                    limit=1,
-                )
-                .id,
-                "depreciation_account_id": cls.env["account.account"]
-                .search(
-                    [
-                        (
-                            "user_type_id",
-                            "=",
-                            cls.env.ref("account.data_account_type_expenses").id,
-                        )
-                    ],
-                    limit=1,
-                )
-                .id,
-                "fund_account_id": cls.env["account.account"]
-                .search(
-                    [
-                        (
-                            "user_type_id",
-                            "=",
-                            cls.env.ref(
-                                "account.data_account_type_non_current_assets"
-                            ).id,
-                        )
-                    ],
-                    limit=1,
-                )
-                .id,
-                "gain_account_id": cls.env["account.account"]
-                .search(
-                    [
-                        (
-                            "user_type_id",
-                            "=",
-                            cls.env.ref("account.data_account_type_revenue").id,
-                        )
-                    ],
-                    limit=1,
-                )
-                .id,
-                "journal_id": cls.env["account.journal"]
-                .search([("type", "=", "general")], limit=1)
-                .id,
-                "loss_account_id": cls.env["account.account"]
-                .search(
-                    [
-                        (
-                            "user_type_id",
-                            "=",
-                            cls.env.ref("account.data_account_type_expenses").id,
-                        )
-                    ],
-                    limit=1,
-                )
-                .id,
-                "type_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "depreciation_type_id": cls.env.ref(
-                                "assets_management.ad_type_civilistico"
-                            ).id,
-                            "mode_id": cls.env.ref(
-                                "assets_management.ad_mode_materiale"
-                            ).id,
-                        },
-                    )
-                ],
-            }
-        )
-        cls.tax_account = cls.env["account.account"].create(
-            {
-                "name": "Deductable tax",
-                "code": "DEDTAX",
-                "user_type_id": cls.env.ref(
-                    "account.data_account_type_current_assets"
-                ).id,
-            }
-        )
-        cls.tax_22_partial_60 = cls.env["account.tax"].create(
-            {
-                "name": "22% deductable partial 60%",
-                "type_tax_use": "purchase",
-                "amount_type": "percent",
-                "amount": 22,
-                "invoice_repartition_line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "factor_percent": 100,
-                            "repartition_type": "base",
-                        },
-                    ),
-                    (
-                        0,
-                        0,
-                        {
-                            "factor_percent": 60,
-                            "repartition_type": "tax",
-                            "account_id": cls.tax_account.id,
-                        },
-                    ),
-                    (
-                        0,
-                        0,
-                        {
-                            "factor_percent": 40,
-                            "repartition_type": "tax",
-                        },
-                    ),
-                ],
-                "refund_repartition_line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "factor_percent": 100,
-                            "repartition_type": "base",
-                        },
-                    ),
-                    (
-                        0,
-                        0,
-                        {
-                            "factor_percent": 60,
-                            "repartition_type": "tax",
-                            "account_id": cls.tax_account.id,
-                        },
-                    ),
-                    (
-                        0,
-                        0,
-                        {
-                            "factor_percent": 40,
-                            "repartition_type": "tax",
-                        },
-                    ),
-                ],
-            }
-        )
 
-    def _create_asset(self, asset_date):
-        asset = self.env["asset.asset"].create(
-            {
-                "name": "Test asset",
-                "category_id": self.asset_category_1.id,
-                "company_id": self.env.ref("base.main_company").id,
-                "currency_id": self.env.ref("base.main_company").currency_id.id,
-                "purchase_amount": 1000.0,
-                "purchase_date": asset_date,
-            }
-        )
-        return asset
-
-    def _depreciate_asset(self, asset, date_dep):
-        wiz_vals = asset.with_context(
-            {"allow_reload_window": True}
-        ).launch_wizard_generate_depreciations()
-        wiz = (
-            self.env["wizard.asset.generate.depreciation"]
-            .with_context(wiz_vals["context"])
-            .create({"date_dep": date_dep})
-        )
-        wiz.do_generate()
-
-    def _create_purchase_invoice(self, invoice_date, tax_ids=False, amount=7000):
-        invoice_line_vals = {
-            "account_id": self.asset_category_1.asset_account_id.id,
-            "quantity": 1,
-            "price_unit": amount,
-        }
-        if tax_ids:
-            invoice_line_vals.update({"tax_ids": tax_ids})
-        purchase_invoice = self.env["account.move"].create(
-            {
-                "move_type": "in_invoice",
-                "invoice_date": invoice_date,
-                "partner_id": self.env.ref("base.partner_demo").id,
-                "journal_id": self.env["account.journal"]
-                .search(
-                    [
-                        ("type", "=", "purchase"),
-                    ],
-                    limit=1,
-                )
-                .id,
-                "invoice_line_ids": [
-                    (
-                        0,
-                        0,
-                        invoice_line_vals,
-                    )
-                ],
-            }
-        )
-        purchase_invoice.action_post()
-        self.assertEqual(purchase_invoice.state, "posted")
-        return purchase_invoice
-
+class TestAssetsManagement(TestAssets):
     def test_00_create_asset_depreciate_and_sale(self):
         today = fields.Date.today()
         first_depreciation_date = today.replace(month=12, day=31) + relativedelta(
@@ -347,7 +126,7 @@ class TestAssets(SavepointCase):
         move_line_ids = wiz_vals["context"]["default_move_line_ids"][0][2]
         move_lines = self.env["account.move.line"].browse(move_line_ids)
         move_lines_to_do = move_lines.filtered(
-            lambda x: x.account_id == self.asset_category_1.asset_account_id
+            lambda x: x.account_id == self.asset_category_1_company_1.asset_account_id
         )
         wiz_vals["context"]["default_move_line_ids"] = [(6, 0, move_lines_to_do.ids)]
         wiz = (
@@ -356,7 +135,7 @@ class TestAssets(SavepointCase):
             .create(
                 {
                     "management_type": "create",
-                    "category_id": self.asset_category_1.id,
+                    "category_id": self.asset_category_1_company_1.id,
                     "name": "Test asset",
                 }
             )
@@ -421,7 +200,7 @@ class TestAssets(SavepointCase):
             sum(
                 line.debit
                 for line in purchase_invoice.line_ids
-                if line.account_id == self.asset_category_1.asset_account_id
+                if line.account_id == self.asset_category_1_company_1.asset_account_id
             ),
             7000 + (7000 * 0.22 * 0.4),
         )
@@ -429,7 +208,7 @@ class TestAssets(SavepointCase):
         move_line_ids = wiz_vals["context"]["default_move_line_ids"][0][2]
         move_lines = self.env["account.move.line"].browse(move_line_ids)
         move_lines_to_do = move_lines.filtered(
-            lambda x: x.account_id == self.asset_category_1.asset_account_id
+            lambda x: x.account_id == self.asset_category_1_company_1.asset_account_id
         )
         wiz_vals["context"]["default_move_line_ids"] = [(6, 0, move_lines_to_do.ids)]
         wiz = (
@@ -438,7 +217,7 @@ class TestAssets(SavepointCase):
             .create(
                 {
                     "management_type": "create",
-                    "category_id": self.asset_category_1.id,
+                    "category_id": self.asset_category_1_company_1.id,
                     "name": "Test asset",
                 }
             )
@@ -455,7 +234,7 @@ class TestAssets(SavepointCase):
         move_line_ids = wiz_vals["context"]["default_move_line_ids"][0][2]
         move_lines = self.env["account.move.line"].browse(move_line_ids)
         move_lines_to_do = move_lines.filtered(
-            lambda x: x.account_id == self.asset_category_1.asset_account_id
+            lambda x: x.account_id == self.asset_category_1_company_1.asset_account_id
         )
         wiz_vals["context"]["default_move_line_ids"] = [(6, 0, move_lines_to_do.ids)]
         wiz = (
@@ -464,7 +243,7 @@ class TestAssets(SavepointCase):
             .create(
                 {
                     "management_type": "create",
-                    "category_id": self.asset_category_1.id,
+                    "category_id": self.asset_category_1_company_1.id,
                     "name": "Test asset",
                 }
             )
@@ -508,7 +287,7 @@ class TestAssets(SavepointCase):
         move_line_ids = wiz_vals["context"]["default_move_line_ids"][0][2]
         move_lines = self.env["account.move.line"].browse(move_line_ids)
         move_lines_to_do = move_lines.filtered(
-            lambda x: x.account_id == self.asset_category_1.asset_account_id
+            lambda x: x.account_id == self.asset_category_1_company_1.asset_account_id
         )
         wiz_vals["context"]["default_move_line_ids"] = [(6, 0, move_lines_to_do.ids)]
         wiz = (
@@ -517,7 +296,7 @@ class TestAssets(SavepointCase):
             .create(
                 {
                     "management_type": "update",
-                    "category_id": self.asset_category_1.id,
+                    "category_id": self.asset_category_1_company_1.id,
                     "asset_id": asset.id,
                     "depreciation_type_ids": [(6, 0, civ_type.ids)],
                 }
@@ -553,7 +332,7 @@ class TestAssets(SavepointCase):
         move_line_ids = wiz_vals["context"]["default_move_line_ids"][0][2]
         move_lines = self.env["account.move.line"].browse(move_line_ids)
         move_lines_to_do = move_lines.filtered(
-            lambda x: x.account_id == self.asset_category_1.asset_account_id
+            lambda x: x.account_id == self.asset_category_1_company_1.asset_account_id
         )
         wiz_vals["context"]["default_move_line_ids"] = [(6, 0, move_lines_to_do.ids)]
         wiz = (
@@ -562,7 +341,7 @@ class TestAssets(SavepointCase):
             .create(
                 {
                     "management_type": "create",
-                    "category_id": self.asset_category_1.id,
+                    "category_id": self.asset_category_1_company_1.id,
                     "name": "Test asset",
                 }
             )
@@ -602,7 +381,7 @@ class TestAssets(SavepointCase):
         move_line_ids = wiz_vals["context"]["default_move_line_ids"][0][2]
         move_lines = self.env["account.move.line"].browse(move_line_ids)
         move_lines_to_do = move_lines.filtered(
-            lambda x: x.account_id == self.asset_category_1.asset_account_id
+            lambda x: x.account_id == self.asset_category_1_company_1.asset_account_id
         )
         wiz_vals["context"]["default_move_line_ids"] = [(6, 0, move_lines_to_do.ids)]
         wiz = (
@@ -611,7 +390,7 @@ class TestAssets(SavepointCase):
             .create(
                 {
                     "management_type": "update",
-                    "category_id": self.asset_category_1.id,
+                    "category_id": self.asset_category_1_company_1.id,
                     "asset_id": asset.id,
                     "depreciation_type_ids": [(6, 0, civ_type.ids)],
                 }

--- a/assets_management/tests/test_assets_multicompany.py
+++ b/assets_management/tests/test_assets_multicompany.py
@@ -1,0 +1,21 @@
+# Copyright 2023 Nextev Srl <odoo@nextev.it>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests.common import Form, users
+
+from .test_assets_common import TestAssets
+
+
+class TestAssetsMulticompany(TestAssets):
+    @users("user")
+    def test_00_create_depreciation_mode_multicompany(self):
+        """
+        It checks that you cannot change the default associated company upon
+        asset depreciation mode creation
+        """
+        mode_form = Form(self.env["asset.depreciation.mode"])
+        mode_form.name = "Move 1"
+        mode_form.save()
+        with self.assertRaises(
+            AssertionError, msg="can't write on readonly field company_id"
+        ):
+            mode_form.company_id = self.company_2

--- a/assets_management/views/asset.xml
+++ b/assets_management/views/asset.xml
@@ -87,7 +87,6 @@
                         <group>
                             <field
                                 name="company_id"
-                                attrs="{'readonly': [('state', '!=', 'non_depreciated')]}"
                                 groups="base.group_multi_company"
                             />
                             <field

--- a/assets_management/views/asset_category.xml
+++ b/assets_management/views/asset_category.xml
@@ -31,6 +31,7 @@
                             nolabel="1"
                         >
                             <tree editable="bottom">
+                                <field name="company_id" invisible="1" />
                                 <field name="category_id" invisible="1" />
                                 <field name="depreciation_type_id" />
                                 <field name="pro_rata_temporis" />

--- a/assets_management/wizard/account_move_manage_asset.py
+++ b/assets_management/wizard/account_move_manage_asset.py
@@ -10,22 +10,28 @@ from odoo.tools.float_utils import float_compare, float_is_zero
 class WizardAccountMoveManageAsset(models.TransientModel):
     _name = "wizard.account.move.manage.asset"
     _description = "Manage Assets from Account Moves"
+    _check_company_auto = True
 
     @api.model
     def get_default_company_id(self):
-        return self.env.user.company_id
+        return self.env.company
 
     @api.model
     def get_default_move_ids(self):
         return self._context.get("move_ids")
 
-    asset_id = fields.Many2one("asset.asset", string="Asset")
+    asset_id = fields.Many2one(
+        "asset.asset",
+        string="Asset",
+        check_company=True,
+    )
 
     asset_purchase_amount = fields.Monetary(string="Purchase Amount")
 
     category_id = fields.Many2one(
         "asset.category",
         string="Category",
+        check_company=True,
     )
 
     code = fields.Char(
@@ -35,6 +41,7 @@ class WizardAccountMoveManageAsset(models.TransientModel):
 
     company_id = fields.Many2one(
         "res.company",
+        readonly=True,
         default=get_default_company_id,
         string="Company",
     )
@@ -49,7 +56,9 @@ class WizardAccountMoveManageAsset(models.TransientModel):
     depreciated_fund_amount = fields.Monetary(string="Depreciated Fund Amount")
 
     depreciation_type_ids = fields.Many2many(
-        "asset.depreciation.type", string="Depreciation Types"
+        "asset.depreciation.type",
+        string="Depreciation Types",
+        check_company=True,
     )
 
     dismiss_date = fields.Date(
@@ -77,11 +86,13 @@ class WizardAccountMoveManageAsset(models.TransientModel):
         "account.move",
         default=get_default_move_ids,
         string="Moves",
+        check_company=True,
     )
 
     move_line_ids = fields.Many2many(
         "account.move.line",
         string="Move Lines",
+        check_company=True,
     )
 
     move_type = fields.Selection(

--- a/assets_management/wizard/account_move_manage_asset_view.xml
+++ b/assets_management/wizard/account_move_manage_asset_view.xml
@@ -76,7 +76,6 @@
                             <field name="purchase_date" />
                             <field
                                 name="company_id"
-                                readonly="1"
                                 options="{'no_open':1, 'no_create_edit': True}"
                                 groups="base.group_multi_company"
                             />
@@ -148,12 +147,7 @@
                                     options="{'no_open':1}"
                                     readonly="1"
                                 />
-                                <field
-                                    name="company_id"
-                                    options="{'no_open':1, 'no_create_edit': True}"
-                                    invisible="1"
-                                    readonly="1"
-                                />
+                                <field name="company_id" invisible="1" />
                                 <field
                                     name="account_id"
                                     options="{'no_open':1}"
@@ -163,12 +157,7 @@
                                 <field name="name" readonly="1" />
                                 <field name="debit" widget="monetary" readonly="1" />
                                 <field name="credit" widget="monetary" readonly="1" />
-                                <field
-                                    name="currency_id"
-                                    options="{'no_open':1}"
-                                    invisible="1"
-                                    readonly="1"
-                                />
+                                <field name="currency_id" invisible="1" />
                             </tree>
                         </field>
                     </group>

--- a/assets_management/wizard/asset_generate_depreciation.py
+++ b/assets_management/wizard/asset_generate_depreciation.py
@@ -8,15 +8,16 @@ from odoo import api, fields, models
 class WizardAssetsGenerateDepreciations(models.TransientModel):
     _name = "wizard.asset.generate.depreciation"
     _description = "Generate Asset Depreciations"
+    _check_company_auto = True
 
     @api.model
     def get_default_company_id(self):
-        return self.env.user.company_id
+        return self.env.company
 
     @api.model
     def get_default_date_dep(self):
         fiscal_year = self.env["account.fiscal.year"].get_fiscal_year_by_date(
-            fields.Date.today(), company=self.env.user.company_id, miss_raise=False
+            fields.Date.today(), company=self.env.company, miss_raise=False
         )
         if fiscal_year:
             return fiscal_year.date_to
@@ -29,17 +30,21 @@ class WizardAssetsGenerateDepreciations(models.TransientModel):
     asset_ids = fields.Many2many(
         "asset.asset",
         string="Assets",
+        check_company=True,
     )
 
     category_ids = fields.Many2many(
         "asset.category",
         string="Categories",
+        check_company=True,
     )
 
     company_id = fields.Many2one(
         "res.company",
         default=get_default_company_id,
         string="Company",
+        readonly=True,
+        check_company=True,
     )
 
     date_dep = fields.Date(
@@ -53,6 +58,7 @@ class WizardAssetsGenerateDepreciations(models.TransientModel):
         default=get_default_type_ids,
         required=True,
         string="Depreciation Types",
+        check_company=True,
     )
 
     def do_generate(self):

--- a/assets_management/wizard/asset_journal_report_view.xml
+++ b/assets_management/wizard/asset_journal_report_view.xml
@@ -9,24 +9,26 @@
                 <sheet>
                     <group name="filters" string="Filters">
                         <field name="date" />
-                        <field
-                            name="company_id"
-                            groups="base.group_multi_company"
-                            options="{'no_open':1, 'no_create_edit': True}"
-                        />
+                        <field name="company_id" groups="base.group_multi_company" />
                         <field
                             name="category_ids"
+                            domain="[('company_id', '=', company_id)]"
                             widget="many2many_tags"
-                            options="{'no_create_edit': True}"
+                            options="{'no_create': True, 'no_create_edit': True}"
                         />
                         <field
                             name="type_ids"
+                            domain="[('company_id', '=', company_id)]"
                             widget="many2many_tags"
-                            options="{'no_create_edit': True}"
+                            options="{'no_create': True, 'no_create_edit': True}"
                         />
                     </group>
                     <group name="assets" string="Assets">
-                        <field name="asset_ids" nolabel="1" />
+                        <field
+                            name="asset_ids"
+                            domain="[('company_id', '=', company_id)]"
+                            nolabel="1"
+                        />
                     </group>
                     <group name="print_options" string="Options">
                         <group>

--- a/assets_management/wizard/asset_previsional_report.py
+++ b/assets_management/wizard/asset_previsional_report.py
@@ -10,6 +10,7 @@ from odoo import api, fields, models
 class WizardAssetPrevisionalReport(models.TransientModel):
     _name = "wizard.asset.previsional.report"
     _description = "Wizard Asset Previsional Report"
+    _check_company_auto = True
 
     @api.model
     def get_asset_order_fname_selection(self):
@@ -26,11 +27,16 @@ class WizardAssetPrevisionalReport(models.TransientModel):
 
     @api.model
     def get_default_category_ids(self):
-        return self.env["asset.category"].search([("print_by_default", "=", True)])
+        return self.env["asset.category"].search(
+            [
+                ("print_by_default", "=", True),
+                ("company_id", "=", self.get_default_company_id().id),
+            ]
+        )
 
     @api.model
     def get_default_company_id(self):
-        return self.env.user.company_id
+        return self.env.company
 
     @api.model
     def get_default_date(self):
@@ -43,10 +49,17 @@ class WizardAssetPrevisionalReport(models.TransientModel):
     @api.model
     def get_default_type_ids(self):
         return self.env["asset.depreciation.type"].search(
-            [("print_by_default", "=", True)]
+            [
+                ("print_by_default", "=", True),
+                ("company_id", "=", self.get_default_company_id().id),
+            ]
         )
 
-    asset_ids = fields.Many2many("asset.asset", string="Assets")
+    asset_ids = fields.Many2many(
+        "asset.asset",
+        string="Assets",
+        check_company=True,
+    )
 
     asset_order_fname = fields.Selection(
         get_asset_order_fname_selection,
@@ -56,11 +69,18 @@ class WizardAssetPrevisionalReport(models.TransientModel):
     )
 
     category_ids = fields.Many2many(
-        "asset.category", default=get_default_category_ids, string="Categories"
+        "asset.category",
+        default=get_default_category_ids,
+        string="Categories",
+        check_company=True,
     )
 
     company_id = fields.Many2one(
-        "res.company", default=get_default_company_id, required=True, string="Company"
+        "res.company",
+        default=get_default_company_id,
+        readonly=True,
+        required=True,
+        string="Company",
     )
 
     date = fields.Date(
@@ -86,6 +106,7 @@ class WizardAssetPrevisionalReport(models.TransientModel):
         "asset.depreciation.type",
         default=get_default_type_ids,
         string="Depreciation Types",
+        check_company=True,
     )
 
     @api.onchange("category_ids", "company_id", "date", "type_ids")

--- a/assets_management/wizard/asset_previsional_report_view.xml
+++ b/assets_management/wizard/asset_previsional_report_view.xml
@@ -17,12 +17,12 @@
                         <field
                             name="category_ids"
                             widget="many2many_tags"
-                            options="{'no_create_edit': True}"
+                            options="{'no_create': True, 'no_create_edit': True}"
                         />
                         <field
                             name="type_ids"
                             widget="many2many_tags"
-                            options="{'no_create_edit': True}"
+                            options="{'no_create': True, 'no_create_edit': True}"
                         />
                     </group>
                     <group name="assets" string="Assets">


### PR DESCRIPTION
Questa PR serve per mostrare sia in lettura che in scrittura i record relativi alle company consentite all'utente (solo quelle selezionate nel menu in alto a destra).

Sono state quindi modificate tutte le regole di accesso dei modelli dei cespiti passando da:
`['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]` 
                                                     |
                                                    V
`['|',('company_id','=',False),('company_id','in',company_ids)]`

Ho aggiunto il reset dei campi legati alle aziende alla modifica del campo `company_id`.

Per completare ho aggiunto il seguente dominio nei campi legati alle aziende nelle viste:
`domain="[('company_id', '=', company_id)]"`


rif https://github.com/OCA/l10n-italy/issues/3651