### PR TITLE
[14.0] [FIX] l10n_it_ricevute_bancarie: multicompany

### DIFF
--- a/l10n_it_ricevute_bancarie/models/riba_config.py
+++ b/l10n_it_ricevute_bancarie/models/riba_config.py
@@ -13,6 +13,7 @@ class RibaConfiguration(models.Model):
 
     _name = "riba.configuration"
     _description = "Configuration parameters for Cash Orders"
+    _check_company_auto = True
 
     name = fields.Char("Description", size=64, required=True)
     type = fields.Selection(
@@ -24,17 +25,20 @@ class RibaConfiguration(models.Model):
         "res.partner.bank",
         "Bank Account",
         required=True,
+        check_company=True,
         help="Bank account used for C/O issuing.",
     )
     acceptance_journal_id = fields.Many2one(
         "account.journal",
         "Acceptance Journal",
-        domain=[("type", "=", "bank")],
+        check_company=True,
+        domain="[('company_id', '=', company_id), ('type', '=', 'bank')]",
         help="Journal used when C/O is accepted by the bank.",
     )
     acceptance_account_id = fields.Many2one(
         "account.account",
         "Acceptance Account",
+        check_company=True,
         help="Account used when C/O is accepted by the bank.",
     )
     company_id = fields.Many2one(
@@ -46,38 +50,46 @@ class RibaConfiguration(models.Model):
     accreditation_journal_id = fields.Many2one(
         "account.journal",
         "Credit Journal",
-        domain=[("type", "=", "bank")],
+        check_company=True,
+        domain="[('company_id', '=', company_id), ('type', '=', 'bank')]",
         help="Journal used when C/O amount is credited by the bank.",
     )
     accreditation_account_id = fields.Many2one(
         "account.account",
         "C/O Account",
+        check_company=True,
         help="Account used when C/O amount is credited by the bank.",
-        domain=[("internal_type", "!=", "liquidity")],
+        domain="[('company_id', '=', company_id), ('internal_type', '!=', 'liquidity')]",
     )
     bank_account_id = fields.Many2one(
         "account.account",
         "A/C Bank Account",
-        domain=[("internal_type", "=", "liquidity")],
+        check_company=True,
+        domain="[('company_id', '=', company_id), ('internal_type', '=', 'liquidity')]",
     )
     bank_expense_account_id = fields.Many2one("account.account", "Bank Fees Account")
     unsolved_journal_id = fields.Many2one(
         "account.journal",
         "Past Due Journal",
-        domain=[("type", "=", "bank")],
+        check_company=True,
+        domain="[('company_id', '=', company_id), ('type', '=', 'bank')]",
         help="Journal used when C/O is past due.",
     )
     overdue_effects_account_id = fields.Many2one(
         "account.account",
         "Past Due Bills Account",
-        domain=[("internal_type", "=", "receivable")],
+        check_company=True,
+        domain="[('company_id', '=', company_id), ('internal_type', '=', 'receivable')]",
     )
     protest_charge_account_id = fields.Many2one(
-        "account.account", "Protest Fee Account"
+        "account.account",
+        "Protest Fee Account",
+        check_company=True,
     )
     settlement_journal_id = fields.Many2one(
         "account.journal",
         "Settlement Journal",
+        check_company=True,
         help="Journal used when customers finally pay the invoice to bank.",
     )
 

--- a/l10n_it_ricevute_bancarie/tests/riba_common.py
+++ b/l10n_it_ricevute_bancarie/tests/riba_common.py
@@ -4,6 +4,11 @@ from odoo.tests import common
 class TestRibaCommon(common.TransactionCase):
     def setUp(self):
         super(TestRibaCommon, self).setUp()
+        self.company2 = self.env["res.company"].create(
+            {
+                "name": "company 2",
+            }
+        )
         self.service_due_cost = self._create_service_due_cost()
         self.account_model = self.env["account.account"]
         self.move_line_model = self.env["account.move.line"]
@@ -88,6 +93,13 @@ class TestRibaCommon(common.TransactionCase):
             }
         )
         self.company_bank = self.env.ref("l10n_it_ricevute_bancarie.company_bank")
+        self.company2_bank = self.env["res.partner.bank"].create(
+            {
+                "acc_number": "IT000000000000000000",
+                "partner_id": self.company2.partner_id.id,
+                "company_id": self.company2.id,
+            }
+        )
         self.riba_config = self.create_config()
         self.account_payment_term_riba = self.env.ref(
             "l10n_it_ricevute_bancarie.account_payment_term_riba"

--- a/l10n_it_ricevute_bancarie/tests/test_riba.py
+++ b/l10n_it_ricevute_bancarie/tests/test_riba.py
@@ -6,6 +6,7 @@
 import base64
 import os
 
+from odoo.exceptions import UserError
 from odoo.tools import config
 
 from . import riba_common
@@ -536,3 +537,16 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
             self.env["account.move.line"].search(domain).mapped("amount_residual")
         )
         self.assertTrue(total_amount - total_issue_amount >= 0)
+
+    def test_riba_bank_multicompany(self):
+        with self.assertRaises(UserError) as ue:
+            self.env["riba.configuration"].create(
+                {
+                    "name": "Subject To Collection",
+                    "type": "incasso",
+                    "bank_id": self.company2_bank.id,
+                }
+            )
+        exc_message = ue.exception.args[0]
+        self.assertIn(self.env.company.name, exc_message)
+        self.assertIn(self.company2_bank.acc_number, exc_message)

--- a/l10n_it_ricevute_bancarie/views/configuration_view.xml
+++ b/l10n_it_ricevute_bancarie/views/configuration_view.xml
@@ -55,6 +55,20 @@
     </record>
 
     <!-- ====================================================== -->
+    <!-- 				CONFIGURAZIONE RIBA TREE 				-->
+    <!-- ====================================================== -->
+    <record model="ir.ui.view" id="view_riba_configuration_tree">
+        <field name="name">riba.configuration.tree</field>
+        <field name="model">riba.configuration</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="company_id" groups="base.group_multi_company" />
+            </tree>
+        </field>
+    </record>
+
+    <!-- ====================================================== -->
     <!-- 				CONFIGURAZIONE RIBA ACTION				-->
     <!-- ====================================================== -->
     <record id="action_riba_configuration" model="ir.actions.act_window">


### PR DESCRIPTION
Questa PR serve per impostare automaticamente l'azienda alla creazione di una configurazione Ri.Ba e mostrare solo i conti di quell'azienda.
In questo modo si evita che un utente che può accedere a più aziende faccia confusione creando configurazioni con l'azienda a cui non è collegato in quel momento ed imposti conti non appartenenti solo a quest'azienda.