### PR TITLE
[14.0] [IMP] l10n_it_ricevute_bancarie: aggiunto numero fattura nelle account move line create da Ri.Ba

### DIFF
--- a/l10n_it_ricevute_bancarie/models/riba.py
+++ b/l10n_it_ricevute_bancarie/models/riba.py
@@ -374,8 +374,8 @@ class RibaListLine(models.Model):
             total_credit = 0.0
             move = move_model.create(
                 {
-                    "ref": "C/O {} - Line {}".format(
-                        line.distinta_id.name, line.sequence
+                    "ref": "{} C/O {} - Line {}".format(
+                        line.invoice_number, line.distinta_id.name, line.sequence
                     ),
                     "journal_id": journal.id,
                     "date": line.distinta_id.registration_date,
@@ -423,8 +423,9 @@ class RibaListLine(models.Model):
                 to_be_reconciled |= riba_move_line.move_line_id
             move_line_model.with_context({"check_move_validity": False}).create(
                 {
-                    "name": "C/O %s-%s Ref. %s - %s"
+                    "name": "%s C/O %s-%s Ref. %s - %s"
                     % (
+                        line.invoice_number,
                         line.distinta_id.name,
                         line.sequence,
                         riba_move_line_name,


### PR DESCRIPTION
Viene aggiunto il numero delle fatture al riferimento distinta nella descrizione delle `account.move.line` generate da Ri.ba.
Questo dato è utile nei seguenti casi:
1. quando è presente l'insoluto
2. quando una riba è presentata ed ancora non scaduta

![image](https://github.com/OCA/l10n-italy/assets/93990941/81dc7ab7-41b3-4964-9f99-45efa5bf61e7)
![image](https://github.com/OCA/l10n-italy/assets/93990941/641f962a-9d8c-4a63-a829-9aa80f91a6d4)

#3657