### PR TITLE
[REF] I test non devono essere importati

### DIFF
--- a/l10n_it_bill_of_entry/__init__.py
+++ b/l10n_it_bill_of_entry/__init__.py
@@ -1,4 +1,3 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
-from . import tests


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/3628 per `14.0`.