### PR TITLE
[14.0]Aggiunta colonna Ref a report Libro Giornale su Reportlab

### DIFF
--- a/l10n_it_central_journal_reportlab/wizard/print_giornale.py
+++ b/l10n_it_central_journal_reportlab/wizard/print_giornale.py
@@ -195,9 +195,6 @@ class WizardGiornaleReportlab(models.TransientModel):
         move_line_ids = flatten(res)
         return move_line_ids
 
-    def _get_move_name_reportlab(self, line):
-        return " - ".join(filter(None, [line.move_id.ref, line.move_id.name]))
-
     def _get_account_name_reportlab(self, line):
         return " - ".join(filter(None, [line.account_id.code, line.account_id.name]))
 
@@ -270,7 +267,7 @@ class WizardGiornaleReportlab(models.TransientModel):
         }
 
     def get_colwidths_report_giornale(self, width_available):
-        colwidths = [32, 35, 130, 130, 130, 50, 50]
+        colwidths = [32, 40, 50, 120, 130, 100, 50, 50]
         total = sum(colwidths)
         return [c / total * width_available for c in colwidths]
 
@@ -284,7 +281,8 @@ class WizardGiornaleReportlab(models.TransientModel):
             [
                 Paragraph(_("Row"), style_header),
                 Paragraph(_("Date"), style_header),
-                Paragraph(_("Account Move"), style_header),
+                Paragraph(_("Ref"), style_header),
+                Paragraph(_("Number"), style_header),
                 Paragraph(_("Account"), style_header),
                 Paragraph(_("Name"), style_header),
                 Paragraph(_("Debit"), style_header_number),
@@ -299,6 +297,7 @@ class WizardGiornaleReportlab(models.TransientModel):
 
         initial_balance_data = [
             [
+                "",
                 "",
                 "",
                 "",
@@ -386,7 +385,8 @@ class WizardGiornaleReportlab(models.TransientModel):
             start_row += 1
             row = Paragraph(str(start_row), style_name)
             date = Paragraph(format_date(self.env, line.date), style_name)
-            move_name = self._get_move_name_reportlab(line)
+            ref = Paragraph(str(line.ref or ""), style_name)
+            move_name = line.move_id.name or ""
             move = Paragraph(move_name, style_name)
             account_name = self._get_account_name_reportlab(line)
             account = Paragraph(account_name, style_name)
@@ -397,7 +397,7 @@ class WizardGiornaleReportlab(models.TransientModel):
             debit = Paragraph(formatLang(self.env, line.debit), style_number)
             credit = Paragraph(formatLang(self.env, line.credit), style_number)
             list_balance.append((line.debit, line.credit))
-            line_data = [[row, date, move, account, name, debit, credit]]
+            line_data = [[row, date, ref, move, account, name, debit, credit]]
             if previous_move_name != move_name:
                 previous_move_name = move_name
                 tables.append(
@@ -418,6 +418,7 @@ class WizardGiornaleReportlab(models.TransientModel):
 
         balance_data = [
             [
+                "",
                 "",
                 "",
                 "",


### PR DESCRIPTION
Issue: #3631 

Aggiunta colonna Ref a report Libro Giornale su Reportlab, è stato necessario cambiare i rapporti di spaziatura delle altre colonne.

E' stata rimossa la funzione per la concatenazione del Riferimento a Movimento Contabile.

Sarà necessaria traduzione per campo chiamato 'Number' a 'Numero' e 'Ref' a 'Rif'.
