### PR TITLE
[16.0][FIX] l10n_it_fatturapa_in: link to existing supplier bills with

### DIFF
--- a/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.xml
+++ b/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.xml
@@ -7,25 +7,23 @@
         <field name="arch" type="xml">
             <form string="Link to existing supplier bills">
                 <sheet>
-                    <group>
-                        <field name="line_ids" nolabel="1">
-                            <tree editable="top" create="false">
-                                <field name="wizard_id" invisible="True" />
-                                <field name="e_invoice_descr" />
-                                <field
-                                    name="invoice_id"
-                                    domain="[
-                                              ('move_type', 'in', ('in_invoice', 'in_refund')),
-                                              ('state', '!=', 'cancel'),
-                                              ('fatturapa_attachment_in_id', '=', False)]"
-                                    context="{
-                                               'form_view_ref': 'account.view_move_form',
-                                               'tree_view_ref': 'account.view_move_tree'}"
-                                    options="{'no_create': True}"
-                                />
-                            </tree>
-                        </field>
-                    </group>
+                    <field name="line_ids" nolabel="1">
+                        <tree editable="top" create="false">
+                            <field name="wizard_id" invisible="True" />
+                            <field name="e_invoice_descr" />
+                            <field
+                                name="invoice_id"
+                                domain="[
+                                          ('move_type', 'in', ('in_invoice', 'in_refund')),
+                                          ('state', '!=', 'cancel'),
+                                          ('fatturapa_attachment_in_id', '=', False)]"
+                                context="{
+                                           'form_view_ref': 'account.view_move_form',
+                                           'tree_view_ref': 'account.view_move_tree'}"
+                                options="{'no_create': True}"
+                            />
+                        </tree>
+                    </field>
                 </sheet>
                 <footer>
                     <button special="cancel" string="Cancel" />


### PR DESCRIPTION
Superseeds https://github.com/OCA/l10n-italy/pull/3607

Remove `group` tag from view which causes fields one2many to have a broken width. See https://github.com/OCA/l10n-italy/issues/3646