### PR TITLE
[14.0] [FIX] l10n_it_declaration_of_intent: controllo dichiarazione solo se tipo fattura

### DIFF
--- a/l10n_it_declaration_of_intent/tests/test_declaration_of_intent.py
+++ b/l10n_it_declaration_of_intent/tests/test_declaration_of_intent.py
@@ -476,3 +476,29 @@ class TestDeclarationOfIntent(AccountTestInvoicingCommon):
         )
         self.assertEqual(declaration_model.search([]), declaration)
         self.assertEqual(self.env.company, declaration.company_id)
+
+    def test_action_register_payment(self):
+        """
+        Check register payment from action in invoice.
+        """
+        partner = self.partner1
+        partner.property_account_position_id = self.fiscal_position.id
+
+        out_invoice = self._create_invoice(
+            "test_out_invoice_registr_payment", partner, tax=self.tax1, in_type=False
+        )
+        self.assertEqual(out_invoice.move_type, "out_invoice")
+        out_invoice.action_post()
+
+        result = out_invoice.action_register_payment()
+        wizard = Form(
+            self.env[(result.get("res_model"))].with_context(**result["context"])
+        ).save()
+        self.assertEqual(wizard._name, "account.payment.register")
+        action = wizard.action_create_payments()
+        if action.get("res_id", False):
+            payments = [action["res_id"]]
+            self.assertTrue(len(payments) == 1)
+        else:
+            payments = action["domain"][0][2]
+            self.assertTrue(len(payments) > 1)


### PR DESCRIPTION
Added new test for register payment from action in invoice

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing