### PR TITLE
[16.0][FIX] l10n_it_fatturapa_out: fix account view related documents…

### DIFF
--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -46,21 +46,19 @@
                     string="Related Documents"
                     attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}"
                 >
-                    <group string="Related Documents">
-                        <field name="related_documents" nolabel="1">
-                            <tree editable="bottom">
-                                <field name="type" />
-                                <field name="name" />
-                                <field name="lineRef" readonly="1" />
-                                <field name="date" />
-                                <field name="numitem" />
-                                <field name="code" />
-                                <field name="cig" />
-                                <field name="cup" />
-                                <field name="invoice_id" invisible="1" />
-                            </tree>
-                        </field>
-                    </group>
+                    <field name="related_documents" nolabel="1">
+                        <tree editable="bottom">
+                            <field name="type" />
+                            <field name="name" />
+                            <field name="lineRef" readonly="1" />
+                            <field name="date" />
+                            <field name="numitem" />
+                            <field name="code" />
+                            <field name="cig" />
+                            <field name="cup" />
+                            <field name="invoice_id" invisible="1" />
+                        </tree>
+                    </field>
                 </page>
                 <page
                     string="Electronic Invoice"


### PR DESCRIPTION
… width

Remove `group` tag from view which causes fields one2many to have a broken width. See #3646

This commit will also fix #3490 as it's related to same issue.