### PR TITLE
[16.0][FIX] l10n_it_fatturapa_out: fix account view attachments width

### DIFF
--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -82,28 +82,26 @@
                     attrs="{'invisible': [('electronic_invoice_subjected', '=', False),
                                           ('fatturapa_attachment_out_id', '=', False)]}"
                 >
-                    <group string="Attachments">
-                        <field name="fatturapa_doc_attachments" nolabel="1">
-                            <tree>
-                                <field name="ir_attachment_id" />
-                                <field name="name" />
-                                <field name="description" />
-                                <field name="is_pdf_invoice_print" />
-                            </tree>
-                            <form string="Attachments">
+                    <field name="fatturapa_doc_attachments" nolabel="1">
+                        <tree>
+                            <field name="ir_attachment_id" />
+                            <field name="name" />
+                            <field name="description" />
+                            <field name="is_pdf_invoice_print" />
+                        </tree>
+                        <form string="Attachments">
+                            <group>
                                 <group>
-                                    <group>
-                                        <field name="description" />
-                                        <field name="is_pdf_invoice_print" />
-                                    </group>
-                                    <group>
-                                        <field name="datas" filename="name" />
-                                        <field name="name" />
-                                    </group>
+                                    <field name="description" />
+                                    <field name="is_pdf_invoice_print" />
                                 </group>
-                            </form>
-                        </field>
-                    </group>
+                                <group>
+                                    <field name="datas" filename="name" />
+                                    <field name="name" />
+                                </group>
+                            </group>
+                        </form>
+                    </field>
                 </page>
             </xpath>
         </field>


### PR DESCRIPTION
Remove `group` tag from view which causes fields one2many to have a broken width. See #3646

This commit will also fix #3490 as it's related to same issue.