### PR TITLE
[14.0][IMP] l10n_it_financial_statements_report: add company header

### DIFF
--- a/l10n_it_financial_statements_report/readme/USAGE.rst
+++ b/l10n_it_financial_statements_report/readme/USAGE.rst
@@ -1,4 +1,25 @@
-From your Accounting / Report section, select "Financial Statements Report".
+**Italiano**
+
+Operazioni preliminari:
+1. Attivare modalità sviluppatore
+2. Andare in Impostazioni -> Utenti e aziende -> Gruppi
+3. Selezionare "Funzioni tecniche / Mostrare funzionalità contabili complete"
+4. Aggiungere al gruppo gli utenti che devono stampare il bilancio
+
+Ora dalla sezione Contabilità -> Rendicontazione è possibile selezionare "Stampa Bilancio Contabile".
+
+Si attiverà una procedura guidata dalla quale potrai impostare la configurazione del tuo report.
+Qui è possibile scegliere se creare una vista interattiva HTML o un foglio PDF/XLS.
+
+**English**
+
+Preliminary operations:
+1. Enable developer mode
+2. Go to Settings -> Users & Companies -> Groups
+3. Select "Technical / Show full accounting features"
+4. Add the users who need to print financial statements report to the group
+
+Now from Accounting -> Report section you can select "Financial Statements Report".
 
 This will trigger a wizard, from which you can setup your report configuration.
-From it, you can choose whether should be created, either an HTML interactive view, or a PDF / XLS sheet.
+From it, you can choose whether should be created, either an HTML interactive view, or a PDF/XLS sheet.

--- a/l10n_it_financial_statements_report/report/templates/financial_statements_report.xml
+++ b/l10n_it_financial_statements_report/report/templates/financial_statements_report.xml
@@ -13,10 +13,13 @@
     <template id="report">
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
-                <t t-call="account_financial_report.internal_layout">
-                    <t
-                        t-call="l10n_it_financial_statements_report.financial_statements_report_base"
-                    />
+                <t t-set="company" t-value="o.company_id" />
+                <t t-call="web.external_layout">
+                    <t t-call="account_financial_report.internal_layout">
+                        <t
+                            t-call="l10n_it_financial_statements_report.financial_statements_report_base"
+                        />
+                    </t>
                 </t>
             </t>
         </t>


### PR DESCRIPTION
Attualmente i report PDF dei bilanci di questo modulo non hanno riferimenti all'azienda a cui si riferiscono i dati ed in ambito multiazienda è un problema.

Per questo motivo ho aggiunto l'intestazione standard al template.

https://github.com/OCA/l10n-italy/issues/3660