### PR TITLE
[16.0] [IMP] l10n_it_ricevute_bancarie: aggiunto numero fattura nelle account move line create da Ri.Ba

### DIFF
--- a/l10n_it_riba/models/riba.py
+++ b/l10n_it_riba/models/riba.py
@@ -367,7 +367,9 @@ class RibaListLine(models.Model):
             total_credit = 0.0
             move = move_model.create(
                 {
-                    "ref": "RiBa {} - Line {}".format(line.slip_id.name, line.sequence),
+                    "ref": "{} RiBa {} - Line {}".format(
+                        line.invoice_number, line.slip_id.name, line.sequence
+                    ),
                     "journal_id": journal.id,
                     "date": line.slip_id.registration_date,
                 }
@@ -414,8 +416,9 @@ class RibaListLine(models.Model):
                 to_be_reconciled |= riba_move_line.move_line_id
             move_line_model.with_context(check_move_validity=False).create(
                 {
-                    "name": "RiBa %s-%s Ref. %s - %s"
+                    "name": "%s RiBa %s-%s Ref. %s - %s"
                     % (
+                        line.invoice_number,
                         line.slip_id.name,
                         line.sequence,
                         riba_move_line_name,


### PR DESCRIPTION
Viene aggiunto il numero delle fatture al riferimento distinta nella descrizione delle account.move.line generate da Ri.ba.
Questo dato è utile nei seguenti casi:

1. quando è presente l'insoluto
2. quando una riba è presentata ed ancora non scaduta

![image](https://github.com/OCA/l10n-italy/assets/93990941/a2b9101e-e260-4800-bafe-9cbdbccc4be9)

https://github.com/OCA/l10n-italy/issues/3657