### PR TITLE
[16.0][IMP] l10n_it_financial_statements_report: add company header

### DIFF
--- a/l10n_it_financial_statements_report/README.rst
+++ b/l10n_it_financial_statements_report/README.rst
@@ -58,12 +58,39 @@ l10n_it_account_balance_report is present, it replaces it.
 Usage
 =====
 
-From your Accounting / Report section, select "Financial Statements
-Report".
+**Italiano**
+
+Operazioni preliminari:
+
+1. Attivare modalità sviluppatore
+2. Andare in Impostazioni -> Utenti e aziende -> Gruppi
+3. Selezionare "Funzioni tecniche / Mostrare funzionalità contabili
+   complete"
+4. Aggiungere al gruppo gli utenti che devono stampare il bilancio
+
+Ora dalla sezione Contabilità -> Rendicontazione è possibile selezionare
+"Stampa Bilancio Contabile".
+
+Si attiverà una procedura guidata dalla quale potrai impostare la
+configurazione del tuo report. Qui è possibile scegliere se creare una
+vista interattiva HTML o un foglio PDF/XLS.
+
+**English**
+
+Preliminary operations:
+
+1. Enable developer mode
+2. Go to Settings -> Users & Companies -> Groups
+3. Select "Technical / Show full accounting features"
+4. Add the users who need to print financial statements report to the
+   group
+
+Now from Accounting -> Report section you can select "Financial
+Statements Report".
 
 This will trigger a wizard, from which you can setup your report
 configuration. From it, you can choose whether should be created, either
-an HTML interactive view, or a PDF / XLS sheet.
+an HTML interactive view, or a PDF/XLS sheet.
 
 Bug Tracker
 ===========
@@ -86,22 +113,22 @@ Authors
 Contributors
 ------------
 
-- Silvio Gregorini <https://github.com/SilvioGregorini>
-- `Ooops <https://www.ooops404.com>`__
-- `TAKOBI <https://takobi.online>`__:
+-  Silvio Gregorini <https://github.com/SilvioGregorini>
+-  `Ooops <https://www.ooops404.com>`__
+-  `TAKOBI <https://takobi.online>`__:
 
-  - Simone Rubino <sir@takobi.online>
+   -  Simone Rubino <sir@takobi.online>
 
-- `Aion Tech <https://aiontech.company/>`__:
+-  `Aion Tech <https://aiontech.company/>`__:
 
-  - Simone Rubino <simone.rubino@aion-tech.it>
+   -  Simone Rubino <simone.rubino@aion-tech.it>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
-- Odoo Italia Network
+-  Odoo Italia Network
 
 Maintainers
 -----------

--- a/l10n_it_financial_statements_report/readme/USAGE.md
+++ b/l10n_it_financial_statements_report/readme/USAGE.md
@@ -1,6 +1,25 @@
-From your Accounting / Report section, select "Financial Statements
-Report".
+**Italiano**
 
-This will trigger a wizard, from which you can setup your report
-configuration. From it, you can choose whether should be created, either
-an HTML interactive view, or a PDF / XLS sheet.
+Operazioni preliminari:
+1. Attivare modalità sviluppatore
+2. Andare in Impostazioni -> Utenti e aziende -> Gruppi
+3. Selezionare "Funzioni tecniche / Mostrare funzionalità contabili complete"
+4. Aggiungere al gruppo gli utenti che devono stampare il bilancio
+
+Ora dalla sezione Contabilità -> Rendicontazione è possibile selezionare "Stampa Bilancio Contabile".
+
+Si attiverà una procedura guidata dalla quale potrai impostare la configurazione del tuo report.
+Qui è possibile scegliere se creare una vista interattiva HTML o un foglio PDF/XLS.
+
+**English**
+
+Preliminary operations:
+1. Enable developer mode
+2. Go to Settings -> Users & Companies -> Groups
+3. Select "Technical / Show full accounting features"
+4. Add the users who need to print financial statements report to the group
+
+Now from Accounting -> Report section you can select "Financial Statements Report".
+
+This will trigger a wizard, from which you can setup your report configuration.
+From it, you can choose whether should be created, either an HTML interactive view, or a PDF/XLS sheet.

--- a/l10n_it_financial_statements_report/report/templates/financial_statements_report.xml
+++ b/l10n_it_financial_statements_report/report/templates/financial_statements_report.xml
@@ -17,7 +17,12 @@
     <template id="report">
         <t t-call="web.html_container">
             <t t-foreach="docs" t-as="o">
-                <t t-call="account_financial_report.internal_layout">
+                <t t-call="web.external_layout">
+                    <t t-set="company" t-value="o.company_id" />
+                    <link
+                        href="/account_financial_report/static/src/css/report.css"
+                        rel="stylesheet"
+                    />
                     <t
                         t-call="l10n_it_financial_statements_report.financial_statements_report_base"
                     />

--- a/l10n_it_financial_statements_report/static/description/index.html
+++ b/l10n_it_financial_statements_report/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -401,11 +400,34 @@ l10n_it_account_balance_report is present, it replaces it.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
-<p>From your Accounting / Report section, select “Financial Statements
-Report”.</p>
+<p><strong>Italiano</strong></p>
+<p>Operazioni preliminari:</p>
+<ol class="arabic simple">
+<li>Attivare modalità sviluppatore</li>
+<li>Andare in Impostazioni -&gt; Utenti e aziende -&gt; Gruppi</li>
+<li>Selezionare “Funzioni tecniche / Mostrare funzionalità contabili
+complete”</li>
+<li>Aggiungere al gruppo gli utenti che devono stampare il bilancio</li>
+</ol>
+<p>Ora dalla sezione Contabilità -&gt; Rendicontazione è possibile selezionare
+“Stampa Bilancio Contabile”.</p>
+<p>Si attiverà una procedura guidata dalla quale potrai impostare la
+configurazione del tuo report. Qui è possibile scegliere se creare una
+vista interattiva HTML o un foglio PDF/XLS.</p>
+<p><strong>English</strong></p>
+<p>Preliminary operations:</p>
+<ol class="arabic simple">
+<li>Enable developer mode</li>
+<li>Go to Settings -&gt; Users &amp; Companies -&gt; Groups</li>
+<li>Select “Technical / Show full accounting features”</li>
+<li>Add the users who need to print financial statements report to the
+group</li>
+</ol>
+<p>Now from Accounting -&gt; Report section you can select “Financial
+Statements Report”.</p>
 <p>This will trigger a wizard, from which you can setup your report
 configuration. From it, you can choose whether should be created, either
-an HTML interactive view, or a PDF / XLS sheet.</p>
+an HTML interactive view, or a PDF/XLS sheet.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
@@ -448,9 +470,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Attualmente i report PDF dei bilanci di questo modulo non hanno riferimenti all'azienda a cui si riferiscono i dati ed in ambito multiazienda è un problema.

Per questo motivo ho aggiunto l'intestazione standard al template.

https://github.com/OCA/l10n-italy/issues/3660