### PR TITLE
[16.0][FIX] l10n_it_ricevute_bancarie: multicompany

### DIFF
--- a/l10n_it_riba/models/riba_config.py
+++ b/l10n_it_riba/models/riba_config.py
@@ -25,17 +25,19 @@ class RibaConfiguration(models.Model):
         "res.partner.bank",
         "Bank Account",
         required=True,
-        help="Bank account used for RiBa issuing.",
+        domain="[('company_id', '=', company_id)]",
+        help="Bank account used for C/O issuing.",
     )
     acceptance_journal_id = fields.Many2one(
         "account.journal",
         "Acceptance Journal",
-        domain=[("type", "=", "bank")],
+        domain="[('company_id', '=', company_id), ('type', '=', 'bank')]",
         help="Journal used when RiBa is accepted by the bank.",
     )
     acceptance_account_id = fields.Many2one(
         "account.account",
         "Acceptance Account",
+        domain="[('company_id', '=', company_id)]",
         help="Account used when RiBa is accepted by the bank.",
     )
     company_id = fields.Many2one(
@@ -47,38 +49,42 @@ class RibaConfiguration(models.Model):
     credit_journal_id = fields.Many2one(
         "account.journal",
         "Credit Journal",
-        domain=[("type", "=", "bank")],
+        domain="[('company_id', '=', company_id), ('type', '=', 'bank')]",
         help="Journal used when RiBa amount is credited by the bank.",
     )
     credit_account_id = fields.Many2one(
         "account.account",
         "RiBa Account",
         help="Account used when RiBa amount is credited by the bank.",
-        domain=[("account_type", "!=", "liability_credit_card")],
+        domain="[('company_id', '=', company_id), \
+                ('account_type', '!=', 'liability_credit_card')]",
     )
     bank_account_id = fields.Many2one(
         "account.account",
         "A/C Bank Account",
-        domain=[("account_type", "=", "asset_cash")],
+        domain="[('company_id', '=', company_id), ('account_type', '=', 'asset_cash')]",
     )
     bank_expense_account_id = fields.Many2one("account.account", "Bank Fees Account")
     past_due_journal_id = fields.Many2one(
         "account.journal",
         "Past Due Journal",
-        domain=[("type", "=", "bank")],
+        domain="[('company_id', '=', company_id), ('type', '=', 'bank')]",
         help="Journal used when RiBa is past due.",
     )
     overdue_effects_account_id = fields.Many2one(
         "account.account",
         "Past Due Bills Account",
-        domain=[("account_type", "=", "asset_receivable")],
+        domain="[('company_id', '=', company_id), ('account_type', '=', 'asset_receivable')]",
     )
     protest_charge_account_id = fields.Many2one(
-        "account.account", "Protest Fee Account"
+        "account.account",
+        "Protest Fee Account",
+        domain="[('company_id', '=', company_id)]",
     )
     settlement_journal_id = fields.Many2one(
         "account.journal",
         "Settlement Journal",
+        domain="[('company_id', '=', company_id)]",
         help="Journal used when customers finally pay the invoice to bank.",
     )
 

--- a/l10n_it_riba/tests/riba_common.py
+++ b/l10n_it_riba/tests/riba_common.py
@@ -72,11 +72,19 @@ class TestRibaCommon(common.TransactionCase):
         self.partner = self.env.ref("base.res_partner_3")
         self.partner.vat = "IT01234567890"
         self.product1 = self.env.ref("product.product_product_5")
-        self.sale_journal = self.env["account.journal"].search([("type", "=", "sale")])[
-            0
-        ]
-        self.bank_journal = self.env["account.journal"].search(
-            [("type", "=", "bank")], limit=1
+        self.sale_journal = self.env["account.journal"].create(
+            {
+                "name": "Sale",
+                "code": "SALE",
+                "type": "sale",
+            }
+        )
+        self.bank_journal = self.env["account.journal"].create(
+            {
+                "name": "Bank",
+                "code": "BANK",
+                "type": "bank",
+            }
         )
         self.payment_term1 = self._create_pterm()
         self.payment_term2 = self._create_pterm2()
@@ -88,39 +96,34 @@ class TestRibaCommon(common.TransactionCase):
                 reconcile=True,
             )
         )
-        self.sale_account = self.env["account.account"].search(
-            [
-                (
-                    "account_type",
-                    "=",
-                    "income_other",
-                )
-            ],
-            limit=1,
+        self.sale_account = self.account_model.create(
+            dict(
+                code="incothacc",
+                name="income other account",
+                account_type="income_other",
+                reconcile=True,
+            )
         )
-        self.expenses_account = self.env["account.account"].search(
-            [
-                (
-                    "account_type",
-                    "=",
-                    "expense",
-                )
-            ],
-            limit=1,
+        self.expenses_account = self.account_model.create(
+            dict(
+                code="expacc",
+                name="expense account",
+                account_type="expense",
+                reconcile=True,
+            )
         )
-        self.bank_account = self.env["account.account"].search(
-            [
-                (
-                    "account_type",
-                    "=",
-                    "asset_cash",
-                )
-            ],
-            limit=1,
+        self.bank_account = self.account_model.create(
+            dict(
+                code="asscasacc",
+                name="asset cash account",
+                account_type="asset_cash",
+                reconcile=True,
+            )
         )
+
         self.invoice = self._create_invoice()
         self.invoice2 = self._create_invoice()
-        self.sbf_effects = self.env["account.account"].create(
+        self.sbf_effects = self.account_model.create(
             {
                 "code": "STC",
                 "name": "STC Bills (test)",
@@ -128,14 +131,14 @@ class TestRibaCommon(common.TransactionCase):
                 "account_type": "asset_receivable",
             }
         )
-        self.riba_account = self.env["account.account"].create(
+        self.riba_account = self.account_model.create(
             {
                 "code": "RiBa",
                 "name": "RiBa Account (test)",
                 "account_type": "asset_fixed",
             }
         )
-        self.past_due_account = self.env["account.account"].create(
+        self.past_due_account = self.account_model.create(
             {
                 "code": "PastDue",
                 "name": "Past Due Bills Account (test)",

--- a/l10n_it_riba/views/configuration_view.xml
+++ b/l10n_it_riba/views/configuration_view.xml
@@ -13,12 +13,14 @@
         <field name="model">riba.configuration</field>
         <field name="arch" type="xml">
             <form string="RiBa - Configuration">
+                <field name="company_id" invisible="1" />
                 <group>
                     <field name="name" />
                     <field name="type" />
                     <field
                         name="bank_id"
-                        domain="[('partner_id.ref_company_ids', 'in', allowed_company_ids)]"
+                        domain="[('partner_id.ref_company_ids', 'in', [company_id])]"
+                        options="{'no_create': True}"
                     />
                     <field
                         name="company_id"
@@ -32,32 +34,57 @@
                     <field
                         name="acceptance_journal_id"
                         attrs="{'required':[('type','=','sbf')]}"
+                        options="{'no_create': True}"
                     />
                     <field
                         name="acceptance_account_id"
                         attrs="{'required':[('type','=','sbf')]}"
+                        options="{'no_create': True}"
                     />
                 </group>
 
                 <group string="Credit" attrs="{'invisible': [('type','!=','sbf')]}">
-                    <field name="credit_journal_id" />
-                    <field name="credit_account_id" />
-                    <field name="bank_account_id" />
-                    <field name="bank_expense_account_id" />
+                    <field name="credit_journal_id" options="{'no_create': True}" />
+                    <field name="credit_account_id" options="{'no_create': True}" />
+                    <field name="bank_account_id" options="{'no_create': True}" />
+                    <field
+                        name="bank_expense_account_id"
+                        options="{'no_create': True}"
+                    />
                 </group>
 
                 <group string="Past Due" attrs="{'invisible': [('type','!=','sbf')]}">
-                    <field name="past_due_journal_id" />
-                    <field name="overdue_effects_account_id" />
-                    <field name="protest_charge_account_id" />
+                    <field name="past_due_journal_id" options="{'no_create': True}" />
+                    <field
+                        name="overdue_effects_account_id"
+                        options="{'no_create': True}"
+                    />
+                    <field
+                        name="protest_charge_account_id"
+                        options="{'no_create': True}"
+                    />
                 </group>
 
                 <group string="Settlement" attrs="{'invisible': [('type','!=','sbf')]}">
-                    <field name="past_due_journal_id" />
-                    <field name="settlement_journal_id" />
+                    <field name="past_due_journal_id" options="{'no_create': True}" />
+                    <field name="settlement_journal_id" options="{'no_create': True}" />
                 </group>
 
             </form>
+        </field>
+    </record>
+
+    <!-- ====================================================== -->
+    <!-- 				CONFIGURAZIONE RIBA TREE 				-->
+    <!-- ====================================================== -->
+    <record model="ir.ui.view" id="view_riba_configuration_tree">
+        <field name="name">riba.configuration.tree</field>
+        <field name="model">riba.configuration</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="company_id" groups="base.group_multi_company" />
+            </tree>
         </field>
     </record>
 


### PR DESCRIPTION
Questa PR serve per impostare automaticamente l'azienda alla creazione di una configurazione Ri.Ba e mostrare solo i conti di quell'azienda.
In questo modo si evita che un utente che può accedere a più aziende faccia confusione creando configurazioni con l'azienda a cui non è collegato in quel momento ed imposti conti non appartenenti solo a quest'azienda.
https://github.com/OCA/l10n-italy/issues/3650