### PR TITLE
[14.0] `l10n_it_delivery_note_base`: Rimosso l'utente `Byloth` dai maintainers.

### DIFF
--- a/l10n_it_delivery_note_base/__manifest__.py
+++ b/l10n_it_delivery_note_base/__manifest__.py
@@ -16,7 +16,7 @@
     "version": "14.0.1.0.1",
     "category": "Localization/Italy",
     "license": "AGPL-3",
-    "maintainers": ["MarcoCalcagni", "Byloth"],
+    "maintainers": ["MarcoCalcagni"],
     "depends": ["base"],
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
Come [suggerito](https://github.com/OCA/l10n-italy/pull/3664#issuecomment-1768402619) da @francesco-ooops nella Issue #3664, apro una PR per rimuovermi dai maintainers del modulo `l10n_it_delivery_note_base`.

Non ho idea se sia necessario far girare script di rigenerazione di documenti, README vari e cose di questo tipo...  
Purtroppo non ho né memoria di come si faccia, né ho un ambiente pronto e atto a far girare questi script, né mi metterò a documentarmi per ricrearlo da zero.

In questa eventualità, chiudete pure la PR; troverò un modo per bloccare @OCA-git-bot e le sue notifiche. 🙃