### PR TITLE
Update of Maintainers

### DIFF
--- a/l10n_it_delivery_note_base/__manifest__.py
+++ b/l10n_it_delivery_note_base/__manifest__.py
@@ -15,7 +15,7 @@
     "version": "16.0.1.0.0",
     "category": "Localization/Italy",
     "license": "AGPL-3",
-    "maintainers": ["As400it", "Byloth"],
+    "maintainers": ["MarcoCalcagni", "Borruso"],
     "depends": ["base"],
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
Cambio dei mainteiners per aggiunta di Borruso e rimozione di Matteo. Calcagni ha cambiato nome da As400it a MarcoCalcagni