### PR TITLE
Update of Maintainers

### DIFF
--- a/l10n_it_delivery_note_batch/__manifest__.py
+++ b/l10n_it_delivery_note_batch/__manifest__.py
@@ -11,7 +11,7 @@
     "version": "16.0.1.0.0",
     "category": "Localization/Italy",
     "license": "AGPL-3",
-    "maintainers": ["As400it", "TheMule71"],
+    "maintainers": ["MarcoCalcagni", "TheMule71", "Borruso"],
     "depends": [
         "stock",
         "stock_picking_batch",


### PR DESCRIPTION
Cambio dei mainteiners per aggiunta di Borruso. Calcagni ha cambiato nome da As400it a MarcoCalcagni