### PR TITLE
[16.0] [FIX] l10n_it_fatturapa_in: add migration to remove view inheritance

### DIFF
--- a/l10n_it_fatturapa_in/migrations/16.0.1.0.0/pre-migrate.py
+++ b/l10n_it_fatturapa_in/migrations/16.0.1.0.0/pre-migrate.py
@@ -1,0 +1,10 @@
+#  Copyright 2023 Nextev Srl
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    view = env.ref("l10n_it_fatturapa_in.view_fatturapa_in_attachment_form")
+    view.inherit_id = False


### PR DESCRIPTION
E' necessario aggiungere questo script per migrare correttamente il modulo dalla v14 alla v16.
Infatti senza rimuovere preventivamente l'ereditarietà dalla vista `view_fatturapa_in_attachment_form`, questa verrebbe considerata  come un'estensione anche nella v16 ed andrebbe in errore.