### PR TITLE
[16.0] [FIX] l10n_it_fatturapa_out: fix migration script

### DIFF
--- a/l10n_it_fatturapa_out/migrations/16.0.1.0.0/pre-migrate.py
+++ b/l10n_it_fatturapa_out/migrations/16.0.1.0.0/pre-migrate.py
@@ -20,7 +20,8 @@ def migrate(env, version):
         (table_name, "%s" % constraint_name),
     )
 
-    if env.cr.fetchall()[0]:
+    res = env.cr.fetchall()
+    if res and res[0]:
         alter_table_sql = sql.SQL("ALTER TABLE {} DROP CONSTRAINT {}").format(
             sql.Identifier(table_name), sql.Identifier(constraint_name)
         )


### PR DESCRIPTION
E' necessario modificare lo script per migrare correttamente il modulo dalla v14 alla v16.

Infatti senza rimuovere preventivamente l'ereditarietà dalla vista view_fatturapa_in_attachment_form, questa verrebbe considerata come un'estensione anche nella v16 ed andrebbe in errore.

Inoltre bisogna considerare il caso in cui non ci siano costanti da eliminare altrimenti si verificherebbe un errore bloccante.
