### PR TITLE
[16.0][FIX] l10n_it_fatturapa_out: not generate empty Causale

### DIFF
--- a/l10n_it_fatturapa_out/wizard/efattura.py
+++ b/l10n_it_fatturapa_out/wizard/efattura.py
@@ -139,7 +139,8 @@ class EFatturaOut:
 
                 try:
                     narration_text = "\n".join(
-                        html.fromstring(invoice.narration).xpath("//text()")
+                        text.strip()
+                        for text in html.fromstring(invoice.narration).xpath("//text()")
                     )
                 except Exception:
                     narration_text = ""


### PR DESCRIPTION
No generate empty Causale in xml

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing