### PR TITLE
[16.0][FIX] l10n_it_fiscalcode: trivial support for v17 by fixing the selector

### DIFF
--- a/l10n_it_fiscalcode/__manifest__.py
+++ b/l10n_it_fiscalcode/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "ITA - Codice fiscale",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "development_status": "Production/Stable",
     "category": "Localization/Italy",
     "author": "Link IT s.r.l., "

--- a/l10n_it_fiscalcode/view/fiscalcode_view.xml
+++ b/l10n_it_fiscalcode/view/fiscalcode_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
             <xpath
-                expr="//field[@name='vat']/ancestor::div | //field[@name='vat']" 
+                expr="//field[@name='vat']/ancestor::div | //field[@name='vat']"
                 position="after"
             >
                 <label for="fiscalcode" />

--- a/l10n_it_fiscalcode/view/fiscalcode_view.xml
+++ b/l10n_it_fiscalcode/view/fiscalcode_view.xml
@@ -5,7 +5,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <xpath 
+            <xpath
                 expr="//field[@name='vat']/ancestor::div | //field[@name='vat']" 
                 position="after"
             >

--- a/l10n_it_fiscalcode/view/fiscalcode_view.xml
+++ b/l10n_it_fiscalcode/view/fiscalcode_view.xml
@@ -5,12 +5,12 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <field name="vat" position="before">
+            <xpath expr="//field[@name='vat']/ancestor::div | //field[@name='vat']" position="after">
                 <label for="fiscalcode" />
                 <div name="fiscalcode_info" class="o_row">
-                    <field name="fiscalcode" class="oe_inline" />
+                    <field name="fiscalcode" nolabel="1" />
                 </div>
-            </field>
+            </xpath>
         </field>
     </record>
     <record id="view_res_partner_filter_fiscalcode_data" model="ir.ui.view">
@@ -24,3 +24,4 @@
         </field>
     </record>
 </odoo>
+

--- a/l10n_it_fiscalcode/view/fiscalcode_view.xml
+++ b/l10n_it_fiscalcode/view/fiscalcode_view.xml
@@ -5,7 +5,10 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='vat']/ancestor::div | //field[@name='vat']" position="after">
+            <xpath 
+                expr="//field[@name='vat']/ancestor::div | //field[@name='vat']" 
+                position="after"
+            >
                 <label for="fiscalcode" />
                 <div name="fiscalcode_info" class="o_row">
                     <field name="fiscalcode" nolabel="1" />


### PR DESCRIPTION
Add trivial support for Odoo 17 by fixing the selector in the form view.