### PR TITLE
[FIX] l10n_it_account_stamp: fix tests

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.11"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v1


### PR DESCRIPTION
After https://github.com/odoo/odoo/commit/28004b7e92f22cf0f0078d4512f8a5f59c82122c#diff-a97352a94802dc006fe1dad7587741ccc6e8d9edf5eb70110a1087c52dde2759R97-R109 **test_amount_total_changing_currency** fails with the following error:


````Traceback (most recent call last):
  File "/__w/l10n-italy/l10n-italy/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py", line 93, in test_amount_total_changing_currency
    invoice_form = Form(invoice)
  File "/opt/odoo/odoo/tests/common.py", line 1977, in __init__
    assert recordp['id'], "editing unstored records is not supported"
  File "/opt/odoo/odoo/models.py", line 5897, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/opt/odoo/odoo/fields.py", line 5065, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: account.move(230, 236)

`````

and **test_keep_lines_description** fails with the following error:

```
Traceback (most recent call last):
  File "/__w/l10n-italy/l10n-italy/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py", line 73, in test_keep_lines_description
    self.assertEqual(len(invoice), 1)
AssertionError: 2 != 1
```
and **test_post_invoicing** fails with the following error:
    
```
    Traceback (most recent call last):
      File "/__w/l10n-italy/l10n-italy/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py", line 55, in test_post_invoicing
        self.assertEqual(len(invoice_ids), 1)
    AssertionError: 2 != 1
```
