### PR TITLE
[16.0] [IMP] l10n_it_fiscalcode: add codicefiscale.isvalid()

### DIFF
--- a/l10n_it_fiscalcode/model/res_partner.py
+++ b/l10n_it_fiscalcode/model/res_partner.py
@@ -1,5 +1,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from codicefiscale import isvalid
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -21,8 +23,12 @@ class ResPartner(models.Model):
                     # Perform the same check as Company case
                     continue
                 if len(partner.fiscalcode) != 16:
-                    # Check fiscalcode of a person
-                    msg = _("The fiscal code doesn't seem to be correct.")
+                    # Check fiscalcode length of a person
+                    msg = _("The fiscal code must have 16 characters.")
+                    raise ValidationError(msg)
+                if not isvalid(partner.fiscalcode):
+                    # Check fiscalcode validity
+                    msg = _("The fiscal code isn't valid.")
                     raise ValidationError(msg)
         return True
 

--- a/l10n_it_fiscalcode/readme/HISTORY.rst
+++ b/l10n_it_fiscalcode/readme/HISTORY.rst
@@ -1,0 +1,21 @@
+[ The change log. The goal of this file is to help readers
+  understand changes between version. The primary audience is
+  end users and integrators. Purely technical changes such as
+  code refactoring must not be mentioned here.
+
+  This file may contain ONE level of section titles, underlined
+  with the ~ (tilde) character. Other section markers are
+  forbidden and will likely break the structure of the README.rst
+  or other documents where this fragment is included. ]
+
+16.0.1.0.0 (2022-11-11)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [MIG] Migration from Odoo 14.0 to 16.0
+* [IMP] Black, isort, prettier (pre-commit)
+
+
+16.0.1.0.1 (2022-11-16)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [IMP] Add codicefiscale.isvalid() to improve fiscalcode validation

--- a/l10n_it_fiscalcode/tests/test_fiscalcode.py
+++ b/l10n_it_fiscalcode/tests/test_fiscalcode.py
@@ -31,7 +31,7 @@ class TestFiscalCode(TransactionCase):
         self.assertEqual(self.partner.fiscalcode, "RSSMRA84H04H501X")
 
     def test_fiscalcode_check(self):
-        # Wrong FC
+        # Wrong FC length
         with self.assertRaises(ValidationError):
             self.env["res.partner"].create(
                 {
@@ -63,3 +63,12 @@ class TestFiscalCode(TransactionCase):
                 "fiscalcode": "123456789",
             }
         )
+        # Invalid FC
+        with self.assertRaises(ValidationError):
+            self.env["res.partner"].create(
+                {
+                    "name": "Person",
+                    "is_company": False,
+                    "fiscalcode": "AAAMRA00H04H5010",
+                }
+            )


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/3719