### PR TITLE
[14.0] [IMP] l10n_it_delivery_note: filter 'type_id' based on company

### DIFF
--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -49,13 +49,18 @@ class StockDeliveryNote(models.Model):
     ]
     _description = "Delivery Note"
     _order = "date DESC, id DESC"
+    _check_company_auto = True
 
     def _default_company(self):
         return self.env.company
 
     def _default_type(self):
         return self.env["stock.delivery.note.type"].search(
-            [("code", "=", DOMAIN_PICKING_TYPES[1])], limit=1
+            [
+                ("code", "=", DOMAIN_PICKING_TYPES[1]),
+                ("company_id", "=", self.env.company.id),
+            ],
+            limit=1,
         )
 
     def _default_volume_uom(self):
@@ -241,12 +246,16 @@ class StockDeliveryNote(models.Model):
     )
 
     picking_ids = fields.One2many(
-        "stock.picking", "delivery_note_id", string="Pickings"
+        "stock.picking",
+        "delivery_note_id",
+        string="Pickings",
+        check_company=True,
     )
     pickings_picker = fields.Many2many(
         "stock.picking",
         compute="_compute_get_pickings",
         inverse="_inverse_set_pickings",
+        check_company=True,
     )
 
     picking_type = fields.Selection(

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -41,7 +41,9 @@ class StockPicking(models.Model):
     )
 
     delivery_note_type_id = fields.Many2one(
-        "stock.delivery.note.type", related="delivery_note_id.type_id"
+        "stock.delivery.note.type",
+        related="delivery_note_id.type_id",
+        check_company=True,
     )
     delivery_note_type_code = fields.Selection(related="delivery_note_type_id.code")
     delivery_note_date = fields.Date(string="DN Date", related="delivery_note_id.date")

--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -338,6 +338,7 @@ class StockPicking(models.Model):
         )
         return self.env["stock.delivery.note"].create(
             {
+                "company_id": self.company_id.id,
                 "partner_sender_id": partners[0].id,
                 "partner_id": self.sale_id.partner_id.id
                 if self.sale_id

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Alex Comba - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import UserError
 from odoo.tests import new_test_user
 from odoo.tests.common import Form
 
@@ -101,7 +102,7 @@ class StockDeliveryNote(StockDeliveryNoteCommon):
         # create delivery note with advanced mode
         dn_form = Form(
             self.env["stock.delivery.note.create.wizard"].with_context(
-                {"active_ids": [picking.id]}
+                {"active_id": picking.id, "active_ids": picking.ids}
             )
         )
         dn = dn_form.save()
@@ -110,3 +111,11 @@ class StockDeliveryNote(StockDeliveryNoteCommon):
         picking.delivery_note_id.action_confirm()
         self.assertEqual(picking.delivery_note_id.state, "confirm")
         self.assertEqual(picking.delivery_note_id.invoice_status, "no")
+
+        test_company = self.env["res.company"].create({"name": "Test Company"})
+        with self.assertRaises(UserError) as exc:
+            picking.delivery_note_id.write({"company_id": test_company.id})
+        exc_message = exc.exception.args[0]
+        self.assertIn("type_id", exc_message)
+        self.assertIn("picking_ids", exc_message)
+        self.assertIn("belongs to another company", exc_message)

--- a/l10n_it_delivery_note/views/stock_delivery_note.xml
+++ b/l10n_it_delivery_note/views/stock_delivery_note.xml
@@ -136,6 +136,7 @@
                             <field
                                 name="company_id"
                                 options="{'no_create': True}"
+                                attrs="{'readonly': [('pickings_picker', '!=', [])]}"
                                 groups="base.group_multi_company"
                             />
                             <field

--- a/l10n_it_delivery_note/wizard/delivery_note_base.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_base.py
@@ -15,6 +15,9 @@ class StockDeliveryNoteBaseWizard(models.AbstractModel):
 
         return self.env["stock.picking"].browse(active_ids)
 
+    def _domain_type_id(self):
+        return [("company_id", "in", [False, self.env.company.id])]
+
     selected_picking_ids = fields.Many2many(
         "stock.picking", default=_default_stock_pickings, readonly=True
     )
@@ -28,7 +31,11 @@ class StockDeliveryNoteBaseWizard(models.AbstractModel):
     partner_shipping_id = fields.Many2one("res.partner", string="Shipping address")
 
     date = fields.Date(string="Date")
-    type_id = fields.Many2one("stock.delivery.note.type", string="Type")
+    type_id = fields.Many2one(
+        "stock.delivery.note.type",
+        string="Type",
+        domain=_domain_type_id,
+    )
 
     error_message = fields.Html(compute="_compute_fields")
 

--- a/l10n_it_delivery_note/wizard/delivery_note_create.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_create.py
@@ -21,9 +21,9 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
         picking_ids = self.env["stock.picking"].browse(active_ids)
         if picking_ids:
             type_code = picking_ids[0].picking_type_id.code
-
+            company_id = picking_ids[0].company_id
             return self.env["stock.delivery.note.type"].search(
-                [("code", "=", type_code)], limit=1
+                [("code", "=", type_code), ("company_id", "=", company_id.id)], limit=1
             )
 
         else:
@@ -82,6 +82,8 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
 
         delivery_note = self.env["stock.delivery.note"].create(
             {
+                "company_id": self.selected_picking_ids.mapped("company_id")[:1].id
+                or False,
                 "partner_sender_id": self.partner_sender_id.id,
                 "partner_id": self.selected_picking_ids.mapped("sale_id.partner_id").id
                 if self.selected_picking_ids.mapped("sale_id.partner_id").id


### PR DESCRIPTION
Con questa PR viene rimossa la possibilità di selezionare tipi di delivery note di company diverse, rispetto alla company che viene utilizzata alla creazione/modifica del documento di trasporto.

Oltretutto, ora non è più possibile selezionare una company diversa da quella utilizzata nei picking.