### PR TITLE
[FIX] account_vat_period_end_statement: Creazione del movimento quando c'è un termine di pagamento

### DIFF
--- a/account_vat_period_end_statement/README.rst
+++ b/account_vat_period_end_statement/README.rst
@@ -186,6 +186,10 @@ Contributors
 
    -  Simone Rubino <sir@takobi.online>
 
+-  `Aion Tech <https://aiontech.company/>`__:
+
+   -  Simone Rubino <simone.rubino@aion-tech.it>
+
 Maintainers
 -----------
 

--- a/account_vat_period_end_statement/readme/CONTRIBUTORS.md
+++ b/account_vat_period_end_statement/readme/CONTRIBUTORS.md
@@ -12,3 +12,5 @@
 - Michele Rusticucci \<<michele.rusticucci@agilebg.com>\>
 - [TAKOBI](https://takobi.online):
   - Simone Rubino \<<sir@takobi.online>\>
+- [Aion Tech](https://aiontech.company/):
+  - Simone Rubino \<<simone.rubino@aion-tech.it>\>

--- a/account_vat_period_end_statement/static/description/index.html
+++ b/account_vat_period_end_statement/static/description/index.html
@@ -525,6 +525,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:sir&#64;takobi.online">sir&#64;takobi.online</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_vat_period_end_statement/tests/common.py
+++ b/account_vat_period_end_statement/tests/common.py
@@ -1,5 +1,6 @@
 #  Copyright 2015 Agile Business Group <http://www.agilebg.com>
 #  Copyright 2022 Simone Rubino - TAKOBI
+#  Copyright 2024 Simone Rubino - Aion Tech
 #  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from datetime import date, datetime
@@ -157,16 +158,18 @@ class TestVATStatementCommon(AccountTestInvoicingCommon):
         bill.action_post()
         return bill
 
-    def _get_statement(self, period, statement_date, accounts):
+    def _get_statement(self, period, statement_date, accounts, payment_term=None):
         """
         Create a VAT Statement in date `statement_date`
         for Period `period` and Accounts `accounts`.
         """
+        if payment_term is None:
+            payment_term = self.account_payment_term
         # Create statement
         statement_form = Form(self.vat_statement_model)
         statement_form.journal_id = self.general_journal
         statement_form.authority_vat_account_id = self.vat_authority
-        statement_form.payment_term_id = self.account_payment_term
+        statement_form.payment_term_id = payment_term
         statement_form.date = statement_date
         statement_form.account_ids.clear()
         for account in accounts:


### PR DESCRIPTION
Il metodo `account.payment.term.compute` non esiste più da https://github.com/odoo/odoo/commit/d9057e332d04e676a926fcc7852008349556c4a4.

Ho verificato che in `14.0` non succede, quindi non credo ci sia bisogno di issue di tracciamento.
Sono comunque state create delle issues per questo problema https://github.com/OCA/l10n-italy/issues/3977 e https://github.com/OCA/l10n-italy/issues/4182.

**Passi**

1. In un'imposta di vendita, aggiungere il conto per la liquidazione IVA.
2. Creare una fattura con l'imposta configurata e confermarla.
3. Creare un intervallo date contenente la fattura.
4. Creare una liquidazione per l'intervallo date.
5. Aggiungere il termine di pagamento,
    senza questo step, l'errore non succede.
7. Crea movimento.

**Comportamento attuale**
Errore:
> AttributeError: 'account.payment.term' object has no attribute 'compute'

**Comportamento atteso**
Creazione del movimento contabile