### PR TITLE
[14.0] [FIX] l10n_it_fatturapa_in_rc: Fix roundings in error check

### DIFF
--- a/l10n_it_fatturapa_in_rc/__init__.py
+++ b/l10n_it_fatturapa_in_rc/__init__.py
@@ -1,2 +1,3 @@
 from . import wizard
 from . import models
+from . import tests

--- a/l10n_it_fatturapa_in_rc/models/account_invoice.py
+++ b/l10n_it_fatturapa_in_rc/models/account_invoice.py
@@ -1,3 +1,5 @@
+import math
+
 from odoo import _, api, models
 from odoo.tools import float_compare
 
@@ -52,7 +54,16 @@ class Invoice(models.Model):
         if any(self.invoice_line_ids.mapped("rc")) and self.e_invoice_amount_total:
             error_message = ""
             amount_added_for_rc = self.get_tax_amount_added_for_rc()
-            amount_total = self.amount_total - amount_added_for_rc
+            rounding_value = 0.01
+            if self.currency_id.rounding:
+                rounding_value = self.currency_id.rounding
+            rounding_digits = int(math.ceil(math.log10(1 / rounding_value)))
+            rounding_factor = math.pow(10, rounding_digits)
+            rounded_amount_total = (
+                self.amount_total - amount_added_for_rc
+            ) * rounding_factor
+            int_amnt_total = math.trunc(rounded_amount_total)
+            amount_total = int_amnt_total / rounding_factor
             if (
                 float_compare(
                     amount_total,

--- a/l10n_it_fatturapa_in_rc/tests/data/IT01234567890_FPR05.xml
+++ b/l10n_it_fatturapa_in_rc/tests/data/IT01234567890_FPR05.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<p:FatturaElettronica
+    versione="FPR12"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd"
+>
+  <FatturaElettronicaHeader>
+    <DatiTrasmissione>
+      <IdTrasmittente>
+        <IdPaese>IT</IdPaese>
+        <IdCodice>05979361218</IdCodice>
+      </IdTrasmittente>
+      <ProgressivoInvio>00002</ProgressivoInvio>
+      <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+      <CodiceDestinatario>0000000</CodiceDestinatario>
+      <ContattiTrasmittente />
+    </DatiTrasmissione>
+    <CedentePrestatore>
+      <DatiAnagrafici>
+        <IdFiscaleIVA>
+          <IdPaese>IT</IdPaese>
+          <IdCodice>02780790107</IdCodice>
+        </IdFiscaleIVA>
+        <Anagrafica>
+          <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
+        </Anagrafica>
+        <RegimeFiscale>RF01</RegimeFiscale>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIALE ROMA 543</Indirizzo>
+        <CAP>07100</CAP>
+        <Comune>SASSARI</Comune>
+        <Provincia>SS</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CedentePrestatore>
+    <CessionarioCommittente>
+      <DatiAnagrafici>
+        <CodiceFiscale>03533590174</CodiceFiscale>
+        <Anagrafica>
+          <Denominazione>BETA GAMMA</Denominazione>
+        </Anagrafica>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIA TORINO 38-B</Indirizzo>
+        <CAP>00145</CAP>
+        <Comune>ROMA</Comune>
+        <Provincia>RM</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CessionarioCommittente>
+  </FatturaElettronicaHeader>
+  <FatturaElettronicaBody>
+    <DatiGenerali>
+      <DatiGeneraliDocumento>
+        <TipoDocumento>TD01</TipoDocumento>
+        <Divisa>EUR</Divisa>
+        <Data>2019-02-15</Data>
+        <Numero>123</Numero>
+      </DatiGeneraliDocumento>
+    </DatiGenerali>
+    <DatiBeniServizi>
+      <DettaglioLinee>
+        <NumeroLinea>1</NumeroLinea>
+        <Descrizione>LA DESCRIZIONE</Descrizione>
+        <Quantita>5.00</Quantita>
+        <PrezzoUnitario>1.00</PrezzoUnitario>
+        <PrezzoTotale>5.00</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+      </DettaglioLinee>
+      <DettaglioLinee>
+        <NumeroLinea>2</NumeroLinea>
+        <Descrizione>BANCALI</Descrizione>
+        <Quantita>10.00</Quantita>
+        <PrezzoUnitario>2.00</PrezzoUnitario>
+        <PrezzoTotale>20.00</PrezzoTotale>
+        <AliquotaIVA>0.00</AliquotaIVA>
+        <Natura>N6.3</Natura>
+      </DettaglioLinee>
+      <DatiRiepilogo>
+        <AliquotaIVA>22.00</AliquotaIVA>
+        <ImponibileImporto>5.00</ImponibileImporto>
+        <Imposta>1.10</Imposta>
+        <EsigibilitaIVA>I</EsigibilitaIVA>
+      </DatiRiepilogo>
+      <DatiRiepilogo>
+        <AliquotaIVA>0.00</AliquotaIVA>
+        <Natura>N6.3</Natura>
+        <ImponibileImporto>20.00</ImponibileImporto>
+        <Imposta>0.00</Imposta>
+        <EsigibilitaIVA>I</EsigibilitaIVA>
+        <RiferimentoNormativo
+                >ex art.74 commi 7 e 8 art.17.commi 2e 6 DPR 633/72</RiferimentoNormativo>
+      </DatiRiepilogo>
+    </DatiBeniServizi>
+  </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_fatturapa_in_rc/tests/test_fatturapa_in_rc.py
+++ b/l10n_it_fatturapa_in_rc/tests/test_fatturapa_in_rc.py
@@ -219,7 +219,7 @@ class TestInvoiceRC(FatturapaCommon):
 
     def test_01_xml_import(self):
         res = self.run_wizard(
-            "test1", "IT01234567890_FPR05.xml", module_name="l10n_it_fatturapa_in_rc"
+            "test2", "IT01234567890_FPR05.xml", module_name="l10n_it_fatturapa_in_rc"
         )
         invoice_id = res.get("domain")[0][2][0]
         invoice = self.invoice_model.browse(invoice_id)
@@ -248,7 +248,7 @@ class TestInvoiceRC(FatturapaCommon):
         partner = invoice.partner_id
         partner.e_invoice_detail_level = "0"
         res = self.run_wizard(
-            "test1", "IT01234567890_FPR05.xml", module_name="l10n_it_fatturapa_in_rc"
+            "test3", "IT01234567890_FPR05.xml", module_name="l10n_it_fatturapa_in_rc"
         )
         invoice_id = res.get("domain")[0][2][0]
         invoice = self.invoice_model.browse(invoice_id)

--- a/l10n_it_fatturapa_in_rc/tests/test_fatturapa_in_rc.py
+++ b/l10n_it_fatturapa_in_rc/tests/test_fatturapa_in_rc.py
@@ -16,15 +16,20 @@ class TestInvoiceRC(FatturapaCommon):
 
     def _create_account(self):
         account_model = self.env["account.account"]
-        self.account_selfinvoice = account_model.create(
-            {
-                "code": "295000",
-                "name": "selfinvoice temporary",
-                "user_type_id": self.env.ref(
-                    "account.data_account_type_current_liabilities"
-                ).id,
-            }
-        )
+        self_invoice_account = account_model.search([("code", "=", "295000")], limit=1)
+
+        if not self_invoice_account:
+            self.account_selfinvoice = account_model.create(
+                {
+                    "code": "295000",
+                    "name": "selfinvoice temporary",
+                    "user_type_id": self.env.ref(
+                        "account.data_account_type_current_liabilities"
+                    ).id,
+                }
+            )
+        else:
+            self.account_selfinvoice = self_invoice_account
 
     def _create_taxes(self):
         tax_model = self.env["account.tax"]
@@ -47,31 +52,80 @@ class TestInvoiceRC(FatturapaCommon):
                 "sequence": 10,
             }
         )
+        self.tax_n63ai = tax_model.create(
+            {
+                "name": "Purchase Art. 17 c. 6 lett. a) (n 6.3)",
+                "type_tax_use": "purchase",
+                "amount": 22,
+                "kind_id": self.env.ref("l10n_it_account_tax_kind.n6_3").id,
+                "sequence": 10,
+            }
+        )
+        self.tax_n63vi = tax_model.create(
+            {
+                "name": "Sale Art. 17 c. 6 lett. a) (n 6.3)",
+                "type_tax_use": "sale",
+                "amount": 22,
+                "kind_id": self.env.ref("l10n_it_account_tax_kind.n6_3").id,
+                "law_reference": "articoli 23 e 25 D.P.R. 633/1972",
+                "sequence": 10,
+            }
+        )
 
     def _create_journals(self):
         journal_model = self.env["account.journal"]
-        self.journal_selfinvoice = journal_model.create(
-            {
-                "name": "selfinvoice",
-                "type": "sale",
-                "code": "SLF",
-            }
+        selfinvoice_sale_journal = journal_model.search(
+            [
+                ("type", "=", "sale"),
+                ("code", "=", "SLF"),
+            ],
+            limit=1,
         )
-        self.journal_reconciliation = journal_model.create(
-            {
-                "name": "RC reconciliation",
-                "type": "bank",
-                "code": "SLFRC",
-                "default_account_id": self.account_selfinvoice.id,
-            }
+        if not selfinvoice_sale_journal:
+            self.journal_selfinvoice = journal_model.create(
+                {
+                    "name": "selfinvoice",
+                    "type": "sale",
+                    "code": "SLF",
+                }
+            )
+        else:
+            self.journal_selfinvoice = selfinvoice_sale_journal
+        rc_reconciliation_journal = journal_model.search(
+            [
+                ("type", "=", "bank"),
+                ("code", "=", "SLFRC"),
+            ],
+            limit=1,
         )
-        self.journal_selfinvoice_extra = journal_model.create(
-            {
-                "name": "Extra Selfinvoice",
-                "type": "sale",
-                "code": "SLFEX",
-            }
+        if not rc_reconciliation_journal:
+            self.journal_reconciliation = journal_model.create(
+                {
+                    "name": "RC reconciliation",
+                    "type": "bank",
+                    "code": "SLFRC",
+                    "default_account_id": self.account_selfinvoice.id,
+                }
+            )
+        else:
+            self.journal_reconciliation = rc_reconciliation_journal
+        extra_selfinvoice_journal = journal_model.search(
+            [
+                ("type", "=", "sale"),
+                ("code", "=", "SLFEX"),
+            ],
+            limit=1,
         )
+        if not extra_selfinvoice_journal:
+            self.journal_selfinvoice_extra = journal_model.create(
+                {
+                    "name": "Extra Selfinvoice",
+                    "type": "sale",
+                    "code": "SLFEX",
+                }
+            )
+        else:
+            self.journal_selfinvoice_extra = extra_selfinvoice_journal
 
     def _create_rc_types(self):
         rc_type_model = self.env["account.rc.type"]
@@ -87,6 +141,18 @@ class TestInvoiceRC(FatturapaCommon):
                 "e_invoice_suppliers": True,
             }
         )
+        self.rc_type_n63 = rc_type_model.create(
+            {
+                "name": "RC ITA n6.3",
+                "method": "selfinvoice",
+                "partner_type": "other",
+                "partner_id": self.env.ref("base.main_partner").id,
+                "journal_id": self.journal_selfinvoice.id,
+                "payment_journal_id": self.journal_reconciliation.id,
+                "transitory_account_id": self.account_selfinvoice.id,
+                "e_invoice_suppliers": False,
+            }
+        )
 
     def _create_rc_type_taxes(self):
         rc_type_tax_model = self.env["account.rc.type.tax"]
@@ -97,11 +163,21 @@ class TestInvoiceRC(FatturapaCommon):
                 "sale_tax_id": self.tax_22vi.id,
             }
         )
+        self.rc_type_tax_n6_3 = rc_type_tax_model.create(
+            {
+                "rc_type_id": self.rc_type_n63.id,
+                "purchase_tax_id": self.tax_n63ai.id,
+                "sale_tax_id": self.tax_n63vi.id,
+            }
+        )
 
     def _create_fiscal_position(self):
         model_fiscal_position = self.env["account.fiscal.position"]
         self.fiscal_position_rc_ita = model_fiscal_position.create(
             {"name": "RC ITA", "rc_type_id": self.rc_type_ita.id}
+        )
+        self.fiscal_position_rc_ita = model_fiscal_position.create(
+            {"name": "RC ITA", "rc_type_id": self.rc_type_n63.id}
         )
 
     def test_00_xml_import(self):
@@ -136,6 +212,43 @@ class TestInvoiceRC(FatturapaCommon):
         partner.e_invoice_detail_level = "0"
         res = self.run_wizard(
             "test1", "IT01234567890_FPR04.xml", module_name="l10n_it_fatturapa_in_rc"
+        )
+        invoice_id = res.get("domain")[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertTrue(len(invoice.invoice_line_ids) == 0)
+
+    def test_01_xml_import(self):
+        res = self.run_wizard(
+            "test1", "IT01234567890_FPR05.xml", module_name="l10n_it_fatturapa_in_rc"
+        )
+        invoice_id = res.get("domain")[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertEqual(invoice.invoice_line_ids[0].name, "LA DESCRIZIONE")
+        self.assertEqual(invoice.invoice_line_ids[1].name, "BANCALI")
+        self.assertFalse(invoice.invoice_line_ids[0].rc)
+        self.assertTrue(invoice.invoice_line_ids[1].rc)
+        self.assertEqual(invoice.invoice_line_ids[0].tax_ids.name, "22% e-bill")
+        self.assertEqual(
+            invoice.invoice_line_ids[1].tax_ids.name,
+            "Purchase Art. 17 c. 6 lett. a) (n 6.3)",
+        )
+        self.assertEqual(invoice.amount_total, 30.5)
+        self.assertEqual(invoice.get_tax_amount_added_for_rc(), 4.4)
+        self.assertEqual(invoice.amount_tax, 5.5)
+        self.assertEqual(invoice.e_invoice_amount_tax, 1.1)
+        invoice.action_post()
+        self.assertAlmostEqual(invoice.rc_self_invoice_id.amount_total, 24.4)
+        self.assertEqual(invoice.rc_self_invoice_id.amount_tax, 4.4)
+        self.assertEqual(invoice.rc_self_invoice_id.amount_untaxed, 20)
+        self.assertEqual(
+            invoice.rc_self_invoice_id.invoice_line_ids.tax_ids.name,
+            "Sale Art. 17 c. 6 lett. a) (n 6.3)",
+        )
+
+        partner = invoice.partner_id
+        partner.e_invoice_detail_level = "0"
+        res = self.run_wizard(
+            "test1", "IT01234567890_FPR05.xml", module_name="l10n_it_fatturapa_in_rc"
         )
         invoice_id = res.get("domain")[0][2][0]
         invoice = self.invoice_model.browse(invoice_id)


### PR DESCRIPTION
When import / autocomplete the invoice with RC lines, the rounding of amount total has 3 decimal position, and using `float_round` method of Odoo round total amount to next decimal value; using integers allow to obtain correct value for rounding