### PR TITLE
[12.0] [FIX] l10n_it_fatturapa_in_rc: avoid wrong representaion of floating point number for invoice amount total

### DIFF
--- a/l10n_it_fatturapa_in_rc/tests/__init__.py
+++ b/l10n_it_fatturapa_in_rc/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_fatturapa_in_rc
+from . import test_fatturapa_in_rc_n63

--- a/l10n_it_fatturapa_in_rc/tests/data/IT01234567890_FPR05.xml
+++ b/l10n_it_fatturapa_in_rc/tests/data/IT01234567890_FPR05.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:FatturaElettronica versione="FPR12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+  <FatturaElettronicaHeader>
+    <DatiTrasmissione>
+      <IdTrasmittente>
+        <IdPaese>IT</IdPaese>
+        <IdCodice>05979361218</IdCodice>
+      </IdTrasmittente>
+      <ProgressivoInvio>00001</ProgressivoInvio>
+      <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+      <CodiceDestinatario>0000000</CodiceDestinatario>
+      <ContattiTrasmittente/>
+    </DatiTrasmissione>
+    <CedentePrestatore>
+      <DatiAnagrafici>
+        <IdFiscaleIVA>
+          <IdPaese>IT</IdPaese>
+          <IdCodice>02780790107</IdCodice>
+        </IdFiscaleIVA>
+        <Anagrafica>
+          <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
+        </Anagrafica>
+        <RegimeFiscale>RF01</RegimeFiscale>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIALE ROMA 543</Indirizzo>
+        <CAP>07100</CAP>
+        <Comune>SASSARI</Comune>
+        <Provincia>SS</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CedentePrestatore>
+    <CessionarioCommittente>
+      <DatiAnagrafici>
+        <CodiceFiscale>03533590174</CodiceFiscale>
+        <Anagrafica>
+          <Denominazione>BETA GAMMA</Denominazione>
+        </Anagrafica>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIA TORINO 38-B</Indirizzo>
+        <CAP>00145</CAP>
+        <Comune>ROMA</Comune>
+        <Provincia>RM</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+    </CessionarioCommittente>
+  </FatturaElettronicaHeader>
+  <FatturaElettronicaBody>
+    <DatiGenerali>
+      <DatiGeneraliDocumento>
+        <TipoDocumento>TD01</TipoDocumento>
+        <Divisa>EUR</Divisa>
+        <Data>2019-02-15</Data>
+        <Numero>123</Numero>
+        <ScontoMaggiorazione>
+            <Tipo>SC</Tipo>
+            <Importo>2.00</Importo>
+        </ScontoMaggiorazione>
+        <ImportoTotaleDocumento>85.25</ImportoTotaleDocumento>
+        <Arrotondamento>0.00</Arrotondamento>
+      </DatiGeneraliDocumento>
+    </DatiGenerali>
+    <DatiBeniServizi>
+      <DettaglioLinee>
+        <NumeroLinea>1</NumeroLinea>
+        <Descrizione>BENE 1</Descrizione>
+        <Quantita>1.00</Quantita>
+        <PrezzoUnitario>85.25</PrezzoUnitario>
+        <PrezzoTotale>85.25</PrezzoTotale>
+        <AliquotaIVA>0.00</AliquotaIVA>
+        <Natura>N6.3</Natura>
+      </DettaglioLinee>
+      <DettaglioLinee>
+        <NumeroLinea>2</NumeroLinea>
+        <Descrizione>SPEDIZIONE</Descrizione>
+        <Quantita>1.00</Quantita>
+        <PrezzoUnitario>2.00</PrezzoUnitario>
+        <ScontoMaggiorazione>
+            <Tipo>SC</Tipo>
+            <Importo>2.00</Importo>
+        </ScontoMaggiorazione>
+        <PrezzoTotale>0.00</PrezzoTotale>
+        <AliquotaIVA>0.00</AliquotaIVA>
+        <Natura>N6.3</Natura>
+      </DettaglioLinee>
+      <DatiRiepilogo>
+        <AliquotaIVA>0.00</AliquotaIVA>
+        <Natura>N6.3</Natura>
+        <ImponibileImporto>85.25</ImponibileImporto>
+        <Imposta>0.00</Imposta>
+        <RiferimentoNormativo>Inversione contabile - Articolo 194 Direttiva 2006/112/EC</RiferimentoNormativo>
+      </DatiRiepilogo>
+    </DatiBeniServizi>
+  </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_fatturapa_in_rc/tests/test_fatturapa_in_rc_n63.py
+++ b/l10n_it_fatturapa_in_rc/tests/test_fatturapa_in_rc_n63.py
@@ -1,0 +1,141 @@
+from odoo.addons.l10n_it_fatturapa_in.tests.fatturapa_common import (
+    FatturapaCommon)
+from odoo.tests import tagged
+
+
+class TestInvoiceRCN63(FatturapaCommon):
+
+    def setUp(self):
+        super(TestInvoiceRCN63, self).setUp()
+        self.invoice_model = self.env['account.invoice']
+        self.invoice_line_model = self.env['account.invoice.line']
+        self.partner_model = self.env['res.partner']
+        self._create_account()
+        self._create_taxes()
+        self._create_journals()
+        self._create_rc_types()
+        self._create_rc_type_taxes()
+        self._create_fiscal_position()
+
+    def _create_account(self):
+        account_model = self.env['account.account']
+        self.account_selfinvoice = account_model.create({
+            'code': '295000',
+            'name': 'selfinvoice temporary',
+            'user_type_id': self.env.ref(
+                'account.data_account_type_current_liabilities').id
+        })
+
+    def _create_taxes(self):
+        tax_model = self.env['account.tax']
+        self.tax_n63ai = tax_model.create({
+            'name': "Acquisti Art. 17 c. 6 lett. a) ter (22%)",
+            'type_tax_use': 'purchase',
+            'amount': 22,
+            'kind_id': self.env.ref('l10n_it_account_tax_kind.n6_3').id,
+            'sequence': 20,
+        })
+        self.tax_n63vi = tax_model.create({
+            'name': "Acquisti Art. 17 c. 6 lett. a) ter (22%) (integrazione)",
+            'type_tax_use': 'sale',
+            'amount': 22,
+            'kind_id': self.env.ref('l10n_it_account_tax_kind.n6_3').id,
+            'law_reference': 'articoli 23 e 25 D.P.R. 633/1972',
+            'sequence': 20,
+        })
+
+    def _create_journals(self):
+        journal_model = self.env['account.journal']
+        self.journal_selfinvoice = journal_model.create({
+            'name': 'selfinvoice',
+            'type': 'sale',
+            'code': 'SLF',
+            'update_posted': True
+        })
+        self.journal_reconciliation = journal_model.create({
+            'name': 'RC reconciliation',
+            'type': 'bank',
+            'code': 'SLFRC',
+            'default_credit_account_id': self.account_selfinvoice.id,
+            'default_debit_account_id': self.account_selfinvoice.id,
+            'update_posted': True
+        })
+        self.journal_selfinvoice_extra = journal_model.create({
+            'name': 'Extra Selfinvoice',
+            'type': 'sale',
+            'code': 'SLFEX',
+            'update_posted': True
+        })
+
+    def _create_rc_types(self):
+        rc_type_model = self.env['account.rc.type']
+        self.rc_type_n6_3 = rc_type_model.create({
+            'name': 'Acquisti Art. 17 c. 6 lett. a) ter (22%)',
+            'method': 'selfinvoice',
+            'partner_type': 'other',
+            'partner_id': self.env.ref('base.main_partner').id,
+            'journal_id': self.journal_selfinvoice.id,
+            'payment_journal_id': self.journal_reconciliation.id,
+            'transitory_account_id': self.account_selfinvoice.id,
+            'e_invoice_suppliers': True,
+        })
+
+    def _create_rc_type_taxes(self):
+        rc_type_tax_model = self.env['account.rc.type.tax']
+        self.rc_type_tax_n6_3 = rc_type_tax_model.create({
+            'rc_type_id': self.rc_type_n6_3.id,
+            'purchase_tax_id': self.tax_n63ai.id,
+            'sale_tax_id': self.tax_n63vi.id
+        })
+        self.rc_type_n6_3.tax_ids = [(6, 0, self.rc_type_tax_n6_3.ids)]
+
+    def _create_fiscal_position(self):
+        model_fiscal_position = self.env['account.fiscal.position']
+        self.fiscal_position_rc_n6_3 = model_fiscal_position.create({
+            'name': 'Acquisti Art. 17 c. 6 lett. a) ter (22%) ITA',
+            'rc_type_id': self.rc_type_n6_3.id
+        })
+
+    def test_00_xml_import_n63(self):
+        res = self.run_wizard(
+            'test2', 'IT01234567890_FPR05.xml',
+            module_name='l10n_it_fatturapa_in_rc')
+        invoice_id = res.get('domain')[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        # Set invoice with RC fiscal position
+        invoice.fiscal_position_id=self.fiscal_position_rc_n6_3.id
+        # Set all invoice lines as RC line
+        for line in invoice.invoice_line_ids:
+            line.update({
+                "invoice_line_tax_ids": [(4, self.tax_n63ai.id)],
+                "rc": True,
+            })
+        self.assertEqual(invoice.invoice_line_ids[0].name, 'BENE 1')
+        self.assertTrue(invoice.invoice_line_ids[0].rc)
+        self.assertEqual(invoice.invoice_line_ids[1].name, 'SPEDIZIONE')
+        self.assertTrue(invoice.invoice_line_ids[1].rc)
+        self.assertEqual(
+            invoice.invoice_line_ids[0].invoice_line_tax_ids.name,
+            'Acquisti Art. 17 c. 6 lett. a) ter (22%)')
+        self.assertEqual(invoice.amount_total, 102.01)
+        self.assertEqual(invoice.get_tax_amount_added_for_rc(), 18.32)
+        self.assertEqual(invoice.amount_tax, 18.76)
+        self.assertEqual(invoice.e_invoice_amount_tax, 0.0)
+        invoice.action_invoice_open()
+        self.assertAlmostEqual(invoice.rc_self_invoice_id.amount_total, 102.01)
+        self.assertEqual(invoice.rc_self_invoice_id.amount_tax, 18.32)
+        self.assertEqual(invoice.rc_self_invoice_id.amount_untaxed, 85.25)
+        self.assertEqual(
+            invoice.rc_self_invoice_id.invoice_line_ids.
+            invoice_line_tax_ids.name,
+            'Acquisti Art. 17 c. 6 lett. a) ter (22%) (integrazione)'
+        )
+
+        partner = invoice.partner_id
+        partner.e_invoice_detail_level = '0'
+        res = self.run_wizard(
+            'test3', 'IT01234567890_FPR05.xml',
+            module_name='l10n_it_fatturapa_in_rc')
+        invoice_id = res.get('domain')[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertTrue(len(invoice.invoice_line_ids) == 0)


### PR DESCRIPTION
In some case, subctration of rc tax amount from invoice amount total can lead to long decimal places represantation that not allow to validate invoice because the method invoice amount total and e-invoice amount total are different, this is due to wrong floating point number representaion