### PR TITLE
[14.0] FIX l10n_it_fatturapa_in: importing refund with negative lines

### DIFF
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -323,7 +323,9 @@ class AccountInvoice(models.Model):
         for line in self.invoice_line_ids:
             if line.price_unit >= 0:
                 return
-        # if every line is negative, change them all
+        # if every line is negative, change them all, and change move type
+        if self.fiscal_document_type_id.code == "TD01":
+            self.move_type = "in_refund"
         for line in self.invoice_line_ids:
             line = line.with_context(check_move_validity=False)
             line.update({"price_unit": -line.price_unit})

--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -325,12 +325,19 @@ class AccountInvoice(models.Model):
                 return
         # if every line is negative, change them all
         for line in self.invoice_line_ids:
-            line.with_context(check_move_validity=False).update(
-                {"price_unit": -line.price_unit}
-            )
-        self.with_context(check_move_validity=False)._recompute_dynamic_lines(
-            recompute_all_taxes=True
-        )
+            line = line.with_context(check_move_validity=False)
+            line.update({"price_unit": -line.price_unit})
+            line._onchange_price_subtotal()
+            line._onchange_mark_recompute_taxes()
+        self.with_context(check_move_validity=False)._onchange_invoice_line_ids()
+        for line in self.line_ids:
+            if (
+                not line.amount_currency
+                and self.company_id.currency_id.id == self.currency_id.id
+            ):
+                # force updating amount_currency,
+                # computed like in account.move.line.create
+                line.update({"amount_currency": line.balance})
 
 
 class FatturapaArticleCode(models.Model):

--- a/l10n_it_fatturapa_in/tests/data/IT02098391200_FPR16.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT02098391200_FPR16.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FatturaElettronica xmlns="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" versione="FPR12">
+
+  <FatturaElettronicaHeader xmlns="">
+
+    <DatiTrasmissione>
+
+      <IdTrasmittente>
+
+        <IdPaese>IT</IdPaese>
+        <IdCodice>05979361218</IdCodice>
+
+      </IdTrasmittente>
+      <ProgressivoInvio>56Fvy</ProgressivoInvio>
+      <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+      <CodiceDestinatario>0000000</CodiceDestinatario>
+
+    </DatiTrasmissione>
+    <CedentePrestatore>
+
+      <DatiAnagrafici>
+
+        <IdFiscaleIVA>
+
+          <IdPaese>IT</IdPaese>
+          <IdCodice>02780790107</IdCodice>
+
+        </IdFiscaleIVA>
+        <CodiceFiscale>02780790107</CodiceFiscale>
+        <Anagrafica>
+
+          <Denominazione>SOCIETA' ALPHA SRL</Denominazione>
+
+        </Anagrafica>
+        <RegimeFiscale>RF01</RegimeFiscale>
+
+      </DatiAnagrafici>
+      <Sede>
+
+        <Indirizzo>VIALE ROMA 543</Indirizzo>
+        <CAP>07100</CAP>
+        <Comune>SASSARI</Comune>
+        <Provincia>SS</Provincia>
+        <Nazione>IT</Nazione>
+
+      </Sede>
+
+    </CedentePrestatore>
+    <CessionarioCommittente>
+
+      <DatiAnagrafici>
+        <CodiceFiscale>03533590174</CodiceFiscale>
+        <Anagrafica>
+          <Denominazione>BETA GAMMA</Denominazione>
+        </Anagrafica>
+      </DatiAnagrafici>
+      <Sede>
+        <Indirizzo>VIA TORINO 38-B</Indirizzo>
+        <CAP>00145</CAP>
+        <Comune>ROMA</Comune>
+        <Provincia>RM</Provincia>
+        <Nazione>IT</Nazione>
+      </Sede>
+
+    </CessionarioCommittente>
+  </FatturaElettronicaHeader>
+  <FatturaElettronicaBody xmlns="">
+
+    <DatiGenerali>
+
+      <DatiGeneraliDocumento>
+
+        <TipoDocumento>TD01</TipoDocumento>
+        <Divisa>EUR</Divisa>
+        <Data>2023-01-23</Data>
+        <Numero>2023/131703/1</Numero>
+        <ImportoTotaleDocumento>-1.83</ImportoTotaleDocumento>
+        <Causale>LA FATTURA FA RIFERIMENTO AD UNA OPERAZIONE AAAA BBBBBBBBBBBBBBBBBB CCC DDDDDDDDDDDDDDD E FFFFFFFFFFFFFFFFFFFF GGGGGGGGGG HHHHHHH II LLLLLLLLLLLLLLLLL MMM NNNNN OO PPPPPPPPPPP QQQQ RRRR SSSSSSSSSSSSSS</Causale>
+        <Causale>SEGUE DESCRIZIONE CAUSALE NEL CASO IN CUI NON SIANO STATI SUFFICIENTI 200 CARATTERI AAAAAAAAAAA BBBBBBBBBBBBBBBBB</Causale>
+
+      </DatiGeneraliDocumento>
+
+    </DatiGenerali>
+    <DatiBeniServizi>
+      <DettaglioLinee>
+
+        <NumeroLinea>10</NumeroLinea>
+        <Descrizione>Quota fissa Fognatura</Descrizione>
+        <Quantita>10.00</Quantita>
+        <DataInizioPeriodo>2022-01-01</DataInizioPeriodo>
+        <DataFinePeriodo>2022-04-19</DataFinePeriodo>
+        <PrezzoUnitario>-0.15</PrezzoUnitario>
+        <PrezzoTotale>-1.50</PrezzoTotale>
+        <AliquotaIVA>22.00</AliquotaIVA>
+
+      </DettaglioLinee>
+
+      <DatiRiepilogo>
+
+        <AliquotaIVA>22.00</AliquotaIVA>
+        <ImponibileImporto>-1.50</ImponibileImporto>
+        <Imposta>-0.33</Imposta>
+        <EsigibilitaIVA>I</EsigibilitaIVA>
+        <RiferimentoNormativo>IVA al 22%</RiferimentoNormativo>
+
+      </DatiRiepilogo>
+
+    </DatiBeniServizi>
+    <DatiPagamento>
+
+      <CondizioniPagamento>TP02</CondizioniPagamento>
+      <DettaglioPagamento>
+
+        <ModalitaPagamento>MP19</ModalitaPagamento>
+        <DataScadenzaPagamento>2023-02-22</DataScadenzaPagamento>
+        <ImportoPagamento>0.00</ImportoPagamento>
+
+      </DettaglioPagamento>
+
+    </DatiPagamento>
+  </FatturaElettronicaBody>
+
+</FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -984,6 +984,21 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
             ),
         )
 
+    def test_54_xml_import(self):
+        """
+        Test: Negative invoice (TD01) is correctly imported,
+        converted all values to positive and set move_type to in_refund
+        """
+        res = self.run_wizard("test54", "IT02098391200_FPR16.xml")
+        invoice_id = res.get("domain")[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        self.assertEqual(invoice.amount_untaxed, 1.5)
+        self.assertEqual(invoice.amount_total, 1.83)
+        self.assertEqual(invoice.invoice_line_ids[0].price_unit, 0.15)
+        self.assertEqual(invoice.invoice_line_ids[0].quantity, 10.0)
+        self.assertEqual(invoice.invoice_line_ids[0].price_subtotal, 1.5)
+        self.assertEqual(invoice.move_type, "in_refund")
+
     def test_01_xml_link(self):
         """
         E-invoice lines are created.


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/2465 e https://github.com/OCA/l10n-italy/issues/3523

Il caso dovrebbe essere coperto dal test https://github.com/OCA/l10n-italy/blob/14.0/l10n_it_fatturapa_in/tests/data/IT01234567890_FPR07.xml , infatti, importando tale file da browser, si ottiene l'errore.

Il test però non fallisce probabilmente perchè la valuta dell'azienda nei test è USD e quella delle fatture è EUR, mentre nell'importazione manuale è tutto EUR.

Ci sarebbe quindi da provare a fare un test dove la valuta dell'azienda è EUR