### PR TITLE
[14.0][FIX] restore separator in riba issue filter to exclude reconciled riba

### DIFF
--- a/l10n_it_ricevute_bancarie/views/account_view.xml
+++ b/l10n_it_ricevute_bancarie/views/account_view.xml
@@ -85,6 +85,7 @@
                     string="RIBA Issued"
                     domain="[('distinta_line_ids', '!=', False)]"
                 />
+                <separator />
                 <filter
                     name="reconciled"
                     string="Reconciled"


### PR DESCRIPTION
Nella migrazione è stato rimosso un `separator` che comporta che i filtri diventino in OR invece di essere in AND come nella v. 12.0, rendendo quindi inefficace il filtro composto.
Grazie a @TheMule71 per l'ottimo consiglio :)