### PR TITLE
[16.0][FIX] restore separator in riba issue filter to exclude reconciled riba

### DIFF
--- a/l10n_it_riba/views/account_view.xml
+++ b/l10n_it_riba/views/account_view.xml
@@ -89,6 +89,7 @@
                     string="Issued RiBas"
                     domain="[('slip_line_ids', '!=', False)]"
                 />
+            <separator />
             <filter
                     name="reconciled"
                     string="Reconciled"


### PR DESCRIPTION
forward port of #3754