### PR TITLE
[FIX] Stale github action processa poche PR/issues a ogni run

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -43,6 +43,7 @@ jobs:
 
             If you want this issue to never become stale, please ask a PSC member to
             apply the "no stale" label.
+          operations-per-run: 100
 
       # 15+30 day stale policy for issues pending more information
       # * Issues that are pending more information


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/3334.

Direi di provare ad aumentare come suggerito in
>@SirTakobi @TheMule71 
>
>Quanto costa / cosa comporta aumentare il numero di operazioni della action? 
>
>Credo che se si aumentassero per qualche settimana o mese sarebbe in grado di smaltire il backlog, e il numero di operazioni necessarie si ri-abbasserebbe nel tempo
>
>Penso che l'etichetta "stale" sia un buon sistema per richiamare l'attenzione a task lasciate indietro e sollecitare una verifica sulle funzionalità che sono veramente necessarie

_Originally posted by @francesco-ooops in https://github.com/OCA/l10n-italy/issues/3334#issuecomment-1635719117_