### PR TITLE
[FIX] l10n_it_delivery_note: fix join clause in pre-migrate script

### DIFF
--- a/l10n_it_delivery_note/migrations/13.0.1.0.0/pre-migrate.py
+++ b/l10n_it_delivery_note/migrations/13.0.1.0.0/pre-migrate.py
@@ -24,16 +24,21 @@ def migrate(env, version):
             ),
         )
     # update invoice_id ref in table
+    if openupgrade.column_exists(env.cr, "account_move", "old_invoice_id"):
+        clause = "am.old_invoice_id = inv.id"
+    else:
+        clause = "am.id = inv.move_id"
     query = """
         UPDATE {table}
         SET
             invoice_id = am.id
         FROM account_invoice inv
-            JOIN account_move am ON am.id = inv.move_id
+            JOIN account_move am ON {clause}
         WHERE
             invoice_id = inv.id
     """.format(
-        table=table
+        table=table,
+        clause=clause,
     )
     openupgrade.logged_query(
         env.cr,


### PR DESCRIPTION
Come discusso qui https://discord.com/channels/753902328494424064/753902328494424070/1184785631025569833, nella migrazione del modulo dalla versione 12.0 alla 14.0 viene assegnato l'ID dell'account.move relativa alla vecchia account.invoice alla DN, ma senza la correzione della clausola del JOIN nell'UPDATE dava questo errore:
```
ALTER TABLE "stock_delivery_note_account_invoice_rel_invoice_id_fkey" ADD FOREIGN KEY ("invoice_id") REFERENCES "account_move"("id") ON DELETE cascade
ERROR: insert or update on table "stock_delivery_note_account_invoice_rel" violates foreign key constraint "stock_delivery_note_account_invoice_rel_invoice_id_fkey"
DETAIL: Key (invoice_id)=(xxx) is not present in table "account_move"
```