### PR TITLE
[IMP] l10n_it_account_stamp: Usabilità per il bollo in fattura

### DIFF
--- a/l10n_it_account_stamp/README.rst
+++ b/l10n_it_account_stamp/README.rst
@@ -152,6 +152,9 @@ Contributors
 -  Marco Colombo <https://github.com/TheMule71>
 -  Gianmarco Conte <gconte@dinamicheaziendali.it>
 -  Giovanni Serra <giovanni@gslab.it>
+-  `Aion Tech <https://aiontech.company/>`__:
+
+   -  Simone Rubino <simone.rubino@aion-tech.it>
 
 Maintainers
 -----------

--- a/l10n_it_account_stamp/readme/CONTRIBUTORS.md
+++ b/l10n_it_account_stamp/readme/CONTRIBUTORS.md
@@ -6,3 +6,5 @@
 - Marco Colombo \<<https://github.com/TheMule71>\>
 - Gianmarco Conte \<<gconte@dinamicheaziendali.it>\>
 - Giovanni Serra \<<giovanni@gslab.it>\>
+- [Aion Tech](https://aiontech.company/):
+  - Simone Rubino \<<simone.rubino@aion-tech.it>\>

--- a/l10n_it_account_stamp/static/description/index.html
+++ b/l10n_it_account_stamp/static/description/index.html
@@ -486,6 +486,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Marco Colombo &lt;<a class="reference external" href="https://github.com/TheMule71">https://github.com/TheMule71</a>&gt;</li>
 <li>Gianmarco Conte &lt;<a class="reference external" href="mailto:gconte&#64;dinamicheaziendali.it">gconte&#64;dinamicheaziendali.it</a>&gt;</li>
 <li>Giovanni Serra &lt;<a class="reference external" href="mailto:giovanni&#64;gslab.it">giovanni&#64;gslab.it</a>&gt;</li>
+<li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
+++ b/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
@@ -101,3 +101,28 @@ class InvoicingTest(TestAccountInvoiceReport):
         total = invoice.amount_total
         invoice.action_post()
         self.assertEqual(total, invoice.amount_total)
+
+    def test_tax_stamp_line_button(self):
+        """Stamp fields show when stamp is added with the button to the invoice."""
+        # Arrange: Create an invoice eligible for tax stamp but without it
+        stamp_tax = self.tax_id
+        invoice = self.init_invoice(
+            "out_invoice",
+            taxes=stamp_tax,
+            amounts=[
+                100,
+            ],
+        )
+        # pre-condition
+        self.assertTrue(invoice.tax_stamp)
+        self.assertFalse(invoice.tax_stamp_line_present)
+
+        # Act
+        invoice.add_tax_stamp_line()
+
+        # Assert
+        self.assertTrue(invoice.tax_stamp_line_present)
+
+        # Resetting to draft removes the stamp
+        invoice.button_draft()
+        self.assertFalse(invoice.tax_stamp_line_present)

--- a/l10n_it_account_stamp/views/account_move_view.xml
+++ b/l10n_it_account_stamp/views/account_move_view.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2023 Simone Rubino - Aion Tech
+  ~ License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+  -->
 <odoo>
 
     <!-- Form: Invoice Customer -->
@@ -23,20 +27,38 @@
                     name="manually_apply_tax_stamp"
                     attrs="{'invisible': [('auto_compute_stamp', '=', True)]}"
                 />
+                <field name="tax_stamp_line_present" invisible="1" />
             </xpath>
             <field name="narration" position="before">
-                <img
-                    src="/l10n_it_account_stamp/static/description/icon.png"
-                    alt="Tax stamp"
+                <div
+                    name="stamp_applicability"
                     attrs="{'invisible': [('tax_stamp', '=', False)]}"
-                />
-                <button
-                    class="oe_edit_only"
-                    type="object"
-                    string="Add tax stamp line"
-                    name="add_tax_stamp_line"
-                    attrs="{'invisible': ['|',('tax_stamp', '=', False),('state', 'not in', 'draft')]}"
-                />
+                    colspan="2"
+                >
+                    <img
+                        src="/l10n_it_account_stamp/static/description/icon.png"
+                        alt="Tax stamp"
+                    />
+                    <span
+                        attrs="{'invisible': [('tax_stamp_line_present', '=', True)]}"
+                    >
+                        <span attrs="{'invisible': [('state', 'not in', 'draft')]}">
+                            <button
+                                type="object"
+                                string="Charge stamp to customer"
+                                name="add_tax_stamp_line"
+                            />
+                        </span>
+                        <span attrs="{'invisible': [('state', '=', 'draft')]}">
+                            Stamp can only be charged to customer when invoice is in draft state
+                        </span>
+                    </span>
+                    <span
+                        attrs="{'invisible': [('tax_stamp_line_present', '=', False)]}"
+                    >
+                        Stamp charged to customer
+                    </span>
+                </div>
                 <!--move narration down-->
                 <div />
             </field>


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/2447 per `16.0`﻿.

Forward port di https://github.com/OCA/l10n-italy/pull/2448.
Manca https://github.com/OCA/l10n-italy/commit/c34b3595de1e2b3cd22e1ddc9710e0665517f609 perché è stato risolto nella migrazione https://github.com/OCA/l10n-italy/commit/86e6cc744bece079243345dfc50fe75d71d0b1d6.

Sostituisce https://github.com/OCA/l10n-italy/pull/3457 per risolvere https://github.com/OCA/l10n-italy/pull/3457#pullrequestreview-1769957034.
