### PR TITLE
[IMP] Impedire la creazione della fattura elettronica per i corrispettivi + abilita esportazione FE per note di credito

### DIFF
--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -9,7 +9,7 @@
             <xpath expr="//field[@name='state']" position="before">
                 <field
                     name="fatturapa_state"
-                    invisible="context.get('default_move_type') not in ('out_invoice', 'in_refund')"
+                    invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund')"
                 />
             </xpath>
         </field>
@@ -30,7 +30,7 @@
                     attrs="{
                         'invisible': [
                             '|',
-                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                ('move_type', 'not in', ('out_invoice', 'out_refund')),
                                 '|',
                                     '|',
                                         ('fatturapa_attachment_out_id', '!=', False),
@@ -47,7 +47,7 @@
                     attrs="{
                         'invisible': [
                             '|',
-                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                ('move_type', 'not in', ('out_invoice', 'out_refund')),
                                 '|',
                                     '|',
                                         ('fatturapa_attachment_out_id', '=', False),
@@ -65,7 +65,7 @@
                     name="fatturapa_state"
                     attrs="{
                         'invisible': [
-                            ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                            ('move_type', 'not in', ('out_invoice', 'out_refund')),
                         ],
                     }"
                 />
@@ -77,7 +77,7 @@
                     attrs="{
                         'invisible': [
                             '|',
-                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                ('move_type', 'not in', ('out_invoice', 'out_refund')),
                                 ('electronic_invoice_subjected', '=', False),
                         ],
                     }"
@@ -101,7 +101,7 @@
                     attrs="{
                         'invisible': [
                             '|',
-                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                ('move_type', 'not in', ('out_invoice', 'out_refund')),
                                 '&amp;',
                                     ('electronic_invoice_subjected', '=', False),
                                     ('fatturapa_attachment_out_id', '=', False),
@@ -123,7 +123,7 @@
                     attrs="{
                         'invisible': [
                             '|',
-                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                ('move_type', 'not in', ('out_invoice', 'out_refund')),
                                 '&amp;',
                                     ('electronic_invoice_subjected', '=', False),
                                     ('fatturapa_attachment_out_id', '=', False),

--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -7,7 +7,10 @@
         <field name="inherit_id" ref="account.view_invoice_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='state']" position="before">
-                <field name="fatturapa_state" />
+                <field
+                    name="fatturapa_state"
+                    invisible="context.get('default_move_type') not in ('out_invoice', 'in_refund')"
+                />
             </xpath>
         </field>
     </record>
@@ -24,27 +27,60 @@
                     type="action"
                     string="Export E-invoice"
                     class="oe_highlight"
-                    attrs="{'invisible': ['|', '|', ('fatturapa_attachment_out_id', '!=', False), ('state' ,'!=', 'posted'), ('electronic_invoice_subjected', '=', False)]}"
+                    attrs="{
+                        'invisible': [
+                            '|',
+                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                '|',
+                                    '|',
+                                        ('fatturapa_attachment_out_id', '!=', False),
+                                        ('state' ,'!=', 'posted'),
+                                    ('electronic_invoice_subjected', '=', False),
+                        ],
+                    }"
                 />
                 <button
                     name="%(action_wizard_export_fatturapa_regenerate)d"
                     type="action"
                     string="Re-Export E-invoice"
                     class="oe_highlight"
-                    attrs="{'invisible': ['|', '|', ('fatturapa_attachment_out_id', '=', False), ('state' ,'!=', 'posted'), ('fatturapa_state', 'not in', ['error'])]}"
+                    attrs="{
+                        'invisible': [
+                            '|',
+                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                '|',
+                                    '|',
+                                        ('fatturapa_attachment_out_id', '=', False),
+                                        ('state' ,'!=', 'posted'),
+                                    ('fatturapa_state', 'not in', ['error']),
+                        ],
+                    }"
                 />
             </button>
             <field name="partner_id" position="after">
                 <field name="electronic_invoice_subjected" invisible="1" />
             </field>
             <xpath expr="//field[@name='invoice_date']" position="after">
-                <field name="fatturapa_state" />
+                <field
+                    name="fatturapa_state"
+                    attrs="{
+                        'invisible': [
+                            ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                        ],
+                    }"
+                />
             </xpath>
 
             <xpath expr="//notebook" position="inside">
                 <page
                     string="Related Documents"
-                    attrs="{'invisible': [('electronic_invoice_subjected', '=', False)]}"
+                    attrs="{
+                        'invisible': [
+                            '|',
+                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                ('electronic_invoice_subjected', '=', False),
+                        ],
+                    }"
                 >
                     <field name="related_documents" nolabel="1">
                         <tree editable="bottom">
@@ -62,8 +98,15 @@
                 </page>
                 <page
                     string="Electronic Invoice"
-                    attrs="{'invisible': [('electronic_invoice_subjected', '=', False),
-                                          ('fatturapa_attachment_out_id', '=', False)]}"
+                    attrs="{
+                        'invisible': [
+                            '|',
+                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                '&amp;',
+                                    ('electronic_invoice_subjected', '=', False),
+                                    ('fatturapa_attachment_out_id', '=', False),
+                        ],
+                    }"
                 >
                     <group>
                         <group string="Results">
@@ -77,8 +120,15 @@
                 </page>
                 <page
                     string="Electronic Invoice Attachments"
-                    attrs="{'invisible': [('electronic_invoice_subjected', '=', False),
-                                          ('fatturapa_attachment_out_id', '=', False)]}"
+                    attrs="{
+                        'invisible': [
+                            '|',
+                                ('move_type', 'not in', ('out_invoice', 'in_refund')),
+                                '&amp;',
+                                    ('electronic_invoice_subjected', '=', False),
+                                    ('fatturapa_attachment_out_id', '=', False),
+                        ],
+                    }"
                 >
                     <field name="fatturapa_doc_attachments" nolabel="1">
                         <tree>


### PR DESCRIPTION
Forward port di https://github.com/OCA/l10n-italy/pull/2979 e https://github.com/OCA/l10n-italy/pull/3421.

Di #2979 ho preso solo il commit che non ha a che fare con **l10n_it_corrispettivi_fatturapa_out** perché la migrazione del modulo dovrebbe essere già stata eseguita durante la migrazione di **l10n_it_fatturapa_out** a `14.0`.

Risolve https://github.com/OCA/l10n-italy/issues/3420 per `16.0`.