### PR TITLE
[14.0][FIX] l10n_it_delivery_note_inter_*: remove pickings

### DIFF
--- a/l10n_it_delivery_note_inter_company/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note_inter_company/models/stock_delivery_note.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Ooops404
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import fields, models
 
 
 class StockDeliveryNote(models.Model):
@@ -14,7 +14,9 @@ class StockDeliveryNote(models.Model):
             if picking_ids:
                 # We want to give access to the referenced
                 # delivery note only in this specific case
-                intercompany_picking_id = picking_ids[-1].intercompany_picking_id.sudo()
+                intercompany_picking_id = fields.first(
+                    picking_ids[::-1]
+                ).intercompany_picking_id.sudo()
 
                 intercompany_note = intercompany_picking_id.delivery_note_id
                 note.partner_ref = intercompany_note.name

--- a/l10n_it_delivery_note_inter_warehouse/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note_inter_warehouse/models/stock_delivery_note.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Ooops404
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import fields, models
 
 
 class StockDeliveryNote(models.Model):
@@ -10,7 +10,8 @@ class StockDeliveryNote(models.Model):
     def update_detail_lines(self):
         res = super().update_detail_lines()
         for note in self:
-            inter_wh_note_id = note.picking_ids[-1].mapped(
+            # Safe operation to get last element
+            inter_wh_note_id = fields.first(note.picking_ids[::-1]).mapped(
                 "move_lines.inter_warehouse_picking_id.delivery_note_id"
             )
             if inter_wh_note_id:


### PR DESCRIPTION
Fixato un bug che non permetteva la rimozione di tutti i picking in modalità avanzata. 

Il bug era analogo in entrambi i moduli.