### PR TITLE
[FIX] Data dismissione già compilata per cespite da fattura di acquisto

### DIFF
--- a/assets_management/tests/test_assets_management.py
+++ b/assets_management/tests/test_assets_management.py
@@ -362,6 +362,7 @@ class TestAssets(SavepointCase):
             )
         )
         asset = wiz.link_asset()
+        self.assertFalse(asset.dismiss_date)
         self.assertEqual(asset.purchase_amount, 7000)
         # dismiss asset with sale
         # create sale invoice and link to asset

--- a/assets_management/wizard/account_move_manage_asset.py
+++ b/assets_management/wizard/account_move_manage_asset.py
@@ -373,6 +373,7 @@ class WizardAccountMoveManageAsset(models.TransientModel):
             "code": self.code,
             "company_id": self.company_id.id,
             "currency_id": self.currency_id.id,
+            "dismiss_date": False,
             "name": self.name,
             "purchase_amount": purchase_amount,
             "purchase_date": self.purchase_date,


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/3851 per `14.0`.