### PR TITLE
[14.0] [FIX] l10n_it_delivery_note_base: add migration for model data

### DIFF
--- a/l10n_it_delivery_note_base/migrations/14.0.1.0.1/pre-migrate.py
+++ b/l10n_it_delivery_note_base/migrations/14.0.1.0.1/pre-migrate.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Nextev Srl
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # delete ir.sequence model data due to change
+    # into via code creation for every company
+    deleted_dn_seq_data = (
+        "l10n_it_delivery_note_base.delivery_note_sequence_ddt_incoming",
+        "l10n_it_delivery_note_base.delivery_note_sequence_ddt",
+        "l10n_it_delivery_note_base.delivery_note_sequence_ddt_internal",
+    )
+    openupgrade.delete_records_safely_by_xml_id(env, deleted_dn_seq_data)
+
+    # delete stock.delivery.note.type model data due to change
+    # into via code creation for every company
+    deleted_dn_type_data = (
+        "l10n_it_delivery_note_base.delivery_note_type_incoming_ddt",
+        "l10n_it_delivery_note_base.delivery_note_type_ddt",
+        "l10n_it_delivery_note_base.delivery_note_type_priced_ddt",
+        "l10n_it_delivery_note_base.delivery_note_type_internal_ddt",
+    )
+    openupgrade.delete_records_safely_by_xml_id(env, deleted_dn_type_data)


### PR DESCRIPTION
Nella versione 14.0 del modulo `l10n_it_delivery_note_base` sono stati rimossi degli `ir.model.data` per avere una creazione dinamica delle sequenze ed i tipi di DN per ogni azienda.
https://github.com/OCA/l10n-italy/issues/3257

Questo crea un problema durante la migrazione da 12.0 a 14.0 perchè, post aggiornamento del modulo, Odoo cerca di cancellare i riferimenti a questi record perchè non esistono più nei `data`, ma non deve farlo perchè esistono ugualmente nel DB.

Per sistemare la questione propongo di cancellare in anticipo nel `pre-migrate` i riferimenti di modo che post migrazione non cerchi di rimuovere anche i record automaticamente.