### PR TITLE
[16.0] FIX l10n_it_reverse_charge: reconcile_supplier_invoice setting currency to avoid redundant exchange_diff_move when not needed

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -194,6 +194,7 @@ class AccountMove(models.Model):
             "credit": credit,
             "debit": debit,
             "account_id": account.id,
+            "currency_id": self.currency_id.id,
         }
 
     def _rc_credit_line_amounts(self, amount):


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/3863