### PR TITLE
[FIX] l10n_it_intrastat country destination visible in out refund too

### DIFF
--- a/l10n_it_intrastat/views/account.xml
+++ b/l10n_it_intrastat/views/account.xml
@@ -140,9 +140,9 @@
                             name="country_destination_id"
                             attrs="{
                                    'invisible': [
-                                       ('statement_section', 'not in', ['sale_s1'])],
+                                       ('statement_section', 'not in', ['sale_s1', 'sale_s2'])],
                                    'required': [
-                                       ('statement_section', 'in', ['sale_s1'])]}"
+                                       ('statement_section', 'in', ['sale_s1', 'sale_s2'])]}"
                         />
                            </group>
 


### PR DESCRIPTION
Nello stesso modo che nelle fatture, così se un utente ha modificato il paese di destinazione in fattura può cambiarlo sulla nota di credito.