### PR TITLE
[14.0][l10n_it_intrastat_statement] Fix credit note compensation not in period

### DIFF
--- a/l10n_it_intrastat_statement/models/intrastat_statement.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Simone Rubino - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 from dateutil.relativedelta import relativedelta
 
@@ -449,7 +449,7 @@ class AccountIntrastatStatement(models.Model):
             month = self.period_number
             period_date_start = date(year, month, 1)
             period_date_stop = (
-                datetime(year, month, 1) + relativedelta(months=1) - timedelta(days=1)
+                period_date_start + relativedelta(months=1) - timedelta(days=1)
             )
         elif self.period_type == "T":
             quarter = self.period_number
@@ -819,11 +819,21 @@ class AccountIntrastatStatement(models.Model):
                 refund_section_details = (section_type, refund_section_number)
                 section_field = self.get_section_field_name(*section_details)
                 for line in self[section_field]:
-                    refund_section_model = self.get_section_model(
-                        *refund_section_details
-                    )
-                    to_refund_model = self.env[refund_section_model]
-                    self.refund_line(line, to_refund_model)
+                    # Compensation can happen only if the credit note has been issued
+                    # for invoices belonging the considered period. Here we check
+                    # if the reversed entry of the Sale/Purchase section 2 line
+                    # respect this constraint otherwise no compensation should
+                    # happen
+                    refund_date = line.invoice_id.reversed_entry_id.invoice_date
+                    if (
+                        refund_date
+                        and period_date_start <= refund_date <= period_date_stop
+                    ):
+                        refund_section_model = self.get_section_model(
+                            *refund_section_details
+                        )
+                        to_refund_model = self.env[refund_section_model]
+                        self.refund_line(line, to_refund_model)
         return True
 
     @staticmethod

--- a/l10n_it_intrastat_statement/views/intrastat.xml
+++ b/l10n_it_intrastat_statement/views/intrastat.xml
@@ -282,15 +282,15 @@
             <field name="model">account.intrastat.statement.sale.section1</field>
             <field name="arch" type="xml">
                 <tree>
-                   <field name="sequence" />
-                   <field name="invoice_id" />
-                   <field name="partner_id" string="Buyer" />
-                   <field name="country_partner_id" string="Buyer State" />
-                   <field name="intrastat_code_id" string="Goods Code" />
-                   <field name="weight_kg" />
-                   <field name="country_destination_id" />
-                   <field name="province_origin_id" />
-                   <field name="amount_euro" sum="Total" />
+                    <field name="sequence" />
+                    <field name="invoice_id" />
+                    <field name="partner_id" string="Buyer" />
+                    <field name="country_partner_id" string="Buyer State" />
+                    <field name="intrastat_code_id" string="Goods Code" />
+                    <field name="weight_kg" />
+                    <field name="country_destination_id" />
+                    <field name="province_origin_id" />
+                    <field name="amount_euro" sum="Total" />
                </tree>
             </field>
         </record>
@@ -356,16 +356,17 @@
             <field name="model">account.intrastat.statement.sale.section2</field>
             <field name="arch" type="xml">
                 <tree>
-                   <field name="sequence" />
-                   <field name="year_id" />
-                   <field name="quarterly" />
-                   <field name="month" />
-                   <field name="country_partner_id" string="Buyer State" />
-                   <field name="partner_id" string="Buyer" />
-                   <field name="vat_code" string="Buyer VAT Code" />
-                   <field name="intrastat_code_id" string="Goods Code" />
-                   <field name="sign_variation" />
-                   <field name="amount_euro" sum="Total" />
+                    <field name="sequence" />
+                    <field name="invoice_id" />
+                    <field name="year_id" />
+                    <field name="quarterly" />
+                    <field name="month" />
+                    <field name="country_partner_id" string="Buyer State" />
+                    <field name="partner_id" string="Buyer" />
+                    <field name="vat_code" string="Buyer VAT Code" />
+                    <field name="intrastat_code_id" string="Goods Code" />
+                    <field name="sign_variation" />
+                    <field name="amount_euro" sum="Total" />
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
La PR fixa il problema della compensazione delle note di credito emesse/ricevute che fanno riferimento a fatture NON del periodo considerato dalla dichiarazione