### PR TITLE
[16.0] [FIX] l10n_it_account_tax_kind unhide law reference on tax

### DIFF
--- a/l10n_it_account_tax_kind/view/account_tax_view.xml
+++ b/l10n_it_account_tax_kind/view/account_tax_view.xml
@@ -10,7 +10,7 @@
                 <field name="kind_id" />
                 <field
                     name="law_reference"
-                    attrs="{'required': [('kind_id', '!=', False),('type_tax_use', '!=', 'purchase')], 'invisible': ['|',('kind_id', '=', False),('type_tax_use', '=', 'purchase')]}"
+                    attrs="{'required': [('kind_id', '!=', False),('type_tax_use', '!=', 'purchase')], 'invisible': [('type_tax_use', '=', 'purchase')]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/3893