### PR TITLE
[14.0] [IMP] l10n_it_delivery_note: group pickings by dn state and date

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -26,7 +26,7 @@ class StockPicking(models.Model):
         "ir.sequence", related="delivery_note_id.sequence_id"
     )
     delivery_note_state = fields.Selection(
-        string="DN State", related="delivery_note_id.state"
+        string="DN State", related="delivery_note_id.state", store=True
     )
     delivery_note_partner_ref = fields.Char(related="delivery_note_id.partner_ref")
     delivery_note_partner_shipping_id = fields.Many2one(
@@ -46,7 +46,9 @@ class StockPicking(models.Model):
         check_company=True,
     )
     delivery_note_type_code = fields.Selection(related="delivery_note_type_id.code")
-    delivery_note_date = fields.Date(string="DN Date", related="delivery_note_id.date")
+    delivery_note_date = fields.Date(
+        string="DN Date", related="delivery_note_id.date", store=True
+    )
     delivery_note_note = fields.Html(related="delivery_note_id.note")
 
     transport_condition_id = fields.Many2one(

--- a/l10n_it_delivery_note/views/stock_picking.xml
+++ b/l10n_it_delivery_note/views/stock_picking.xml
@@ -382,6 +382,18 @@
                     domain="[('delivery_note_state', '=', 'confirm')]"
                 />
             </xpath>
+            <group position="inside">
+                <filter
+                    name="delivery_note_state"
+                    domain="[]"
+                    context="{'group_by': 'delivery_note_state'}"
+                />
+                <filter
+                    name="delivery_note_date"
+                    domain="[]"
+                    context="{'group_by': 'delivery_note_date'}"
+                />
+            </group>
         </field>
     </record>
 


### PR DESCRIPTION
- Add options to group pickings by delivery note state and date
- Make delivery note state and date sortable in picking's tree view