### PR TITLE
[16.0] FIX l10n_it_withholding_tax when other localizations are installed

### DIFF
--- a/l10n_it_withholding_tax/__manifest__.py
+++ b/l10n_it_withholding_tax/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "ITA - Ritenute d'acconto",
-    "version": "16.0.1.1.8",
+    "version": "16.0.1.2.0",
     "category": "Account",
     "author": "Openforce, Odoo Italia Network, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-italy",

--- a/l10n_it_withholding_tax/migrations/16.0.1.2.0/post-migrate.py
+++ b/l10n_it_withholding_tax/migrations/16.0.1.2.0/post-migrate.py
@@ -1,0 +1,9 @@
+#  Copyright 2024 Simone Rubino - Aion Tech
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, installed_version):
+    env.ref("l10n_it_withholding_tax.document_tax_totals_wt").mode = "extension"

--- a/l10n_it_withholding_tax/views/report_invoice.xml
+++ b/l10n_it_withholding_tax/views/report_invoice.xml
@@ -46,30 +46,30 @@
             </t>
         </xpath>
 
-        <xpath expr="//t[@t-call='account.document_tax_totals']" position="attributes">
-            <attribute
-                name="t-call"
-            >l10n_it_withholding_tax.document_tax_totals_wt</attribute>
-        </xpath>
-
     </template>
 
-    <template
-        id="document_tax_totals_wt"
-        inherit_id="account.document_tax_totals"
-        primary="True"
-    >
-            <xpath expr="//tr[hasclass('o_total')]" position="after">
-                <t t-if="o.withholding_tax_in_print and o.withholding_tax">
+    <template id="document_tax_totals_wt" inherit_id="account.document_tax_totals">
+        <xpath expr="//tr[hasclass('o_total')]" position="after">
+            <t t-set="withholding_doc" t-value="o or doc" />
+            <t t-if="withholding_doc">
+                <t
+                    t-set="has_withholding_tax"
+                    t-value="'withholding_tax' in withholding_doc._fields and withholding_doc.withholding_tax"
+                />
+                <t
+                    t-set="print_withholding_tax"
+                    t-value="'withholding_tax_in_print' in withholding_doc._fields and withholding_doc.withholding_tax_in_print"
+                />
+                <t t-if="print_withholding_tax and has_withholding_tax">
                     <tr>
                         <td>
                             <span>Withholding Tax</span>
                         </td>
                         <td class="text-end">
                             <span
-                            t-field="o.withholding_tax_amount"
-                            t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
-                        />
+                                t-field="withholding_doc.withholding_tax_amount"
+                                t-options="{'widget': 'monetary', 'display_currency': withholding_doc.currency_id}"
+                            />
                         </td>
                     </tr>
                     <tr class="border-black">
@@ -78,13 +78,14 @@
                         </td>
                         <td class="text-end">
                             <span
-                            t-field="o.amount_net_pay"
-                            t-options="{'widget': 'monetary', 'display_currency': o.currency_id}"
-                        />
+                                t-field="withholding_doc.amount_net_pay"
+                                t-options="{'widget': 'monetary', 'display_currency': withholding_doc.currency_id}"
+                            />
                         </td>
                     </tr>
                 </t>
-            </xpath>
+            </t>
+        </xpath>
     </template>
 
 </odoo>


### PR DESCRIPTION
Steps:

 - Install l10n_it_withholding_tax
 - install l10n_ar
 - with AR company, print invoice PDF

Get
`ValueError: Element '<t t-call="account.document_tax_totals">' cannot be located in parent view`

Si veda ad esempio
https://github.com/odoo/odoo/blob/d573af55daca3e9e840aaaddaf8d75937b205391/addons/l10n_au/models/account_move.py#L8
e
https://github.com/odoo/odoo/blob/d573af55daca3e9e840aaaddaf8d75937b205391/addons/l10n_au/views/report_invoice.xml#L3