### PR TITLE
[14.0] [IMP] l10n_it_delivery_note: delivery note company field adjustments

### DIFF
--- a/l10n_it_delivery_note/views/stock_delivery_note.xml
+++ b/l10n_it_delivery_note/views/stock_delivery_note.xml
@@ -134,12 +134,6 @@
                     <group>
                         <group>
                             <field
-                                name="company_id"
-                                options="{'no_create': True}"
-                                attrs="{'readonly': [('pickings_picker', '!=', [])]}"
-                                groups="base.group_multi_company"
-                            />
-                            <field
                                 name="partner_sender_id"
                                 attrs="{'readonly': [('pickings_picker', '!=', [])]}"
                             />
@@ -176,6 +170,13 @@
                                     title="Update to now"
                                 />
                             </div>
+                            <field
+                                name="company_id"
+                                options="{'no_create': True}"
+                                attrs="{'readonly': [('pickings_picker', '!=', [])]}"
+                                groups="base.group_multi_company"
+                                domain="[('id', 'in', context.get('allowed_company_ids', []))]"
+                            />
                         </group>
                     </group>
                     <group>


### PR DESCRIPTION
- Moved `company_id` under `transport_datetime`
- Filter domain on user's enabled companies