### PR TITLE
[16.0] FIX l10n_it_fatturapa_out and l10n_it_fatturapa_out_rc avoiding to convert to EUR tax_base_amount as it is already in company currency (currency_field='company_currency_id')

### DIFF
--- a/l10n_it_fatturapa_out/data/invoice_it_template.xml
+++ b/l10n_it_fatturapa_out/data/invoice_it_template.xml
@@ -170,7 +170,7 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
                 t-call="l10n_it_fatturapa_out.account_invoice_line_it_sconto_maggiorazione"
             />
                 <PrezzoTotale
-                t-out="format_monetary(fpa_to_eur(line.price_subtotal, record), euro)"
+                t-out="format_monetary(fpa_to_eur(line.price_subtotal, record, line.currency_rate), euro)"
             />
                 <AliquotaIVA
                 t-if="not line_is_section_note"
@@ -219,27 +219,6 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
             </DettaglioLinee>
         </template>
 
-        <template id="account_invoice_line_it_dati_riepilogo">
-            <t t-set="tax" t-value="tax_line.tax_line_id" />
-            <DatiRiepilogo>
-                <!--2.2.2-->
-                <AliquotaIVA t-out="format_numbers(tax.amount)" />
-                <Natura t-if="tax.kind_id.code" t-out="tax.kind_id.code" />
-                <!--                <SpeseAccessorie t-out=""/>-->
-                <!--                <Arrotondamento t-out=""/>-->
-                <ImponibileImporto
-                t-out="format_monetary(fpa_to_eur(tax_line.tax_base_amount, record), euro)"
-            />
-                <Imposta
-                t-out="format_monetary(fpa_to_eur(tax_line.price_total, record), euro)"
-            />
-                <EsigibilitaIVA t-if="tax.payability" t-out="tax.payability" />
-                <RiferimentoNormativo
-                t-if="tax.law_reference"
-                t-out="encode_for_export(tax.law_reference, 100)"
-            />
-            </DatiRiepilogo>
-        </template>
         <template id="account_invoice_it_FatturaPA_sede">
             <t t-set="indirizzo"><t
                 t-if="partner_id.street2"
@@ -599,10 +578,10 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
                               <!--                <SpeseAccessorie t-out=""/>-->
                               <!--                <Arrotondamento t-out=""/>-->
                               <ImponibileImporto
-                            t-out="format_monetary(fpa_to_eur(tax_data['ImponibileImporto'], record), euro)"
+                            t-out="format_monetary(tax_data['ImponibileImporto'], euro)"
                         />
                               <Imposta
-                            t-out="format_monetary(fpa_to_eur(tax_data['Imposta'], record), euro)"
+                            t-out="format_monetary(tax_data['Imposta'], euro)"
                         />
                                 <EsigibilitaIVA
                             t-if="tax_data.get('EsigibilitaIVA', False)"
@@ -647,7 +626,7 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
                         />
                             <ImportoPagamento
                             t-if="not record.company_id.xml_divisa_value == 'keep_orig'"
-                            t-out="format_numbers_two(fpa_to_eur(payment.amount_currency or payment.debit, record))"
+                            t-out="format_numbers_two(fpa_to_eur(payment.amount_currency or payment.debit, record, payment.currency_rate))"
                         />
 
                             <!--                            <CodUfficioPostale t-out=""/>-->

--- a/l10n_it_fatturapa_out_oss/data/invoice_it_template.xml
+++ b/l10n_it_fatturapa_out_oss/data/invoice_it_template.xml
@@ -26,7 +26,7 @@
                     t-out="tax_data['Natura']"
                 />
                 <ImponibileImporto
-                    t-out="format_monetary(fpa_to_eur(tax_data['ImponibileImporto'], record), euro)"
+                    t-out="format_monetary(tax_data['ImponibileImporto'], euro)"
                 />
                 <Imposta>0.00</Imposta>
                 <EsigibilitaIVA

--- a/l10n_it_fatturapa_out_rc/views/invoice_it_template.xml
+++ b/l10n_it_fatturapa_out_rc/views/invoice_it_template.xml
@@ -45,7 +45,7 @@
         </xpath>
         <xpath expr="//DatiRiepilogo/ImponibileImporto" position="attributes">
             <attribute name="t-out">
-                format_monetary(fpa_to_eur(get_sign(record) * tax_data['ImponibileImporto'], record), euro)
+                format_monetary(get_sign(record) * tax_data['ImponibileImporto'], euro)
             </attribute>
         </xpath>
         <xpath expr="//DatiRiepilogo/Imposta" position="attributes">
@@ -66,7 +66,7 @@
         </xpath>
         <xpath expr="//PrezzoTotale" position="attributes">
             <attribute name="t-out">
-                format_monetary(fpa_to_eur(get_sign(line.move_id) * line.price_subtotal, record), euro)
+                format_monetary(fpa_to_eur(get_sign(line.move_id) * line.price_subtotal, record, line.currency_rate), euro)
             </attribute>
         </xpath>
     </template>


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/3991
+
https://github.com/OCA/l10n-italy/issues/3960