### PR TITLE
[16.0][FIX] l10n_it_riba: remove account and journal domain

### DIFF
--- a/l10n_it_riba/models/riba_config.py
+++ b/l10n_it_riba/models/riba_config.py
@@ -58,7 +58,6 @@ class RibaConfiguration(models.Model):
     bank_account_id = fields.Many2one(
         "account.account",
         "A/C Bank Account",
-        domain=[("account_type", "=", "asset_cash")],
     )
     bank_expense_account_id = fields.Many2one("account.account", "Bank Fees Account")
     past_due_journal_id = fields.Many2one(
@@ -70,7 +69,6 @@ class RibaConfiguration(models.Model):
     overdue_effects_account_id = fields.Many2one(
         "account.account",
         "Past Due Bills Account",
-        domain=[("account_type", "=", "asset_receivable")],
     )
     protest_charge_account_id = fields.Many2one(
         "account.account", "Protest Fee Account"

--- a/l10n_it_riba/wizard/wizard_past_due.py
+++ b/l10n_it_riba/wizard/wizard_past_due.py
@@ -65,7 +65,6 @@ class RibaPastDue(models.TransientModel):
     effects_account_id = fields.Many2one(
         "account.account",
         "Bills Account",
-        domain=[("account_type", "=", "asset_receivable")],
         default=_get_effects_account_id,
     )
     effects_amount = fields.Float("Bills Amount", default=_get_effects_amount)
@@ -76,7 +75,6 @@ class RibaPastDue(models.TransientModel):
     overdue_effects_account_id = fields.Many2one(
         "account.account",
         "Past Due Bills Account",
-        domain=[("account_type", "=", "asset_receivable")],
         default=_get_overdue_effects_account_id,
     )
     overdue_effects_amount = fields.Float(


### PR DESCRIPTION
Questa fix permette di ammettere che sia il conto portafoglio (accettazione) che il conto di accredito (quello che si muove in D) siano dei conti outstanding che riportano la scadenza.
In questo modo anche chi utilizza questo modulo dovrebbe in futuro poter convergere ad odoo standard in modo semplice.

https://discord.com/channels/753902328494424064/753902328494424070/1200197828044140584