### PR TITLE
[14.0] [IMP] l10n_it_delivery_note: Add setting to make 'Partner ref' required

### DIFF
--- a/l10n_it_delivery_note/models/res_config_settings.py
+++ b/l10n_it_delivery_note/models/res_config_settings.py
@@ -17,6 +17,11 @@ class ResConfigSettings(models.TransientModel):
         implied_group="l10n_it_delivery_note.use_advanced_delivery_notes",
     )
 
+    group_required_partner_ref = fields.Boolean(
+        string="Make Partner Ref. in DN Mandatory",
+        implied_group="l10n_it_delivery_note.group_required_partner_ref",
+    )
+
     virtual_locations_root = fields.Many2one(
         "stock.location",
         string="Virtual locations root",

--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -551,6 +551,20 @@ class StockDeliveryNote(models.Model):
 
     def action_confirm(self):
         for note in self:
+            if (
+                note.type_code == "incoming"
+                and not note.partner_ref
+                and self.env.user.has_group(
+                    "l10n_it_delivery_note.group_required_partner_ref"
+                )
+            ):
+                raise UserError(
+                    _(
+                        "The field 'Partner reference' is "
+                        "mandatory to validate the Delivery Note."
+                    )
+                )
+
             warning_message = False
             carrier_ids = note.mapped("picking_ids.carrier_id")
             carrier_partner_ids = carrier_ids.mapped("partner_id")

--- a/l10n_it_delivery_note/security/res_groups.xml
+++ b/l10n_it_delivery_note/security/res_groups.xml
@@ -10,6 +10,11 @@
         <field name="category_id" ref="base.module_category_hidden" />
     </record>
 
+    <record id="group_required_partner_ref" model="res.groups">
+        <field name="name">Make Partner Ref. in DN Required</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
+
     <record id="can_change_number" model="res.groups">
         <field name="name">Allow to change delivery note number</field>
         <field

--- a/l10n_it_delivery_note/views/res_config_settings.xml
+++ b/l10n_it_delivery_note/views/res_config_settings.xml
@@ -29,6 +29,20 @@
                         </div>
                     </div>
                     <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane">
+                            <field name="group_required_partner_ref" />
+                        </div>
+                        <div class="o_setting_right_pane">
+                            <label for="group_required_partner_ref" />
+                            <div class="text-muted">
+                                <p>
+                                    Block the validation of incoming DNs if the
+                                    "Partner reference" field is not set.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
                         <div class="o_setting_right_pane">
                             <label for="virtual_locations_root" />
                             <div class="text-muted">


### PR DESCRIPTION
Add a setting to make the "Partner Ref" field required for validating the Delivery Note.