### PR TITLE
[16.0] [FIX] l10n_it_fatturapa_import_zip: seleziona le imposte di vendita corrette in caso di fatture attive

### DIFF
--- a/l10n_it_fatturapa_import_zip/wizards/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_import_zip/wizards/wizard_import_fatturapa.py
@@ -94,3 +94,15 @@ class WizardImportFatturapa(models.TransientModel):
         else:
             invoice_type = super()._get_invoice_type(fiscal_document_type)
         return invoice_type
+
+    def _get_account_tax_domain(self, amount):
+        tax_domain = super()._get_account_tax_domain(amount)
+        if self._is_import_attachment_out():
+            return [
+                ("type_tax_use", "=", "sale")
+                if item == ("type_tax_use", "=", "purchase")
+                else item
+                for item in tax_domain
+            ]
+        else:
+            return tax_domain


### PR DESCRIPTION
Nuova PR, a causa della chiusura di https://github.com/OCA/l10n-italy/pull/3910 per errore (in https://github.com/OCA/l10n-italy/pull/3910 la discussione e i test).

Corregge https://github.com/OCA/l10n-italy/issues/3908