### PR TITLE
[14.0][FIX] Usare company_id in fatturapa.attachment.out invece che self.env.company o user's company

### DIFF
--- a/l10n_it_fatturapa_pec/models/sdi.py
+++ b/l10n_it_fatturapa_pec/models/sdi.py
@@ -121,10 +121,10 @@ class SdiChannel(models.Model):
         self._check_fetchmail()
         self.check_first_pec_sending()
         user = self.env.user
-        company = user.company_id
         for att in attachment_out_ids:
             if not att.datas or not att.name:
                 raise UserError(_("File content and file name are mandatory"))
+            company = att.company_id
             mail_message = self.env["mail.message"].create(
                 {
                     "model": att._name,
@@ -135,8 +135,8 @@ class SdiChannel(models.Model):
                         att.name, company.email_exchange_system
                     ),
                     "attachment_ids": [(6, 0, att.ir_attachment_id.ids)],
-                    "email_from": (company.email_from_for_fatturaPA),
-                    "reply_to": (company.email_from_for_fatturaPA),
+                    "email_from": company.email_from_for_fatturaPA,
+                    "reply_to": company.email_from_for_fatturaPA,
                     "mail_server_id": company.sdi_channel_id.pec_server_id.id,
                 }
             )

--- a/l10n_it_sdi_channel/models/fatturapa_attachment_out.py
+++ b/l10n_it_sdi_channel/models/fatturapa_attachment_out.py
@@ -34,8 +34,7 @@ class FatturaPAAttachmentOut(models.Model):
         if set(states) != {"ready"}:
             raise UserError(_("You can only send files in 'Ready to Send' state."))
 
-        company = self.env.company
-        sdi_channel = company.sdi_channel_id
+        sdi_channel = self.company_id.sdi_channel_id
         send_result = sdi_channel.send(self)
         return send_result
 


### PR DESCRIPTION
La logica di utilizzo della company nel modello **fatturapa.attachement.out** utilizza la company di self.env oppure la company di default dell'utente. Tutto funziona correttamente in ambiente single-company ma nel multi company non sempre. La PR imposta l'utilizzo del campo company_id  del model **fatturapa.attachement.out** così da seleziona lo il channel corretto per SDI