### PR TITLE
[16.0] FIX l10n_it_fatturapa_out_rc: riferimenti duplicati in "Documenti correlati"

### DIFF
--- a/l10n_it_fatturapa_out_rc/models/account_move.py
+++ b/l10n_it_fatturapa_out_rc/models/account_move.py
@@ -20,6 +20,7 @@ class AccountMove(models.Model):
                 doc_id = self.fatturapa_attachment_in_id.name
             else:
                 doc_id = self.ref if self.ref else self.name
+            self.rc_self_invoice_id.related_documents = [(5, False, False)]
             self.rc_self_invoice_id.related_documents = [
                 (
                     0,


### PR DESCRIPTION
Rif https://github.com/OCA/l10n-italy/issues/2898

Se si annulla e rivalida una fattura fornitore in reverse charge precedentemente validata, nella sezione "Documenti correlati" dell'autofattura di vendita vengono duplicati i riferimenti alla fattura fornitore di partenza