### PR TITLE
[FIX] l10n_it_delivery_note rimosso script di migrazione per campo non più esistente is_carrier

### DIFF
--- a/l10n_it_delivery_note/migrations/14.0.2.0.0/post-migration.py
+++ b/l10n_it_delivery_note/migrations/14.0.2.0.0/post-migration.py
@@ -1,8 +1,0 @@
-from openupgradelib import openupgrade  # pylint: disable=W7936
-
-
-@openupgrade.migrate()
-def migrate(env, version):
-    carriers = env["stock.delivery.note"].search([]).mapped("carrier_id")
-    if carriers:
-        carriers.write({"is_carrier": True})


### PR DESCRIPTION
A seguito di #3838 