### PR TITLE
[16.0] [FIX][l10n_it_intrastat_statement] change date field in  domain

### DIFF
--- a/l10n_it_intrastat_statement/models/intrastat_statement.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement.py
@@ -770,8 +770,8 @@ class AccountIntrastatStatement(models.Model):
 
         # Search intrastat lines
         domain = [
-            ("invoice_date", ">=", period_date_start),
-            ("invoice_date", "<=", period_date_stop),
+            ("date", ">=", period_date_start),
+            ("date", "<=", period_date_stop),
             ("intrastat", "=", True),
         ]
         inv_type = []

--- a/l10n_it_intrastat_statement/tests/test_intrastat_statement.py
+++ b/l10n_it_intrastat_statement/tests/test_intrastat_statement.py
@@ -121,8 +121,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": invoice.invoice_date.month,
-                "fiscalyear": invoice.invoice_date.year,
+                "period_number": invoice.date.month,
+                "fiscalyear": invoice.date.year,
             }
         )
 
@@ -140,13 +140,13 @@ class TestIntrastatStatement(TransactionCase):
 
     def test_statement_sale_quarter(self):
         invoice = self._get_intrastat_computed_invoice()
-        month = invoice.invoice_date.month
+        month = invoice.date.month
         quarter = 1 + (month - 1) // 3
         statement = self.statement_model.create(
             {
                 "period_number": quarter,
                 "period_type": "T",
-                "fiscalyear": invoice.invoice_date.year,
+                "fiscalyear": invoice.date.year,
             }
         )
 
@@ -162,8 +162,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": bill.invoice_date.month,
-                "fiscalyear": bill.invoice_date.year,
+                "period_number": bill.date.month,
+                "fiscalyear": bill.date.year,
             }
         )
 
@@ -184,8 +184,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": bill.invoice_date.month,
-                "fiscalyear": bill.invoice_date.year,
+                "period_number": bill.date.month,
+                "fiscalyear": bill.date.year,
             }
         )
 
@@ -208,8 +208,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": bill_refund.invoice_date.month,
-                "fiscalyear": bill_refund.invoice_date.year,
+                "period_number": bill_refund.date.month,
+                "fiscalyear": bill_refund.date.year,
             }
         )
 
@@ -247,8 +247,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": bill_refund.invoice_date.month,
-                "fiscalyear": bill_refund.invoice_date.year,
+                "period_number": bill_refund.date.month,
+                "fiscalyear": bill_refund.date.year,
             }
         )
 
@@ -286,8 +286,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": bill_refund.invoice_date.month,
-                "fiscalyear": bill_refund.invoice_date.year,
+                "period_number": bill_refund.date.month,
+                "fiscalyear": bill_refund.date.year,
             }
         )
 
@@ -324,13 +324,13 @@ class TestIntrastatStatement(TransactionCase):
 
     def test_statement_purchase_quarter(self):
         bill = self._get_intrastat_computed_bill()
-        month = bill.invoice_date.month
+        month = bill.date.month
         quarter = 1 + (month - 1) // 3
         statement = self.statement_model.create(
             {
                 "period_number": quarter,
                 "period_type": "T",
-                "fiscalyear": bill.invoice_date.year,
+                "fiscalyear": bill.date.year,
             }
         )
 
@@ -346,8 +346,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": invoice.invoice_date.month,
-                "fiscalyear": invoice.invoice_date.year,
+                "period_number": invoice.date.month,
+                "fiscalyear": invoice.date.year,
             }
         )
         statement.compute_statement()
@@ -367,8 +367,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": bill.invoice_date.month,
-                "fiscalyear": bill.invoice_date.year,
+                "period_number": bill.date.month,
+                "fiscalyear": bill.date.year,
             }
         )
         line = statement.purchase_section1_ids.create({})
@@ -383,8 +383,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": invoice.invoice_date.month,
-                "fiscalyear": invoice.invoice_date.year,
+                "period_number": invoice.date.month,
+                "fiscalyear": invoice.date.year,
             }
         )
 
@@ -402,8 +402,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": invoice.invoice_date.month,
-                "fiscalyear": invoice.invoice_date.year,
+                "period_number": invoice.date.month,
+                "fiscalyear": invoice.date.year,
             }
         )
         statement.compute_statement()
@@ -421,8 +421,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": invoice.invoice_date.month,
-                "fiscalyear": invoice.invoice_date.year,
+                "period_number": invoice.date.month,
+                "fiscalyear": invoice.date.year,
             }
         )
         statement.compute_statement()
@@ -444,8 +444,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": bill.invoice_date.month,
-                "fiscalyear": bill.invoice_date.year,
+                "period_number": bill.date.month,
+                "fiscalyear": bill.date.year,
             }
         )
         statement.compute_statement()
@@ -476,8 +476,8 @@ class TestIntrastatStatement(TransactionCase):
 
         statement = self.statement_model.create(
             {
-                "period_number": bill.invoice_date.month,
-                "fiscalyear": bill.invoice_date.year,
+                "period_number": bill.date.month,
+                "fiscalyear": bill.date.year,
             }
         )
         statement.compute_statement()


### PR DESCRIPTION
Change domain date field used to search move(s) that should be included in lines of intrastat statement declaration

Rif https://github.com/OCA/l10n-italy/issues/3820