### PR TITLE
[16.0] [IMP] l10n_it_riba: aggiungere esposizione/rischio e migliorare la gestione degli insoluti

### DIFF
--- a/l10n_it_riba/README.rst
+++ b/l10n_it_riba/README.rst
@@ -93,7 +93,9 @@ I possibili stati della distinta sono: *Bozza*, *Accettata*,
 *Accreditata*, *Pagata*, *Insoluta* e *Annullata*. Ad ogni passaggio di
 stato sarà possibile generare le relative registrazioni contabili, le
 quali verranno riepilogate nella scheda «Contabilità». Questa scheda è
-presente sia sulla distinta che sulle sue righe.
+presente sia sulla distinta che sulle sue righe. Queste ultime hanno una
+vista dedicata per facilitare le operazioni sul singolo elemento invece
+che su tutta la distinta.
 
 La voce di menù 'Presentazione Riba' permette estrarre le riba fino al
 raggiungimento dell'importo massimo inserito dall'utente.

--- a/l10n_it_riba/README.rst
+++ b/l10n_it_riba/README.rst
@@ -98,6 +98,10 @@ presente sia sulla distinta che sulle sue righe.
 La voce di menù 'Presentazione Riba' permette estrarre le riba fino al
 raggiungimento dell'importo massimo inserito dall'utente.
 
+Nella lista delle fatture è presente una colonna per monitorare l'
+esposizione, cioè l'importo dovuto dal cliente a fronte dell'emissione
+della RiBa non ancora scaduta.
+
 Known issues / Roadmap
 ======================
 
@@ -141,6 +145,8 @@ Contributors
 -  `TAKOBI <https://takobi.online>`__:
 
    -  Simone Rubino <sir@takobi.online>
+
+-  Nextev Srl <odoo@nextev.it>
 
 Maintainers
 -----------

--- a/l10n_it_riba/README.rst
+++ b/l10n_it_riba/README.rst
@@ -108,6 +108,12 @@ Nella lista delle fatture è presente una colonna per monitorare l'
 esposizione, cioè l'importo dovuto dal cliente a fronte dell'emissione
 della RiBa non ancora scaduta.
 
+In maniera predefinita la data delle registrazioni dei pagamenti viene
+impostata con la data di scadenza della RiBa, ma è possibile modificarla
+successivamente a pagamento effettivamente avvenuto selezionando la
+registrazione dalla vista ed elenco ed eseguendo l'azione "Imposta data
+di pagamento RiBa".
+
 Known issues / Roadmap
 ======================
 

--- a/l10n_it_riba/README.rst
+++ b/l10n_it_riba/README.rst
@@ -58,7 +58,11 @@ diverso.
 fine', è necessario specificare almeno il registro e il conto da
 utilizzare al momento dell'accettazione della distinta da parte della
 banca. Tale conto deve essere di tipo 'Crediti' (ad esempio "RiBa
-all'incasso", eventualmente da creare).
+all'incasso", eventualmente da creare). Selezionando 'Salvo buon fine' è
+necessario impostare il tipo di incasso, immediato o a maturazione
+valuta: questo influisce sulla gestione degli insoluti perchè solo nel
+caso di incasso immediato vengono stornate le registrazioni di
+presentazione della RiBa.
 
 La configurazione relativa alla fase di accredito, verrà usata nel
 momento in cui la banca accredita l'importo della distinta. È possibile

--- a/l10n_it_riba/__manifest__.py
+++ b/l10n_it_riba/__manifest__.py
@@ -38,6 +38,7 @@
         "views/partner_view.xml",
         "views/wizard_riba_issue.xml",
         "views/wizard_riba_file_export.xml",
+        "views/wizard_riba_payment_date.xml",
         "views/account_config_view.xml",
         "views/slip_report.xml",
         "views/riba_detail_view.xml",

--- a/l10n_it_riba/models/account.py
+++ b/l10n_it_riba/models/account.py
@@ -60,9 +60,9 @@ class AccountMove(models.Model):
                 invoice.is_past_due = True
 
     def _compute_open_amount(self):
+        today = fields.Date.today()
         for invoice in self:
             if invoice.is_riba_payment:
-                today = fields.Date.today()
                 open_amount_line_ids = invoice.line_ids.filtered(
                     lambda line, today=today: line.riba
                     and line.display_type == "payment_term"

--- a/l10n_it_riba/models/account.py
+++ b/l10n_it_riba/models/account.py
@@ -280,6 +280,16 @@ class AccountMove(models.Model):
     def get_due_cost_line_ids(self):
         return self.invoice_line_ids.filtered(lambda line: line.due_cost_line).ids
 
+    def action_riba_payment_date(self):
+        return {
+            "type": "ir.actions.act_window",
+            "name": "RiBa Payment Date",
+            "res_model": "riba.payment.date",
+            "view_mode": "form",
+            "target": "new",
+            "context": self.env.context,
+        }
+
 
 # se slip_line_ids == None allora non è stata emessa
 class AccountMoveLine(models.Model):

--- a/l10n_it_riba/models/account.py
+++ b/l10n_it_riba/models/account.py
@@ -79,7 +79,6 @@ class AccountMove(models.Model):
     open_amount = fields.Float(
         digits="Account",
         compute="_compute_open_amount",
-        store=True,
         default=0.0,
         help="Amount currently only supposed to be paid, but has actually not happened",
     )

--- a/l10n_it_riba/models/account.py
+++ b/l10n_it_riba/models/account.py
@@ -5,6 +5,7 @@
 # (<http://www.odoo-italia.org>).
 # Copyright (C) 2012-2018 Lorenzo Battistini - Agile Business Group
 # Copyright 2023 Simone Rubino - Aion Tech
+# Copyright 2024 Nextev Srl
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -58,9 +59,31 @@ class AccountMove(models.Model):
             if len(invoice.past_due_move_line_ids) != reconciled_past_due:
                 invoice.is_past_due = True
 
+    def _compute_open_amount(self):
+        for invoice in self:
+            if invoice.is_riba_payment:
+                today = fields.Date.today()
+                open_amount_line_ids = invoice.line_ids.filtered(
+                    lambda line, today=today: line.riba
+                    and line.display_type == "payment_term"
+                    and line.date_maturity > today
+                )
+                invoice.open_amount = sum(open_amount_line_ids.mapped("balance"))
+            else:
+                invoice.open_amount = 0.0
+
     riba_credited_ids = fields.One2many(
         "riba.slip", "credit_move_id", "Credited RiBa Slips", readonly=True
     )
+
+    open_amount = fields.Float(
+        digits="Account",
+        compute="_compute_open_amount",
+        store=True,
+        default=0.0,
+        help="Amount currently only supposed to be paid, but has actually not happened",
+    )
+
     riba_past_due_ids = fields.One2many(
         "riba.slip.line", "past_due_move_id", "Past Due RiBa Slips", readonly=True
     )

--- a/l10n_it_riba/models/riba.py
+++ b/l10n_it_riba/models/riba.py
@@ -8,7 +8,6 @@
 # Copyright 2024 Nextev Srl
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from datetime import date
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -497,7 +496,7 @@ class RibaListLine(models.Model):
                     "journal_id": (
                         riba_line.slip_id.config_id.settlement_journal_id.id
                     ),
-                    "date": date.today().strftime("%Y-%m-%d"),
+                    "date": riba_line.due_date.strftime("%Y-%m-%d"),
                     "ref": move_ref,
                 }
             )

--- a/l10n_it_riba/models/riba.py
+++ b/l10n_it_riba/models/riba.py
@@ -5,6 +5,7 @@
 # (<http://www.odoo-italia.org>).
 # Copyright (C) 2012-2017 Lorenzo Battistini - Agile Business Group
 # Copyright 2023 Simone Rubino - Aion Tech
+# Copyright 2024 Nextev Srl
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import date
@@ -376,7 +377,7 @@ class RibaListLine(models.Model):
                         line.invoice_number, line.slip_id.name, line.sequence
                     ),
                     "journal_id": journal.id,
-                    "date": line.slip_id.registration_date,
+                    "date": line.due_date,
                 }
             )
             to_be_reconciled = self.env["account.move.line"]

--- a/l10n_it_riba/models/riba_config.py
+++ b/l10n_it_riba/models/riba_config.py
@@ -21,6 +21,10 @@ class RibaConfiguration(models.Model):
         "Issue Mode",
         required=True,
     )
+    sbf_collection_type = fields.Selection(
+        [("immediate", "Immediate"), ("maturation", "At currency maturation")],
+        "Collection Type",
+    )
     bank_id = fields.Many2one(
         "res.partner.bank",
         "Bank Account",

--- a/l10n_it_riba/readme/CONFIGURE.md
+++ b/l10n_it_riba/readme/CONFIGURE.md
@@ -16,6 +16,10 @@ fine', è necessario specificare almeno il registro e il conto da
 utilizzare al momento dell'accettazione della distinta da parte della
 banca. Tale conto deve essere di tipo 'Crediti' (ad esempio "RiBa
 all'incasso", eventualmente da creare).
+Selezionando 'Salvo buon fine' è necessario impostare il tipo di
+incasso, immediato o a maturazione valuta: questo influisce sulla gestione
+degli insoluti perchè solo nel caso di incasso immediato vengono stornate
+le registrazioni di presentazione della RiBa.
 
 La configurazione relativa alla fase di accredito, verrà usata nel
 momento in cui la banca accredita l'importo della distinta. È possibile

--- a/l10n_it_riba/readme/CONTRIBUTORS.md
+++ b/l10n_it_riba/readme/CONTRIBUTORS.md
@@ -14,3 +14,4 @@
   - Simone Rubino \<<simone.rubino@aion-tech.it>\>
 - [TAKOBI](https://takobi.online):
   - Simone Rubino \<<sir@takobi.online>\>
+- Nextev Srl \<<odoo@nextev.it>\>

--- a/l10n_it_riba/readme/USAGE.md
+++ b/l10n_it_riba/readme/USAGE.md
@@ -17,3 +17,7 @@ presente sia sulla distinta che sulle sue righe.
 
 La voce di menù 'Presentazione Riba' permette estrarre le riba fino al
 raggiungimento dell'importo massimo inserito dall'utente.
+
+Nella lista delle fatture è presente una colonna per monitorare l'
+esposizione, cioè l'importo dovuto dal cliente a fronte dell'emissione 
+della RiBa non ancora scaduta.

--- a/l10n_it_riba/readme/USAGE.md
+++ b/l10n_it_riba/readme/USAGE.md
@@ -14,6 +14,8 @@ I possibili stati della distinta sono: *Bozza*, *Accettata*,
 stato sarà possibile generare le relative registrazioni contabili, le
 quali verranno riepilogate nella scheda «Contabilità». Questa scheda è
 presente sia sulla distinta che sulle sue righe.
+Queste ultime hanno una vista dedicata per facilitare le
+operazioni sul singolo elemento invece che su tutta la distinta.
 
 La voce di menù 'Presentazione Riba' permette estrarre le riba fino al
 raggiungimento dell'importo massimo inserito dall'utente.

--- a/l10n_it_riba/readme/USAGE.md
+++ b/l10n_it_riba/readme/USAGE.md
@@ -23,3 +23,9 @@ raggiungimento dell'importo massimo inserito dall'utente.
 Nella lista delle fatture è presente una colonna per monitorare l'
 esposizione, cioè l'importo dovuto dal cliente a fronte dell'emissione 
 della RiBa non ancora scaduta.
+
+In maniera predefinita la data delle registrazioni dei pagamenti viene
+impostata con la data di scadenza della RiBa, ma è possibile modificarla
+successivamente a pagamento effettivamente avvenuto selezionando la
+registrazione dalla vista ed elenco ed eseguendo l'azione "Imposta data
+di pagamento RiBa".

--- a/l10n_it_riba/security/ir.model.access.csv
+++ b/l10n_it_riba/security/ir.model.access.csv
@@ -19,3 +19,4 @@ access_riba_credit,riba_credit,model_riba_credit,account.group_account_invoice,1
 access_riba_file_export,riba_file_export,model_riba_file_export,account.group_account_invoice,1,1,1,1
 access_presentation_riba_issue,access_presentation_riba_issue,model_presentation_riba_issue,account.group_account_invoice,1,1,1,1
 access_riba_due_date_settlement,riba_due_date_settlement,model_riba_due_date_settlement,account.group_account_invoice,1,1,1,1
+access_riba_payment_date,riba_payment_date,model_riba_payment_date,account.group_account_invoice,1,1,1,1

--- a/l10n_it_riba/static/description/index.html
+++ b/l10n_it_riba/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -436,6 +435,9 @@ quali verranno riepilogate nella scheda «Contabilità». Questa scheda è
 presente sia sulla distinta che sulle sue righe.</p>
 <p>La voce di menù ‘Presentazione Riba’ permette estrarre le riba fino al
 raggiungimento dell’importo massimo inserito dall’utente.</p>
+<p>Nella lista delle fatture è presente una colonna per monitorare l’
+esposizione, cioè l’importo dovuto dal cliente a fronte dell’emissione
+della RiBa non ancora scaduta.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
@@ -476,14 +478,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:sir&#64;takobi.online">sir&#64;takobi.online</a>&gt;</li>
 </ul>
 </li>
+<li>Nextev Srl &lt;<a class="reference external" href="mailto:odoo&#64;nextev.it">odoo&#64;nextev.it</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/l10n_it_riba/static/description/index.html
+++ b/l10n_it_riba/static/description/index.html
@@ -432,7 +432,9 @@ elemento della distinta.</p>
 <em>Accreditata</em>, <em>Pagata</em>, <em>Insoluta</em> e <em>Annullata</em>. Ad ogni passaggio di
 stato sarà possibile generare le relative registrazioni contabili, le
 quali verranno riepilogate nella scheda «Contabilità». Questa scheda è
-presente sia sulla distinta che sulle sue righe.</p>
+presente sia sulla distinta che sulle sue righe. Queste ultime hanno una
+vista dedicata per facilitare le operazioni sul singolo elemento invece
+che su tutta la distinta.</p>
 <p>La voce di menù ‘Presentazione Riba’ permette estrarre le riba fino al
 raggiungimento dell’importo massimo inserito dall’utente.</p>
 <p>Nella lista delle fatture è presente una colonna per monitorare l’

--- a/l10n_it_riba/static/description/index.html
+++ b/l10n_it_riba/static/description/index.html
@@ -444,6 +444,11 @@ raggiungimento dell’importo massimo inserito dall’utente.</p>
 <p>Nella lista delle fatture è presente una colonna per monitorare l’
 esposizione, cioè l’importo dovuto dal cliente a fronte dell’emissione
 della RiBa non ancora scaduta.</p>
+<p>In maniera predefinita la data delle registrazioni dei pagamenti viene
+impostata con la data di scadenza della RiBa, ma è possibile modificarla
+successivamente a pagamento effettivamente avvenuto selezionando la
+registrazione dalla vista ed elenco ed eseguendo l’azione “Imposta data
+di pagamento RiBa”.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>

--- a/l10n_it_riba/static/description/index.html
+++ b/l10n_it_riba/static/description/index.html
@@ -404,7 +404,11 @@ descritta nel documento <a class="reference external" href="http://goo.gl/jpRhJp
 fine’, è necessario specificare almeno il registro e il conto da
 utilizzare al momento dell’accettazione della distinta da parte della
 banca. Tale conto deve essere di tipo ‘Crediti’ (ad esempio “RiBa
-all’incasso”, eventualmente da creare).</p>
+all’incasso”, eventualmente da creare). Selezionando ‘Salvo buon fine’ è
+necessario impostare il tipo di incasso, immediato o a maturazione
+valuta: questo influisce sulla gestione degli insoluti perchè solo nel
+caso di incasso immediato vengono stornate le registrazioni di
+presentazione della RiBa.</p>
 <p>La configurazione relativa alla fase di accredito, verrà usata nel
 momento in cui la banca accredita l’importo della distinta. È possibile
 utilizzare un registro creato appositamente, ad esempio “Accredito

--- a/l10n_it_riba/tests/test_riba.py
+++ b/l10n_it_riba/tests/test_riba.py
@@ -405,11 +405,6 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         # self.assertTrue(
         #     bank_past_due_line.id in [l.id for l in move_lines_for_rec])
 
-        riba_list.line_ids[0].past_due_move_id.line_ids.remove_move_reconcile()
-        self.assertEqual(riba_list.state, "credited")
-        self.assertEqual(len(riba_list.line_ids), 1)
-        self.assertEqual(riba_list.line_ids[0].state, "credited")
-
     def test_riba_fatturapa(self):
         self.partner.property_account_receivable_id = self.account_rec1_id.id
         recent_date = (

--- a/l10n_it_riba/tests/test_riba.py
+++ b/l10n_it_riba/tests/test_riba.py
@@ -67,36 +67,8 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         # Collection fees line has been unlink
         self.assertEqual(len(self.invoice.invoice_line_ids), 1)
 
-    def test_riba_flow(self):
-        self.partner.property_account_receivable_id = self.account_rec1_id.id
-        recent_date = (
-            self.env["account.move"]
-            .search([("invoice_date", "!=", False)], order="invoice_date desc", limit=1)
-            .invoice_date
-        )
-        invoice = self.env["account.move"].create(
-            {
-                "invoice_date": recent_date,
-                "move_type": "out_invoice",
-                "journal_id": self.sale_journal.id,
-                "partner_id": self.partner.id,
-                "invoice_payment_term_id": self.account_payment_term_riba.id,
-                "invoice_line_ids": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": "product1",
-                            "product_id": self.product1.id,
-                            "quantity": 1.0,
-                            "price_unit": 450.00,
-                            "account_id": self.sale_account.id,
-                            "tax_ids": [[6, 0, []]],
-                        },
-                    )
-                ],
-            }
-        )
+    def riba_sbf_common(self, configuration_id):
+        invoice = self._create_sbf_invoice()
         invoice._onchange_riba_partner_bank_id()
         invoice.action_post()
         riba_move_line_id = False
@@ -121,7 +93,7 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
 
         # issue wizard
         wizard_riba_issue = self.env["riba.issue"].create(
-            {"configuration_id": self.riba_config.id}
+            {"configuration_id": configuration_id}
         )
         action = wizard_riba_issue.with_context(
             active_ids=[riba_move_line_id]
@@ -167,6 +139,10 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         )
         credit_wizard.create_move()
         self.assertEqual(riba_list.state, "credited")
+        return invoice, riba_list
+
+    def test_riba_sbf_maturation_flow(self):
+        invoice, riba_list = self.riba_sbf_common(self.riba_config_sbf_maturation.id)
 
         bank_credit_line = False
         for credit_line in riba_list.credit_move_id.line_ids:
@@ -238,6 +214,59 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         to_reconcile.remove_move_reconcile()
         self.assertEqual(riba_list.state, "credited")
         self.assertEqual(riba_list.line_ids[0].state, "credited")
+
+    def test_riba_sbf_immediate_flow(self):
+        invoice, riba_list = self.riba_sbf_common(self.riba_config_sbf_immediate.id)
+
+        # past due wizard
+        past_due_wizard = (
+            self.env["riba.past_due"]
+            .with_context(
+                active_model="riba.slip.line",
+                active_ids=[riba_list.line_ids[0].id],
+                active_id=riba_list.line_ids[0].id,
+            )
+            .create(
+                {
+                    "bank_amount": 455,
+                    "expense_amount": 5,
+                }
+            )
+        )
+        past_due_wizard.create_move()
+        self.assertEqual(riba_list.state, "past_due")
+        self.assertEqual(len(riba_list.line_ids), 1)
+        self.assertEqual(riba_list.line_ids[0].state, "past_due")
+        self.assertTrue(invoice.past_due_move_line_ids)
+
+        # Verifica storno registrazioni di presentazione della RiBa
+        past_due_line_ids = riba_list.line_ids.past_due_move_id.line_ids
+        past_due_line_id_bills = past_due_line_ids.filtered(
+            lambda line: line.name == "Bills"
+        )
+        self.assertEqual(len(past_due_line_id_bills), 1)
+        self.assertEqual(
+            past_due_line_id_bills.account_id, past_due_wizard.effects_account_id
+        )
+        self.assertEqual(past_due_line_id_bills.credit, past_due_wizard.effects_amount)
+        past_due_line_id_riba = past_due_line_ids.filtered(
+            lambda line: line.name == "RiBa"
+        )
+        self.assertEqual(len(past_due_line_id_riba), 1)
+        self.assertEqual(
+            past_due_line_id_riba.account_id, past_due_wizard.riba_bank_account_id
+        )
+        self.assertEqual(past_due_line_id_riba.debit, past_due_wizard.riba_bank_amount)
+
+        # Se la compute non viene invocata il test fallisce
+        riba_list._compute_past_due_move_ids()
+        self.assertEqual(len(riba_list.past_due_move_ids), 1)
+        bank_past_due_line = False
+        for past_due_line in riba_list.past_due_move_ids[0].line_ids:
+            if past_due_line.account_id.id == self.bank_account.id:
+                bank_past_due_line = past_due_line
+                break
+        self.assertTrue(bank_past_due_line)
 
     def test_riba_incasso_flow(self):
         """
@@ -311,7 +340,7 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                 riba_move_line_id = move_line.id
         # issue wizard
         wizard_riba_issue = self.env["riba.issue"].create(
-            {"configuration_id": self.riba_config.id}
+            {"configuration_id": self.riba_config_sbf_maturation.id}
         )
         action = wizard_riba_issue.with_context(
             active_ids=[riba_move_line_id]
@@ -454,7 +483,7 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
             lambda x: x.account_id == self.account_rec1_id
         )
         wizard_riba_issue = self.env["riba.issue"].create(
-            {"configuration_id": self.riba_config.id}
+            {"configuration_id": self.riba_config_sbf_maturation.id}
         )
         action = wizard_riba_issue.with_context(
             active_ids=[riba_move_line_id.id]
@@ -559,7 +588,7 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
             lambda x: x.account_id == self.account_rec1_id
         )
         wizard_riba_issue = self.env["riba.issue"].create(
-            {"configuration_id": self.riba_config.id}
+            {"configuration_id": self.riba_config_sbf_maturation.id}
         )
         action = wizard_riba_issue.with_context(
             active_ids=[riba_move_line_id.id, riba_move_line1_id.id]

--- a/l10n_it_riba/views/account_view.xml
+++ b/l10n_it_riba/views/account_view.xml
@@ -163,6 +163,7 @@
         <field name="inherit_id" ref="account.view_invoice_tree" />
         <field name="arch" type="xml">
             <field name="move_type" position="after">
+                <field name="open_amount" widget="monetary" />
                 <field name="is_past_due" string="Past Due" />
             </field>
         </field>

--- a/l10n_it_riba/views/configuration_view.xml
+++ b/l10n_it_riba/views/configuration_view.xml
@@ -17,6 +17,10 @@
                     <field name="name" />
                     <field name="type" />
                     <field
+                        name="sbf_collection_type"
+                        attrs="{'required': [('type','=','sbf')], 'invisible': [('type','!=','sbf')]}"
+                    />
+                    <field
                         name="bank_id"
                         domain="[('partner_id.ref_company_ids', 'in', allowed_company_ids)]"
                     />

--- a/l10n_it_riba/views/riba_detail_view.xml
+++ b/l10n_it_riba/views/riba_detail_view.xml
@@ -43,6 +43,12 @@
                 <field name="partner_id" />
                 <field name="due_date" />
                 <field name="config_id" />
+                <filter
+                    name="due_date"
+                    string="Due Date"
+                    domain="[]"
+                    context="{'group_by': 'due_date'}"
+                />
             </search>
         </field>
     </record>

--- a/l10n_it_riba/views/riba_view.xml
+++ b/l10n_it_riba/views/riba_view.xml
@@ -55,6 +55,7 @@
                 <field name="date_accepted" />
                 <field name="date_paid" />
                 <field name="state" />
+                <field name="total_amount" widget="monetary" />
             </tree>
         </field>
     </record>
@@ -67,61 +68,63 @@
         <field name="model">riba.slip.line</field>
         <field name="arch" type="xml">
             <form string="Detail">
-                <notebook colspan="4">
-                    <page string="General">
-                        <group>
+                <sheet>
+                    <notebook colspan="4">
+                        <page string="General">
                             <group>
-                                <field name="state" />
-                                <field name="type" />
-                                <field name="invoice_number" />
-                                <field name="invoice_date" />
-                                <field name="partner_id" />
-                                <field name="amount" />
-                                <field name="due_date" />
+                                <group>
+                                    <field name="state" />
+                                    <field name="type" />
+                                    <field name="invoice_number" />
+                                    <field name="invoice_date" />
+                                    <field name="partner_id" />
+                                    <field name="amount" />
+                                    <field name="due_date" />
 
-                            </group>
-                            <group>
-                                <field name="amount" />
-                                <field name="due_date" />
-                                <field name="state" />
-                            </group>
-                        </group>
-                    </page>
-                    <page string="Accounting">
-                        <separator string="Invoice Entries" colspan="4" />
-                        <field name="move_line_ids" nolabel="1" colspan="4">
-                            <tree>
-                                <field name="amount" />
-                                <field name="move_line_id" />
-                            </tree>
-                            <form string="Move Line">
+                                </group>
                                 <group>
                                     <field name="amount" />
-                                    <field name="move_line_id" />
+                                    <field name="due_date" />
+                                    <field name="state" />
                                 </group>
-                            </form>
-                        </field>
-                        <group>
-                        <field name="acceptance_move_id" />
-                        <field name="past_due_move_id" />
-                        </group>
-                        <separator string="Payments" colspan="4" />
-                        <field name="payment_ids" nolabel="1" colspan="4">
-                            <tree>
-                                <field name="date" />
-                                <field name="move_id" />
-                                <field name="ref" />
-                                <field name="name" />
-                                <field name="journal_id" groups="base.group_user" />
-                                <field name="debit" />
-                                <field name="credit" />
-                                <field name="amount_currency" />
-                                <field name="currency_id" />
-                            </tree>
-                        </field>
-                        <field name="past_due_move_id" />
-                    </page>
-                </notebook>
+                            </group>
+                        </page>
+                        <page string="Accounting">
+                            <separator string="Invoice Entries" colspan="4" />
+                            <field name="move_line_ids" nolabel="1" colspan="4">
+                                <tree>
+                                    <field name="amount" />
+                                    <field name="move_line_id" />
+                                </tree>
+                                <form string="Move Line">
+                                    <group>
+                                        <field name="amount" />
+                                        <field name="move_line_id" />
+                                    </group>
+                                </form>
+                            </field>
+                            <group>
+                            <field name="acceptance_move_id" />
+                            <field name="past_due_move_id" />
+                            </group>
+                            <separator string="Payments" colspan="4" />
+                            <field name="payment_ids" nolabel="1" colspan="4">
+                                <tree>
+                                    <field name="date" />
+                                    <field name="move_id" />
+                                    <field name="ref" />
+                                    <field name="name" />
+                                    <field name="journal_id" groups="base.group_user" />
+                                    <field name="debit" />
+                                    <field name="credit" />
+                                    <field name="amount_currency" />
+                                    <field name="currency_id" />
+                                </tree>
+                            </field>
+                            <field name="past_due_move_id" />
+                        </page>
+                    </notebook>
+                </sheet>
             </form>
         </field>
     </record>
@@ -171,100 +174,92 @@
                     />
                     <field name="state" widget="statusbar" />
                 </header>
-                <group>
-                    <field name="name" />
-                    <field name="config_id" widget="selection" />
-                    <field name="registration_date" />
-                </group>
-                <notebook colspan="4">
-                    <page string="General">
-                        <field name="line_ids" nolabel="1" colspan="4">
-                            <tree>
-                                <field name="sequence" />
-                                <field name="invoice_number" />
-                                <field name="invoice_date" />
-                                <field name="partner_id" />
-                                <field name="iban" />
-                                <field name="amount" sum="Amount" />
-                                <field name="due_date" />
-                                <field name="state" />
-                                <button
-                                    name="%(riba_past_due_action)d"
-                                    type='action'
-                                    attrs="{'invisible':['|',('type','=','incasso'),('state','!=','credited')]}"
-                                    string="Mark as Past Due"
-                                    icon="fa-exclamation-triangle"
+                <sheet>
+                    <div name="button_box" class="oe_button_box">
+                        <button
+                            type="object"
+                            name="action_open_lines"
+                            string="Slip lines"
+                            class="oe_stat_button"
+                            icon="fa-list"
+                        />
+                    </div>
+                    <group>
+                        <field name="name" />
+                        <field name="config_id" widget="selection" />
+                        <field name="registration_date" />
+                    </group>
+                    <notebook colspan="4">
+                        <page string="General">
+                            <field name="line_ids" nolabel="1" colspan="4">
+                                <tree>
+                                    <field name="sequence" />
+                                    <field name="invoice_number" />
+                                    <field name="invoice_date" />
+                                    <field name="partner_id" />
+                                    <field name="iban" />
+                                    <field name="amount" sum="Amount" />
+                                    <field name="due_date" />
+                                    <field name="state" />
+                                    <button
+                                        name="%(riba_past_due_action)d"
+                                        type='action'
+                                        attrs="{'invisible':['|',('type','=','incasso'),('state','!=','credited')]}"
+                                        string="Mark as Past Due"
+                                        icon="fa-exclamation-triangle"
+                                    />
+                                    <button
+                                        name="riba_line_settlement"
+                                        type='object'
+                                        attrs="{'invisible':['|',('type','=','incasso'),('state','!=','credited')]}"
+                                        string="Mark as Settled"
+                                        icon="fa-check"
+                                    />
+                                    <field name="type" invisible="1" />
+                                </tree>
+                            </field>
+                            <field name="type" invisible="1" />
+                        </page>
+                        <page string="Other Info">
+                            <group>
+                                <field name="user_id" />
+                                <field name="date_created" />
+                                <field
+                                    name="date_accepted"
+                                    attrs="{'readonly':[('state','!=','draft')]}"
                                 />
-                                <button
-                                    name="riba_line_settlement"
-                                    type='object'
-                                    attrs="{'invisible':['|',('type','=','incasso'),('state','!=','credited')]}"
-                                    string="Mark as Settled"
-                                    icon="fa-check"
+                                <field
+                                    name="date_credited"
+                                    attrs="{'readonly':[('state','!=','draft'), ('state','!=','accepted')]}"
                                 />
-                                <field name="type" invisible="1" />
-                            </tree>
-                        </field>
-                        <field name="type" invisible="1" />
-                    </page>
-                    <page string="Other Info">
-                        <group>
-                            <field name="user_id" />
-                            <field name="date_created" />
-                            <field
-                                name="date_accepted"
-                                attrs="{'readonly':[('state','!=','draft')]}"
-                            />
-                            <field
-                                name="date_credited"
-                                attrs="{'readonly':[('state','!=','draft'), ('state','!=','accepted')]}"
-                            />
-                            <field name="date_paid" />
-                        </group>
-                    </page>
-                    <page string="Accounting">
-                        <group
-                            string="Acceptance Entries"
-                            attrs="{'invisible':[('type', 'not in', ('incasso', 'sbf'))]}"
-                        >
-                            <field name='acceptance_move_ids' nolabel="1" />
-                        </group>
-                        <group
-                            string="Credit Entry"
-                            attrs="{'invisible':[('type', '!=', 'sbf')]}"
-                        >
-                            <field name='credit_move_id' nolabel="1" />
-                        </group>
-                        <group
-                            string="Payments"
-                            attrs="{'invisible':[('type', '!=', 'sbf')]}"
-                        >
-                            <field name='payment_ids' nolabel="1">
-                            <tree>
-                                <field name="date" />
-                                <field name="move_id" />
-                                <field name="ref" />
-                                <field name="name" />
-                                <field name="journal_id" groups="base.group_user" />
-                                <field name="debit" />
-                                <field name="credit" />
-                                <field name="amount_currency" />
-                                <field name="currency_id" />
-                            </tree>
-                        </field>
-                        </group>
-                        <group
-                            colspan="4"
-                            string="Past Dues"
-                            attrs="{'invisible':[('type', '!=', 'sbf')]}"
-                        >
-                            <field
-                                name='past_due_move_ids'
-                                colspan="4"
-                                nolabel="1"
-                            /></group>
-                    </page>
-                </notebook>
+                                <field name="date_paid" />
+                                <field name="total_amount" widget="monetary" />
+                            </group>
+                        </page>
+                        <page string="Accounting">
+                            <separator colspan="4" string="Acceptance Entries" />
+                            <field name='acceptance_move_ids' colspan="4" nolabel="1" />
+                            <separator colspan="4" string="Credit Entry" />
+                            <field name='credit_move_id' colspan="4" nolabel="1" />
+                            <separator colspan="4" string="Payments" />
+                            <field name='payment_ids' colspan="4" nolabel="1">
+                                <tree>
+                                    <field name="date" />
+                                    <field name="move_id" />
+                                    <field name="ref" />
+                                    <field name="name" />
+                                    <field name="journal_id" groups="base.group_user" />
+                                    <field name="debit" />
+                                    <field name="credit" />
+                                    <field name="amount_currency" />
+                                    <field name="currency_id" />
+                                </tree>
+                            </field>
+                            <separator colspan="4" string="Past Dues" />
+                            <field name='past_due_move_ids' colspan="4" nolabel="1" />
+                        </page>
+                    </notebook>
+                </sheet>
             </form>
         </field>
     </record>
@@ -278,6 +273,17 @@
         <field name="res_model">riba.slip</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="view_slip_riba_filter" />
+    </record>
+
+    <!-- ====================================================== -->
+    <!--                     RIBA SLIP LINE ACTION               -->
+    <!-- ====================================================== -->
+    <record id="riba_line_settle_action_server" model="ir.actions.server">
+        <field name="name">Settle RiBa Line</field>
+        <field name="model_id" ref="l10n_it_riba.model_riba_slip_line" />
+        <field name="binding_model_id" ref="l10n_it_riba.model_riba_slip_line" />
+        <field name="state">code</field>
+        <field name="code">action = records.settle_riba_line()</field>
     </record>
 
     <!-- ====================================================== -->

--- a/l10n_it_riba/views/wizard_riba_payment_date.xml
+++ b/l10n_it_riba/views/wizard_riba_payment_date.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 Nextev Srl
+  ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+  -->
+<odoo>
+    <record id="wizard_riba_payment_date" model="ir.ui.view">
+        <field name="name">Set RiBa Payment Date</field>
+        <field name="model">riba.payment.date</field>
+        <field name="arch" type="xml">
+            <form string="Set RiBa Payment Date">
+                <group col="4">
+                    <group colspan="4">
+                        <field name="date" />
+                    </group>
+                    <footer colspan="4">
+                        <button
+                            name="set_riba_payment_date"
+                            string="Confirm"
+                            type="object"
+                        />
+                        <button special="cancel" string="Close" />
+                    </footer>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_riba_payment_date" model="ir.actions.server">
+        <field name="name">RiBa Payment Date</field>
+        <field name="model_id" ref="account.model_account_move" />
+        <field name="binding_model_id" ref="account.model_account_move" />
+        <field name="state">code</field>
+        <field name="code">action = records.action_riba_payment_date()</field>
+    </record>
+
+</odoo>

--- a/l10n_it_riba/wizard/__init__.py
+++ b/l10n_it_riba/wizard/__init__.py
@@ -8,6 +8,7 @@
 
 from . import wizard_riba_issue
 from . import wizard_riba_file_export
+from . import wizard_riba_payment_date
 from . import wizard_credit
 from . import wizard_past_due
 from . import wizard_presentation_riba

--- a/l10n_it_riba/wizard/wizard_past_due.py
+++ b/l10n_it_riba/wizard/wizard_past_due.py
@@ -98,6 +98,8 @@ class RibaPastDue(models.TransientModel):
             raise UserError(_("No active ID found."))
         line_model = self.env["riba.slip.line"]
         line = line_model.browse(active_id)
+        line.acceptance_move_id.button_draft()
+        line.acceptance_move_id.unlink()
         line.state = "past_due"
         line.slip_id.state = "past_due"
         return {"type": "ir.actions.act_window_close"}

--- a/l10n_it_riba/wizard/wizard_past_due.py
+++ b/l10n_it_riba/wizard/wizard_past_due.py
@@ -132,27 +132,6 @@ class RibaPastDue(models.TransientModel):
                     0,
                     0,
                     {
-                        "name": _("Bills"),
-                        "account_id": wizard.effects_account_id.id,
-                        "partner_id": slip_line.partner_id.id,
-                        "credit": wizard.effects_amount,
-                        "debit": 0.0,
-                    },
-                ),
-                (
-                    0,
-                    0,
-                    {
-                        "name": _("RiBa"),
-                        "account_id": wizard.riba_bank_account_id.id,
-                        "debit": wizard.riba_bank_amount,
-                        "credit": 0.0,
-                    },
-                ),
-                (
-                    0,
-                    0,
-                    {
                         "name": _("Past Due Bills"),
                         "account_id": wizard.overdue_effects_account_id.id,
                         "debit": wizard.overdue_effects_amount,
@@ -203,6 +182,7 @@ class RibaPastDue(models.TransientModel):
                             i.id
                             for i in riba_move_line.move_line_id.past_due_invoice_ids
                         ]
+                    riba_move_line.move_line_id.remove_move_reconcile()
                     move_model.browse(invoice_ids).write(
                         {
                             "past_due_move_line_ids": [(4, move_line.id)],

--- a/l10n_it_riba/wizard/wizard_riba_payment_date.py
+++ b/l10n_it_riba/wizard/wizard_riba_payment_date.py
@@ -1,0 +1,22 @@
+# Copyright 2024 Nextev Srl
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+# -------------------------------------------------------
+#        RIBA PAYMENT DATE
+# -------------------------------------------------------
+class RibaPaymentDate(models.TransientModel):
+    _name = "riba.payment.date"
+    _description = "RiBa Payment Date"
+
+    date = fields.Date(string="Payment Date", required=True)
+
+    def set_riba_payment_date(self):
+        active_id = self.env.context.get("active_id", False)
+        if not active_id:
+            raise UserError(_("No active ID found."))
+        move = self.env["account.move"].browse([active_id])
+        move.date = self.date


### PR DESCRIPTION
### Ammontare scoperto/esposizione
Per risolvere questa issue https://github.com/OCA/l10n-italy/issues/3983 abbiamo assegnato all'`account.move.line` del pagamento che viene creata alla conferma della `riba.slip.line` la data effettiva della scadenza della `riba.slip.line` e non quella della `riba.slip`.

![image](https://github.com/OCA/l10n-italy/assets/93990941/03830e31-23cb-4ad1-9ea3-68025ec696fd)

Nel modello `account.move` abbiamo aggiunto un campo che calcola lo scoperto/esposizione della fattura, ovvero quello che attualmente si suppone solamente che sia pagato, ma effettivamente no come indicato nella vista qui sotto:

![image](https://github.com/OCA/l10n-italy/assets/93990941/c15aff52-6353-4da8-a36c-5c8975b41f0d)

### Insoluti
Per risolvere questa issue https://github.com/OCA/l10n-italy/issues/3983 abbiamo eliminato le 2 righe di registrazione sezionale con nome "Bills" e conto effects_account_id in credito e quella con nome "RiBa" e conto riba_bank_account_id in debito e quando si marca come insoluta una riba.slip.line abbiamo annullato la riconciliazione con la account.move.line del pagamento correlata.
Facendo ciò la fattura tornerebbe "non pagata" o "parzialmente pagata" (oltre ad avere il flag "past due").

![image](https://github.com/OCA/l10n-italy/assets/93990941/35cd813e-960b-4e32-932c-c9ab3d22bb1b)

![image](https://github.com/OCA/l10n-italy/assets/93990941/9d737377-59c8-4ff3-85f0-34f434c19016)

![image](https://github.com/OCA/l10n-italy/assets/93990941/9955edb6-220c-4357-bc4a-e478843df01b)

Ho dovuto rimuovere una parte dei test con questo commit: af22ff94e2736290380fb893f799a810ba2dec2e
Suppongo che `riba_list.line_ids[0].past_due_move_id.line_ids` non si riferisca più alle 2 righe di registrazione contabile "Bills" e "RiBa" che non vengono più create e quindi è inutile fare dei check, però l'ho messo in un commitseparato per conferma.