### PR TITLE
[16.0][FIX] l10n_it_delivery_note: always show partner_ref in DN

### DIFF
--- a/l10n_it_delivery_note/report/report_delivery_note.xml
+++ b/l10n_it_delivery_note/report/report_delivery_note.xml
@@ -289,7 +289,7 @@
                             <div
                                 name="transport_date"
                                 style="font-size:10px;"
-                            >DN date</div>
+                            >Transport date</div>
                             <div
                                 class="m-0"
                                 style="font-size:12px;"

--- a/l10n_it_delivery_note/views/stock_delivery_note.xml
+++ b/l10n_it_delivery_note/views/stock_delivery_note.xml
@@ -103,22 +103,20 @@
                             <label for="name" string="Draft document" />
                         </div>
                         <div attrs="{'invisible': [('name', 'in', [False, ''])]}">
-                            <label for="name" string="Document" />
                             <h1>
+                                <label for="name" string="Document" />
                                 <field
                                     name="name"
                                     class="oe_inline"
                                     attrs="{'readonly': [('can_change_number', '=', False)]}"
                                 />
                             </h1>
-                            <div
-                                attrs="{'invisible': [('type_code', '!=', 'incoming')]}"
-                            >
-                                <label for="name" string="Partner document" />
-                                <h2>
-                                    <field name="partner_ref" class="oe_inline" />
-                                </h2>
-                            </div>
+                        </div>
+                        <div attrs="{'invisible': [('type_code', '!=', 'incoming')]}">
+                            <h2>
+                                <label for="partner_ref" />
+                                <field name="partner_ref" class="oe_inline" />
+                            </h2>
                         </div>
                     </div>
                     <div


### PR DESCRIPTION
FW of #3518

Fixes https://github.com/OCA/l10n-italy/issues/3517 for v16