### PR TITLE
[16.0] Fix association between lines and related docs

### DIFF
--- a/l10n_it_fatturapa/models/account.py
+++ b/l10n_it_fatturapa/models/account.py
@@ -197,6 +197,9 @@ class FatturapaRelatedDocumentType(models.Model):
                 vals["lineRef"] = line.sequence
         return super().create(vals_list)
 
+    def setlineRef(self, n):
+        self.lineRef = n
+
 
 class FatturapaActivityProgress(models.Model):
     # _position = ['2.1.7']

--- a/l10n_it_fatturapa_out/data/invoice_it_template.xml
+++ b/l10n_it_fatturapa_out/data/invoice_it_template.xml
@@ -38,35 +38,35 @@ e 'line' per riga di fattura (a seconda del livello in cui sono chiamati)
                 t-foreach="line.related_documents.filtered(lambda doc: doc.type == 'order')"
                 t-as="doc"
             >
-                    <t t-set="doc_lineRef" t-value="line_counter" />
+                    <t t-set="doc_lineRef" t-value="doc.setlineRef(line_counter)" />
                     <t t-set="related_orders" t-value="related_orders + doc" />
                 </t>
                 <t
                 t-foreach="line.related_documents.filtered(lambda doc: doc.type == 'contract')"
                 t-as="doc"
             >
-                    <t t-set="doc_lineRef" t-value="line_counter" />
+                    <t t-set="doc_lineRef" t-value="doc.setlineRef(line_counter)" />
                     <t t-set="related_contracts" t-value="related_contracts + doc" />
                 </t>
                 <t
                 t-foreach="line.related_documents.filtered(lambda doc: doc.type == 'agreement')"
                 t-as="doc"
             >
-                    <t t-set="doc_lineRef" t-value="line_counter" />
+                    <t t-set="doc_lineRef" t-value="doc.setlineRef(line_counter)" />
                     <t t-set="related_agreements" t-value="related_agreements + doc" />
                 </t>
                 <t
                 t-foreach="line.related_documents.filtered(lambda doc: doc.type == 'reception')"
                 t-as="doc"
             >
-                    <t t-set="doc_lineRef" t-value="line_counter" />
+                    <t t-set="doc_lineRef" t-value="doc.setlineRef(line_counter)" />
                     <t t-set="related_receptions" t-value="related_receptions + doc" />
                 </t>
                 <t
                 t-foreach="line.related_documents.filtered(lambda doc: doc.type == 'invoice')"
                 t-as="doc"
             >
-                    <t t-set="doc_lineRef" t-value="line_counter" />
+                    <t t-set="doc_lineRef" t-value="doc.setlineRef(line_counter)" />
                     <t t-set="related_invoices" t-value="related_invoices + doc" />
                 </t>
             </t>

--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00017.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00017.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ns1:FatturaElettronica xmlns:ns1="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" versione="FPA12">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>06363391001</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>00017</ProgressivoInvio>
+            <FormatoTrasmissione>FPA12</FormatoTrasmissione>
+            <CodiceDestinatario>UFPQ1O</CodiceDestinatario>
+            <ContattiTrasmittente>
+                <Telefono>06543534343</Telefono>
+                <Email>info@yourcompany.example.com</Email>
+            </ContattiTrasmittente>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>06363391001</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>YourCompany</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Milano, 1</Indirizzo>
+                <CAP>00100</CAP>
+                <Comune>Roma</Comune>
+                <Provincia>AK</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+            <Contatti>
+                <Telefono>06543534343</Telefono>
+                <Email>info@yourcompany.example.com</Email>
+            </Contatti>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>06363391001</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>06363391001</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>Public Administration</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Roma, 1</Indirizzo>
+                <CAP>10100</CAP>
+                <Comune>Torino</Comune>
+                <Provincia>AK</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2016-06-15</Data>
+                <Numero>INV/2016/0014</Numero>
+                <ImportoTotaleDocumento>17.08</ImportoTotaleDocumento>
+                <Causale>prima riga</Causale>
+                <Causale>seconda riga</Causale>
+                <Art73>SI</Art73>
+            </DatiGeneraliDocumento>
+            <DatiOrdineAcquisto>
+                <RiferimentoNumeroLinea>2</RiferimentoNumeroLinea>
+                <IdDocumento>PO123</IdDocumento>
+                <CodiceCUP>456</CodiceCUP>
+                <CodiceCIG>123</CodiceCIG>
+            </DatiOrdineAcquisto>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>Mouse, Optical</Descrizione>
+                <Quantita>1.000</Quantita>
+                <UnitaMisura>Unit(s)</UnitaMisura>
+                <PrezzoUnitario>10.00000</PrezzoUnitario>
+                <PrezzoTotale>10.00</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>2</NumeroLinea>
+                <Descrizione>Zed+ Antivirus</Descrizione>
+                <Quantita>1.000</Quantita>
+                <UnitaMisura>Unit(s)</UnitaMisura>
+                <PrezzoUnitario>4.00000</PrezzoUnitario>
+                <PrezzoTotale>4.00</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>14.00</ImponibileImporto>
+                <Imposta>3.08</Imposta>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2016-07-31</DataScadenzaPagamento>
+                <ImportoPagamento>17.08</ImportoPagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</ns1:FatturaElettronica>


### PR DESCRIPTION
Breve descrizione: i documenti collegati alle righe fattura non riportano nell'XML il riferimento numerico corretto.

È un risultato della migrazione, nella 16 ci sono maggiori controlli sintattici, sarebbe da vedere se sulla 14 funziona veramente o semplicemente il codice viene ignorato.

Adesso nel template viene calcolata l'associazione corretta, riga per riga.

Fixes: #4036 