### PR TITLE
[14.0] [FIX] l10n_it_fatturapa_import_zip: avoid VAT check

### DIFF
--- a/l10n_it_fatturapa_import_zip/models/attachment.py
+++ b/l10n_it_fatturapa_import_zip/models/attachment.py
@@ -164,7 +164,9 @@ class FatturaPAAttachmentImportZIP(models.Model):
                     )
                     .create({})
                 )
-                wizard.importFatturaPA()
+                wizard.with_context(
+                    fatturapa_in_skip_no_it_vat_check=True
+                ).importFatturaPA()
             self.env.company.in_invoice_registration_date = (
                 original_in_invoice_registration_date
             )


### PR DESCRIPTION
Steps:

 - Try to import an issued XML with                `<IdPaese>DE</IdPaese> <IdCodice>0000000</IdCodice>`

Get

La partita IVA [0000000] del partner [XXX] non sembra essere valida