### PR TITLE
[14.0] [FIX] l10n_it_delivery_note: error in sequence name generation

### DIFF
--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -544,9 +544,17 @@ class StockDeliveryNote(models.Model):
                 note.date = datetime.date.today()
 
             if not note.name:
-                note.name = sequence.with_context(
-                    ir_sequence_date=note.date
-                ).next_by_id()
+                # Avoid duplicates
+                while True:
+                    name = sequence.with_context(
+                        ir_sequence_date=note.date
+                    ).next_by_id()
+                    if not self.search(
+                        [("name", "=", name), ("company_id", "=", note.company_id.id)]
+                    ):
+                        break
+
+                note.name = name
                 note.sequence_id = sequence
 
     def action_confirm(self):


### PR DESCRIPTION
Keep generating name with sequence number until one is available.

This could be useful because if for any weird reason a DN with the next sequence has already been created it would show a validation error.