### PR TITLE
[COV] l10n_it_vat_statement_communication: Eseguire i test solo una volta

### DIFF
--- a/l10n_it_vat_statement_communication/tests/test_vat_statement_communication.py
+++ b/l10n_it_vat_statement_communication/tests/test_vat_statement_communication.py
@@ -8,7 +8,7 @@ from odoo.tests.common import Form, tagged
 from odoo.addons.account.tests.common import TestAccountReconciliationCommon
 
 
-@tagged("post_install")
+@tagged("-at_install", "post_install")
 class VatStatementCommunicationCase(TestAccountReconciliationCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Senza queste modifiche viene anche sollevato questo warning durante l'esecuzione dei test:
> WARNING <db_name> odoo.tests.common: A tests should be either at_install or post_install, which is not the case of <class 'odoo.addons.l10n_it_vat_statement_communication.tests.test_vat_statement_communication.VatStatementCommunicationCase'>

In `14.0` non succede perché non ci sono test.