### PR TITLE
[16.0] [FIX] l10n_it_reverse_charge: write supplier_invoice_vals in generate_supplier_self_invoice

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -481,6 +481,8 @@ class AccountMove(models.Model):
 
         if not supplier_invoice:
             supplier_invoice = self.create(supplier_invoice_vals)
+        else:
+            supplier_invoice.write(supplier_invoice_vals)
         invoice_line_vals = []
         for inv_line in self.invoice_line_ids:
             line_vals = inv_line.copy_data()[0]


### PR DESCRIPTION

Otherwise if user resets to draft supplier invoice and change some invoice fields, they are not propagated to self invoices

Also, this alignes to generate_self_invoice which already performs rc_invoice.write(inv_vals)