### PR TITLE
[16.0] [FIX] l10n_it_reverse_charge: refunds with rc_supplier_invoice

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -289,7 +289,7 @@ class AccountMove(models.Model):
         payment_debit_line_data = self.rc_debit_line_vals(
             line_to_reconcile.account_id,
             payment_credit_line_data["amount_currency"],
-            payment_credit_line_data["credit"],
+            payment_credit_line_data["credit"] or payment_credit_line_data["debit"],
         )
         rc_payment_data["line_ids"] = [
             (0, 0, payment_debit_line_data),


### PR DESCRIPTION
Otherwise you would get "Il movimento non è bilanciato"