### PR TITLE
[16.0][FIX] customer bank account for riba payment from commercial entity

### DIFF
--- a/l10n_it_riba/views/account_view.xml
+++ b/l10n_it_riba/views/account_view.xml
@@ -146,7 +146,7 @@
                  <field
                     name="riba_partner_bank_id"
                     attrs="{'invisible': ['|',('is_riba_payment','=', False),('move_type','!=','out_invoice')], 'required': ['&amp;',('is_riba_payment','=', True),('move_type','=', 'out_invoice')]}"
-                    domain="[('partner_id','=', partner_id)]"
+                    domain="[('partner_id','=', commercial_partner_id)]"
                 />
                 <field
                     name="is_past_due"


### PR DESCRIPTION
I conti correnti sono collegati al contatto dell'entità commerciale principale, per cui il dominio dovrebbe essere 'partner_id' = 'commercial_partner_id' non 'partner_id'