### PR TITLE
[16.0][FIX] l10n_it_fatturapa_out: invoices for San Marino

### DIFF
--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00018.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00018.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ns1:FatturaElettronica xmlns:ns1="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" versione="FPR12">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>06363391001</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>00018</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>2R4GTO8</CodiceDestinatario>
+            <ContattiTrasmittente>
+                <Telefono>06543534343</Telefono>
+                <Email>info@yourcompany.example.com</Email>
+            </ContattiTrasmittente>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>06363391001</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>YourCompany</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Milano, 1</Indirizzo>
+                <CAP>00100</CAP>
+                <Comune>Roma</Comune>
+                <Provincia>AK</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+            <Contatti>
+                <Telefono>06543534343</Telefono>
+                <Email>info@yourcompany.example.com</Email>
+            </Contatti>
+            <RiferimentoAmministrazione>F000000111</RiferimentoAmministrazione>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>SM</IdPaese>
+                    <IdCodice>00123</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>Azienda Sanmarinese</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Piazza della Libertà</Indirizzo>
+                <CAP>47890</CAP>
+                <Comune>Città di San Marino</Comune>
+                <Nazione>SM</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2016-01-07</Data>
+                <Numero>INV/2016/0013</Numero>
+                <ImportoTotaleDocumento>14.00</ImportoTotaleDocumento>
+                <Art73>SI</Art73>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>Mouse Optical</Descrizione>
+                <Quantita>1.000</Quantita>
+                <UnitaMisura>Unit(s)</UnitaMisura>
+                <PrezzoUnitario>10.00000</PrezzoUnitario>
+                <PrezzoTotale>10.00</PrezzoTotale>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N3.3</Natura>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>2</NumeroLinea>
+                <Descrizione>Zed+ Antivirus</Descrizione>
+                <Quantita>1.000</Quantita>
+                <UnitaMisura>Unit(s)</UnitaMisura>
+                <PrezzoUnitario>4.00000</PrezzoUnitario>
+                <PrezzoTotale>4.00</PrezzoTotale>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N3.3</Natura>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N3.3</Natura>
+                <ImponibileImporto>14.00</ImponibileImporto>
+                <Imposta>0.00</Imposta>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2016-02-29</DataScadenzaPagamento>
+                <ImportoPagamento>14.00</ImportoPagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</ns1:FatturaElettronica>

--- a/l10n_it_fatturapa_out/wizard/efattura.py
+++ b/l10n_it_fatturapa_out/wizard/efattura.py
@@ -119,7 +119,9 @@ class EFatturaOut:
         def get_id_fiscale_iva(partner, prefer_fiscalcode=False):
             id_paese = partner.country_id.code
             if partner.vat:
-                if id_paese == "IT" and partner.vat.startswith("IT"):
+                if (id_paese == "IT" and partner.vat.startswith("IT")) or (
+                    id_paese == "SM" and partner.vat.startswith("SM")
+                ):
                     id_codice = partner.vat[2:]
                 else:
                     id_codice = partner.vat


### PR DESCRIPTION
Fixes: #4078

Rimuove "SM" dalla vat di San Marino, per controlli fatti da loro. Allo SdI non interessa (non dà errore).