### PR TITLE
[14.0][FIX] l10n_it_fatturapa_out: invoices for San Marino

### DIFF
--- a/l10n_it_fatturapa_out/tests/data/IT06363391001_00018.xml
+++ b/l10n_it_fatturapa_out/tests/data/IT06363391001_00018.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ns1:FatturaElettronica xmlns:ns1="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" versione="FPR12">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>06363391001</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>00018</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>2R4GTO8</CodiceDestinatario>
+            <ContattiTrasmittente>
+                <Telefono>06543534343</Telefono>
+                <Email>info@yourcompany.example.com</Email>
+            </ContattiTrasmittente>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>06363391001</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>YourCompany</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Milano, 1</Indirizzo>
+                <CAP>00100</CAP>
+                <Comune>Roma</Comune>
+                <Provincia>AK</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+            <Contatti>
+                <Telefono>06543534343</Telefono>
+                <Email>info@yourcompany.example.com</Email>
+            </Contatti>
+            <RiferimentoAmministrazione>F000000111</RiferimentoAmministrazione>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>SM</IdPaese>
+                    <IdCodice>00123</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>Azienda Sanmarinese</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Piazza della Libertà</Indirizzo>
+                <CAP>47890</CAP>
+                <Comune>Città di San Marino</Comune>
+                <Nazione>SM</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2016-01-07</Data>
+                <Numero>INV/2016/0013</Numero>
+                <ImportoTotaleDocumento>14.00</ImportoTotaleDocumento>
+                <Art73>SI</Art73>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>Mouse Optical</Descrizione>
+                <Quantita>1.000</Quantita>
+                <UnitaMisura>Unit(s)</UnitaMisura>
+                <PrezzoUnitario>10.00000</PrezzoUnitario>
+                <PrezzoTotale>10.00</PrezzoTotale>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N3.3</Natura>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>2</NumeroLinea>
+                <Descrizione>Zed+ Antivirus</Descrizione>
+                <Quantita>1.000</Quantita>
+                <UnitaMisura>Unit(s)</UnitaMisura>
+                <PrezzoUnitario>4.00000</PrezzoUnitario>
+                <PrezzoTotale>4.00</PrezzoTotale>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N3.3</Natura>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N3.3</Natura>
+                <ImponibileImporto>14.00</ImponibileImporto>
+                <Imposta>0.00</Imposta>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2016-02-29</DataScadenzaPagamento>
+                <ImportoPagamento>14.00</ImportoPagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</ns1:FatturaElettronica>

--- a/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
@@ -1056,3 +1056,89 @@ class TestFatturaPAXMLValidation(FatturaPACommon):
         invoice.action_post()
 
         self.assertEqual(invoice.state, "posted")
+
+    def test_18_xml_export(self):
+        vals = {
+            "name": "Azienda Sanmarinese",
+            "is_company": "1",
+            "street": "Piazza della Libertà",
+            "is_pa": False,
+            "city": "Città di San Marino",
+            "zip": "47890",
+            "country_id": self.env.ref("base.sm").id,
+            "email": "asm@example.com",
+            "vat": "SM00123",
+            "codice_destinatario": "2R4GTO8",
+        }
+        partner_sm = self.env["res.partner"].create(vals)
+
+        tax_kind = self.env["account.tax.kind"].search([("code", "=", "N3.3")], limit=1)
+        self.assertTrue(tax_kind)
+
+        vals = {
+            "name": "0% SM",
+            "amount": 0.0,
+            "amount_type": "percent",
+            "description": "Non Imponibile Art. 71",
+            "kind_id": tax_kind.id,
+        }
+        tax_id = self.env["account.tax"].create(vals)
+
+        self.env.company.fatturapa_pub_administration_ref = "F000000111"
+        invoice = self.invoice_model.create(
+            {
+                "name": "INV/2016/0013",
+                "company_id": self.env.company.id,
+                "invoice_date": "2016-01-07",
+                "partner_id": partner_sm.id,
+                "journal_id": self.sales_journal.id,
+                # "account_id": self.a_recv.id,
+                "invoice_payment_term_id": self.account_payment_term.id,
+                "user_id": self.user_demo.id,
+                "move_type": "out_invoice",
+                "currency_id": self.EUR.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "account_id": self.a_sale.id,
+                            "product_id": self.product_product_10.id,
+                            "name": "Mouse\nOptical",
+                            "quantity": 1,
+                            "product_uom_id": self.product_uom_unit.id,
+                            "price_unit": 10,
+                            "tax_ids": [(6, 0, [tax_id.id])],
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "account_id": self.a_sale.id,
+                            "product_id": self.product_order_01.id,
+                            "name": "Zed+ Antivirus",
+                            "quantity": 1,
+                            "product_uom_id": self.product_uom_unit.id,
+                            "price_unit": 4,
+                            "tax_ids": [(6, 0, [tax_id.id])],
+                        },
+                    ),
+                ],
+            }
+        )
+        invoice._post()
+        self.assertFalse(self.attach_model.file_name_exists("00001"))
+        res = self.run_wizard(invoice.id)
+
+        self.assertTrue(res)
+        attachment = self.attach_model.browse(res["res_id"])
+        file_name_match = "^%s_[A-Za-z0-9]{5}.xml$" % self.env.company.vat
+        # Checking file name randomly generated
+        self.assertTrue(re.search(file_name_match, attachment.name))
+        self.set_e_invoice_file_id(attachment, "IT06363391001_00018.xml")
+        self.assertTrue(self.attach_model.file_name_exists("00018"))
+
+        # XML doc to be validated
+        xml_content = base64.decodebytes(attachment.datas)
+        self.check_content(xml_content, "IT06363391001_00018.xml")

--- a/l10n_it_fatturapa_out/wizard/efattura.py
+++ b/l10n_it_fatturapa_out/wizard/efattura.py
@@ -110,7 +110,9 @@ class EFatturaOut:
         def get_id_fiscale_iva(partner, prefer_fiscalcode=False):
             id_paese = partner.country_id.code
             if partner.vat:
-                if id_paese == "IT" and partner.vat.startswith("IT"):
+                if (id_paese == "IT" and partner.vat.startswith("IT")) or (
+                    id_paese == "SM" and partner.vat.startswith("SM")
+                ):
                     id_codice = partner.vat[2:]
                 else:
                     id_codice = partner.vat


### PR DESCRIPTION
Fixes: #4078

Rimuove "SM" dalla vat di San Marino, per controlli fatti da loro. Allo SdI non interessa (non dà errore).