### PR TITLE
[16.0] [FIX] l10n_it_reverse_charge: generate self invoices for purchase documents only

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -484,6 +484,8 @@ class AccountMove(models.Model):
     def action_post(self):
         ret = super().action_post()
         for invoice in self:
+            if not invoice.is_purchase_document(include_receipts=True):
+                continue
             fp = invoice.fiscal_position_id
             rc_type = fp and fp.rc_type_id
             if not rc_type:


### PR DESCRIPTION


During the posting of journal entries of bank statements System just follows the logic:"if account move is having a partner assigned with a suitable fiscal position - then post self-invoice"

Although, Odoo by default tries to detect and assign partners to the imported bank statements and during that process fiscal position as well automatically detected on the account_move module: https://github.com/odoo/odoo/blob/50766b74196b3cdc5ac83d7962873f4fffa4c9f6/addons/account/models/account_move.py#L776