### PR TITLE
[14.0][IMP] l10n_it_delivery_note Grouping by product

### DIFF
--- a/l10n_it_delivery_note/report/report_delivery_note.xml
+++ b/l10n_it_delivery_note/report/report_delivery_note.xml
@@ -192,7 +192,10 @@
 
                     <!--row delivery note-->
                     <tbody class="sale_tbody">
-                        <t t-foreach="doc.line_ids" t-as="line">
+
+                        <t t-set="lines" t-value="doc._grouped_lines()" />
+
+                        <t t-foreach="lines" t-as="line">
                             <tr
                                 t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else ''"
                             >

--- a/l10n_it_delivery_note_base/models/stock_delivery_note_type.py
+++ b/l10n_it_delivery_note_base/models/stock_delivery_note_type.py
@@ -55,6 +55,8 @@ class StockDeliveryNoteType(models.Model):
     )
     note = fields.Html(string="Internal note")
 
+    consolidate_line_for_product_in_report = fields.Boolean(default=False)
+
     _sql_constraints = [
         (
             "name_uniq",

--- a/l10n_it_delivery_note_base/views/stock_delivery_note_type.xml
+++ b/l10n_it_delivery_note_base/views/stock_delivery_note_type.xml
@@ -26,6 +26,7 @@
                             <field name="sequence_id" />
                             <field name="next_sequence_number" />
                             <field name="code" />
+                            <field name="consolidate_line_for_product_in_report" />
                         </group>
                         <group>
                             <field


### PR DESCRIPTION
Currently the same product may appear on multiple lines within the same picking or across different pickings.

However, in the DDT (Delivery Document) printout, each product should appear only once (with the same batch, if activated).

Implemented:

Added a flag within the DDT type: "Consolidate lines per product in the report".

If this is activated, a DDT where the same product appears on multiple lines will only appear once in the printout.

If the "show order reference in DDT printout" setting is active and the grouped product comes from different orders merged into the same DDT, multiple orders would show in the "order ref" field on the printout.

The same is for the "show customer reference in DDT printout" setting. 

