### PR TITLE
[16.0][IMP] l10n_it_fatturapa_out: use recipient code from commercial entity if not set

### DIFF
--- a/l10n_it_fatturapa_out/wizard/efattura.py
+++ b/l10n_it_fatturapa_out/wizard/efattura.py
@@ -218,9 +218,15 @@ class EFatturaOut:
 
         if self.partner_id.commercial_partner_id.is_pa:
             # check value code
-            code = self.partner_id.ipa_code
+            code = (
+                self.partner_id.ipa_code
+                or self.partner_id.commercial_partner_id.ipa_code
+            )
         else:
-            code = self.partner_id.codice_destinatario
+            code = (
+                self.partner_id.codice_destinatario
+                or self.partner_id.commercial_partner_id.codice_destinatario
+            )
 
         # Create file content.
         template_values = {


### PR DESCRIPTION
If the recipient code is not set on the partner but it is on the commercial entity, use that instead of leaving it blank.