### PR TITLE
[FIX] l10n_it_fatturapa_in: wrong logic always skips code

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -270,7 +270,7 @@ class WizardImportFatturapa(models.TransientModel):
         if len(partners) > 1:
             for partner in partners:
                 if (
-                    commercial_partner_id
+                    not commercial_partner_id
                     and partner.commercial_partner_id.id != commercial_partner_id
                 ):
                     self.log_inconsistency(


### PR DESCRIPTION
Duplicated partners with same vat and different commercial_parter_id were never detected.

Molto probabilmente da portare anche in 14.0