### PR TITLE
[FIX] l10n_it_fatturapa_import_zip: create bank accounts with correct partner

### DIFF
--- a/l10n_it_fatturapa_import_zip/wizards/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_import_zip/wizards/wizard_import_fatturapa.py
@@ -106,3 +106,11 @@ class WizardImportFatturapa(models.TransientModel):
             ]
         else:
             return tax_domain
+
+    def set_payments_data(self, FatturaBody, invoice, partner_id):
+        if self._is_import_attachment_out():
+            return super().set_payments_data(
+                FatturaBody, invoice, self.env.company.partner_id.id
+            )
+        else:
+            return super().set_payments_data(FatturaBody, invoice, partner_id)


### PR DESCRIPTION
When importing invoices (out) create bank accounts for the company, not for the customer.