### PR TITLE
[IMP] l10n_it_fiscalcode - set better position for fiscalcode

### DIFF
--- a/l10n_it_fiscalcode/view/fiscalcode_view.xml
+++ b/l10n_it_fiscalcode/view/fiscalcode_view.xml
@@ -5,7 +5,7 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base_vat.view_partner_form" />
         <field name="arch" type="xml">
-            <field name="type" position="after">
+            <field name="vat" position="before">
                 <label for="fiscalcode" />
                 <div name="fiscalcode_info" class="o_row">
                     <field name="fiscalcode" class="oe_inline" />


### PR DESCRIPTION
Back porting of https://github.com/OCA/l10n-italy/commit/b96d60ef5fd1fce58120b9c078ec71d1d0339316 added in https://github.com/OCA/l10n-italy/pull/2994

Questo commit inoltre risolve un problema che ho riscontrato su di un'istanza di un cliente su cui ci sono numerose viste ereditate della vista di `res.partner`. Il campo `fiscalcode` rimane collassato non permettendo così il suo editing.

![image](https://github.com/OCA/l10n-italy/assets/3512779/d5ca3f79-1e33-4ec5-b6c0-a1666f0282bf)
 