### PR TITLE
[16.0] l10n_it_fatturapa: tolto staticmethod a ftpa_preview_xml

### DIFF
--- a/l10n_it_fatturapa/models/ir_attachment.py
+++ b/l10n_it_fatturapa/models/ir_attachment.py
@@ -41,7 +41,6 @@ class Attachment(models.Model):
                 att.get_base_url() + "/fatturapa/preview/%s" % att.id
             )
 
-    @staticmethod
     def ftpa_preview(self):
         return {
             "type": "ir.actions.act_url",

--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -181,4 +181,4 @@ class FatturaPAAttachmentIn(models.Model):
                             )
 
     def ftpa_preview(self):
-        return self.env["ir.attachment"].ftpa_preview(self)
+        return self.ir_attachment_id.ftpa_preview()

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -1029,6 +1029,15 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         # allow following tests to reuse the same XML file
         orig_invoice.ref = orig_invoice.payment_reference = "14021"
 
+    def test_01_xml_preview(self):
+        res = self.run_wizard("test_preview", "IT05979361218_001.xml")
+        invoice_id = res.get("domain")[0][2][0]
+        invoice = self.invoice_model.browse(invoice_id)
+        preview_action = invoice.fatturapa_attachment_in_id.ftpa_preview()
+        self.assertEqual(
+            preview_action["url"], invoice.fatturapa_attachment_in_id.ftpa_preview_link
+        )
+
     def test_01_xml_zero_quantity_line(self):
         res = self.run_wizard("test_zeroq_01", "IT05979361218_q0.xml")
         invoice_id = res.get("domain")[0][2][0]

--- a/l10n_it_fatturapa_out/models/attachment.py
+++ b/l10n_it_fatturapa_out/models/attachment.py
@@ -118,7 +118,7 @@ class FatturaPAAttachment(models.Model):
                 attachment_out.has_pdf_invoice_print = True
 
     def ftpa_preview(self):
-        return self.env["ir.attachment"].ftpa_preview(self)
+        return self.ir_attachment_id.ftpa_preview()
 
     def reset_to_ready(self):
         for attachment_out in self:

--- a/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
@@ -932,6 +932,11 @@ class TestFatturaPAXMLValidation(FatturaPACommon):
         e_invoice.reset_to_ready()
         self.assertEqual(e_invoice.state, "ready")
 
+    def test_preview(self):
+        e_invoice = self._create_e_invoice()
+        preview_action = e_invoice.ftpa_preview()
+        self.assertEqual(preview_action["url"], e_invoice.ftpa_preview_link)
+
     def test_no_export_bill(self):
         invoice = self.invoice_model.create(
             {


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/4087 per la 16.0

`def ftpa_preview(self):`
era definita come `@staticmethod` quindi il parametro `self ` veniva considerato come un parametro di nome self e non era possibile fare attachment.ftpa_preview()