### PR TITLE
[16.0] [FIX] l10n_it_reverse_charge: consider original invoice date in RC invoice comments

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -99,11 +99,13 @@ class AccountMove(models.Model):
         else:
             move_type = "out_refund"
         supplier = self.partner_id
+        reference_date = self.invoice_date
         original_invoice = self.search(
             [("rc_self_purchase_invoice_id", "=", self.id)], limit=1
         )
         if original_invoice:
             supplier = original_invoice.partner_id
+            reference_date = original_invoice.invoice_date
 
         narration = _(
             "Reverse charge self invoice.\n"
@@ -113,7 +115,7 @@ class AccountMove(models.Model):
             "Internal reference: %(internal_reference)s",
             supplier=supplier.display_name,
             reference=self.invoice_origin or self.ref or "",
-            date=self.date,
+            date=reference_date,
             internal_reference=self.name,
         )
         return {


### PR DESCRIPTION
For some unknown reason, since its inception (? https://github.com/OCA/l10n-italy/commit/e460d4d8ccdf6362101abaa360d80b4e2c45f390 ) the description relating to the original invoice, always used the date of the RC document, not the actual one.

Fixes: https://github.com/OCA/l10n-italy/issues/4141