### PR TITLE
FIX 16.0-l10n_it_fiscalcode: Fix invoice report, now fiscalcode is always printed if present in partner

### DIFF
--- a/l10n_it_fiscalcode/view/report_invoice_document.xml
+++ b/l10n_it_fiscalcode/view/report_invoice_document.xml
@@ -1,7 +1,25 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="print_invoice_inherit" inherit_id="account.report_invoice_document">
-        <xpath expr="//div[@t-if='o.partner_id.vat']" position="after">
+        <xpath
+            expr="//div[@id='partner_vat_address_not_same_as_shipping']"
+            position="after"
+        >
+            <div t-if="o.partner_id.fiscalcode" class="mt16">
+                Fiscal code:
+                <span t-field="o.partner_id.fiscalcode" />
+            </div>
+        </xpath>
+        <xpath
+            expr="//div[@id='partner_vat_address_same_as_shipping']"
+            position="after"
+        >
+            <div t-if="o.partner_id.fiscalcode" class="mt16">
+                Fiscal code:
+                <span t-field="o.partner_id.fiscalcode" />
+            </div>
+        </xpath>
+        <xpath expr="//div[@id='partner_vat_no_shipping']" position="after">
             <div t-if="o.partner_id.fiscalcode" class="mt16">
                 Fiscal code:
                 <span t-field="o.partner_id.fiscalcode" />


### PR DESCRIPTION
In original view, there are 3 div with t-if='o.partner_id.vat, now they are all managed with correctly xpath

