### PR TITLE
[FIX]l10n_it_financial_statements_report: Syntax compatibility

### DIFF
--- a/l10n_it_financial_statements_report/report/financial_statements_report_xlsx.py
+++ b/l10n_it_financial_statements_report/report/financial_statements_report_xlsx.py
@@ -566,7 +566,9 @@ class FinancialStatementsReportXslx(models.AbstractModel):
             allow = True
 
         if value:
-            if isinstance(value, int | float) and cell_type not in (
+            if (
+                isinstance(value, int) or isinstance(value, float)
+            ) and cell_type not in (
                 "amount",
                 "amount_currency",
             ):


### PR DESCRIPTION
Report XLSX: the syntax "if isinstance(value, int | float)" can be used on Python 3.10 and above versions. 16.0 code should be compatible with Python>=3.7 tho.