### PR TITLE
[FIX] l10n_it_withholding_tax: fix singleton error

### DIFF
--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -189,7 +189,7 @@ class AccountPartialReconcile(models.Model):
                 line_to_reconcile = line
                 break
         if line_to_reconcile:
-            if lines.move_id.move_type in ["in_refund", "out_invoice"]:
+            if line_to_reconcile.move_id.move_type in ["in_refund", "out_invoice"]:
                 debit_move_id = rec_line_statement.id
                 credit_move_id = line_to_reconcile.id
             else:


### PR DESCRIPTION
Fix for:

```
Errore:
Odoo Server Error

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
    result = request.dispatch()
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 696, in dispatch
    result = self._call_function(**self.params)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 370, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 358, in checked_call
    result = self.endpoint(*a, **kw)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 919, in __call__
    return self.method(*args, **kw)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 544, in response_wrap
    response = f(*args, **kw)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/main.py", line 1370, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/main.py", line 1362, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 400, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 373, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/custom/oca/account-reconcile/account_reconciliation_widget/models/reconciliation_widget.py", line 54, in process_bank_statement_line
    moves = st_line.with_context(ctx).process_reconciliation(
  File "/opt/odoo/custom/oca/account-reconcile/account_reconciliation_widget/models/account_bank_statement.py", line 150, in process_reconciliation
    counterpart_moves = self._create_counterpart_and_new_aml(
  File "/opt/odoo/custom/oca/account-reconcile/account_reconciliation_widget/models/account_bank_statement.py", line 253, in _create_counterpart_and_new_aml
    (new_aml | counterpart_move_line).reconcile()
  File "/opt/odoo/custom/oca/l10n-italy/l10n_it_ricevute_bancarie/models/account.py", line 308, in reconcile
    res = super(AccountMoveLine, self).reconcile()
  File "/usr/lib/python3/dist-packages/odoo/addons/account/models/account_move.py", line 5095, in reconcile
    partials = self.env['account.partial.reconcile'].create(sorted_lines._prepare_reconciliation_partials())
  File "<decorator-gen-372>", line 2, in create
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 333, in _model_create_single
    return self.browse().concat(*(create(self, vals) for vals in arg))
  File "/usr/lib/python3/dist-packages/odoo/api.py", line 333, in <genexpr>
    return self.browse().concat(*(create(self, vals) for vals in arg))
  File "/opt/odoo/custom/oca/l10n-italy/l10n_it_withholding_tax/models/account.py", line 99, in create
    reconcile.generate_wt_moves(is_wt_move, lines)
  File "/opt/odoo/custom/oca/l10n-italy/l10n_it_withholding_tax/models/account.py", line 178, in generate_wt_moves
    self.reconcile_exist_account_move(lines, rec_line_statement, amount_wt)
  File "/opt/odoo/custom/oca/l10n-italy/l10n_it_withholding_tax/models/account.py", line 192, in reconcile_exist_account_move
    if lines.move_id.move_type in ["in_refund", "out_invoice"]:
  File "/usr/lib/python3/dist-packages/odoo/fields.py", line 986, in __get__
    record.ensure_one()
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 5041, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ValueError: Expected singleton: account.move(473322, 473321)

```

Rif https://github.com/OCA/l10n-italy/issues/4200