### PR TITLE
[FIX] l10n_it_delivery_note: fix "object has no attribute" error

### DIFF
--- a/l10n_it_delivery_note/wizard/delivery_note_invoice.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_invoice.py
@@ -37,5 +37,4 @@ class StockDeliveryNoteInvoiceWizard(models.TransientModel):
         delivery_note_ids.action_invoice(self.invoice_method)
         for invoice in delivery_note_ids.mapped("invoice_ids"):
             invoice.invoice_date = self.invoice_date
-            # invoice._onchange_invoice_date()
         return True

--- a/l10n_it_delivery_note/wizard/delivery_note_invoice.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_invoice.py
@@ -37,5 +37,5 @@ class StockDeliveryNoteInvoiceWizard(models.TransientModel):
         delivery_note_ids.action_invoice(self.invoice_method)
         for invoice in delivery_note_ids.mapped("invoice_ids"):
             invoice.invoice_date = self.invoice_date
-            invoice._onchange_invoice_date()
+            # invoice._onchange_invoice_date()
         return True


### PR DESCRIPTION
FIX FOR:

RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 1638, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/src/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/src/odoo/odoo/http.py", line 1665, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/odoo/odoo/http.py", line 1869, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/odoo/addons/website/models/ir_http.py", line 237, in _dispatch
    response = super()._dispatch(endpoint)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/odoo/odoo/http.py", line 700, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/odoo/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/home/odoo/src/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/src/odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/src/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/src/user/OCA/l10n-italy/l10n_it_delivery_note/wizard/delivery_note_invoice.py", line 40, in create_invoices
    invoice._onchange_invoice_date()
AttributeError: 'account.move' object has no attribute '_onchange_invoice_date'

