### PR TITLE
[14.0][FIX] l10n_it_bill_of_entry: Multi company management in tests

### DIFF
--- a/l10n_it_bill_of_entry/tests/test_bill_of_entry.py
+++ b/l10n_it_bill_of_entry/tests/test_bill_of_entry.py
@@ -46,6 +46,10 @@ class TestBillOfEntry(AccountTestInvoicingCommon):
         demo_data_company = self.env.ref("base.main_company")
         self.env.user.company_ids |= demo_data_company
         self.env.user.company_id = demo_data_company
+        # Now that current user can access the company,
+        # log the user *only* in this company so that
+        # searching, reading and other operations behave as expected
+        self.env.user.company_ids = demo_data_company
 
         # Default accounts for invoice line account_id
         revenue_acctype_id = self.env.ref("account.data_account_type_revenue").id


### PR DESCRIPTION
The user must be logged in only one company for the tests to behave as expected. For instance, searching for a journal should only find journals in the current company

backport of https://github.com/OCA/l10n-italy/pull/4193