### PR TITLE
[14.0][FIX] l10n_it_withholding_tax pagamento fatture multiple con registrazione spese bancarie

### DIFF
--- a/l10n_it_withholding_tax/views/withholding_tax.xml
+++ b/l10n_it_withholding_tax/views/withholding_tax.xml
@@ -119,7 +119,6 @@
                     <field name="wt_type" />
                     <field name="partner_id" />
                     <field name="date" />
-                    <field name="move_id" />
                     <field name="invoice_id" />
                     <field name="withholding_tax_id" />
                     <field name="company_id" groups="base.group_multi_company" />
@@ -152,7 +151,6 @@
                             </group>
                             <group>
                                 <field name="date" />
-                                <field name="move_id" />
                                 <field name="invoice_id" />
                                 <field
                                 name="company_id"

--- a/l10n_it_withholding_tax/wizards/account_payment_register.py
+++ b/l10n_it_withholding_tax/wizards/account_payment_register.py
@@ -2,7 +2,7 @@
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
-from odoo.tools import float_is_zero
+from odoo.tools import float_compare, float_is_zero
 
 
 class AccountPaymentRegister(models.TransientModel):
@@ -38,3 +38,50 @@ class AccountPaymentRegister(models.TransientModel):
                         "source_amount_currency"
                     ] = net_pay_residual_amount
         return wizard_values_from_batch
+
+    def _create_payment_vals_from_wizard(self):
+        payment_vals = super()._create_payment_vals_from_wizard()
+        residual_amount_precision = self.env["decimal.precision"].precision_get(
+            "Account"
+        )
+        residual_withholding_amount = sum(
+            self.mapped("line_ids.move_id.amount_residual") or []
+        ) - sum(self.mapped("line_ids.move_id.amount_net_pay_residual") or [])
+        if residual_withholding_amount:
+            payment_difference = 0
+            if self.source_currency_id == self.currency_id and (
+                not float_compare(
+                    self.source_amount_currency,
+                    self.amount,
+                    precision_digits=residual_amount_precision,
+                )
+                == 0
+            ):
+                payment_difference = (
+                    self.source_amount_currency
+                    - residual_withholding_amount
+                    - self.amount
+                )
+            elif self.currency_id == self.company_id.currency_id and (
+                not float_compare(
+                    self.source_amount,
+                    self.amount,
+                    precision_digits=residual_amount_precision,
+                )
+                == 0
+            ):
+                # probably not needed as withholding amount does not know currency
+                # Payment expressed on the company's currency.
+                payment_difference = (
+                    self.source_amount - residual_withholding_amount - self.amount
+                )
+            if (
+                not self.currency_id.is_zero(payment_difference)
+                and self.payment_difference_handling == "reconcile"
+            ):
+                payment_vals["write_off_line_vals"] = {
+                    "name": self.writeoff_label,
+                    "amount": payment_difference,
+                    "account_id": self.writeoff_account_id.id,
+                }
+        return payment_vals


### PR DESCRIPTION
Soluzione aggiuntiva a #3781 
Questa PR copre la casistica di un pagamento di una fattura con ritenuta con contemporanea registrazione di spese bancarie.

Nella situazione attuale una fattura registrata di 1000€ + 220€ IVA con ritenuta di 200€, con un debito verso il fornitore quindi di 1020€, se viene pagata per 1021€ genera una registrazione con un write-off di 199€.

Con questa PR viene generato un write-off corretto di 1€.