### PR TITLE
[14.0][FIX]l10n_it_fatturapa_in: remove unnecessary write

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1227,7 +1227,6 @@ class WizardImportFatturapa(models.TransientModel):
 
         invoice._onchange_invoice_line_wt_ids()
         invoice._recompute_dynamic_lines()
-        invoice.write(invoice._convert_to_write(invoice._cache))
 
         rel_docs_dict = {
             # 2.1.2


### PR DESCRIPTION
There's no need to overwrite values when they don't change. Moreover a user might not have permissions to write certain fields (in my case it was `stock_valuation_layer_ids`, which requires the Stock / Administrator group)

Solves: #4242