### PR TITLE
[FIX][16.0] l10n_it_fatturapa_out: fix signle quote double escape

### DIFF
--- a/l10n_it_fatturapa_out/wizard/efattura.py
+++ b/l10n_it_fatturapa_out/wizard/efattura.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Giuseppe Borruso
 # Copyright 2020 Marco Colombo
+import html
 import logging
 import os
 from datetime import datetime
@@ -275,7 +276,7 @@ class EFatturaOut:
         content = ir_ui_view._render_template(
             "l10n_it_fatturapa_out.account_invoice_it_FatturaPA_export", template_values
         )
-
+        content = html.unescape(content)
         # 14.0 - occorre rimuovere gli spazi tra i tag
         root = etree.fromstring(content, parser=etree.XMLParser(remove_blank_text=True))
         # già che ci siamo, validiamo con l'XMLSchema dello SdI


### PR DESCRIPTION
Per la issue #4244



Per delle ragioni che non mi sono chiare al 100%, dentro la [_render()](https://github.com/odoo/odoo/blob/a04ef36576a856d95941a7665a66abf6e7237893/odoo/addons/base/models/ir_qweb.py#L556) della versione 16.0, avviene questo doppio escape


In entrata ci sono i riferimenti ai record, quindi sono corretti (come lo sono a db) ma `result` dopo la `render_template()` risulta con questo doppio escape

Nel template viene chiamata la `encode_for_export()` al quale però arriva il valore dopo un solo escape (quindi giusto) e non è lei la colpevole


Nella 14.0 la [_render()](https://github.com/odoo/odoo/blob/f2765d2cab5671a010404c36842bf1b4c4d6350b/odoo/addons/base/models/ir_qweb.py#L39) è piuttosto diversa e questo non capita

Se avete soluzioni migliori di "mettere un cerotto" come ho fatto sono tutto orecchi! 