### PR TITLE
[FIX] l10n_it_fatturapa: link fatturapa.attachments

### DIFF
--- a/l10n_it_fatturapa/README.rst
+++ b/l10n_it_fatturapa/README.rst
@@ -170,6 +170,10 @@ Contributors
 
    -  Simone Rubino <simone.rubino@aion-tech.it>
 
+-  `Stesi Consulting Srl <https://www.stesi.consulting/>`__:
+
+   -  Michele Di Croce <dicroce.m@stesi.consulting>
+
 Maintainers
 -----------
 

--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "ITA - Fattura elettronica - Base",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.1.1",
     "category": "Localization/Italy",
     "summary": "Fatture elettroniche",
     "author": "Davide Corio, Agile Business Group, Innoviu, "

--- a/l10n_it_fatturapa/migrations/16.0.1.1.1/post-migrate.py
+++ b/l10n_it_fatturapa/migrations/16.0.1.1.1/post-migrate.py
@@ -1,0 +1,10 @@
+#  Copyright 2024 Michele Di Croce - Stesi Consulting srl
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    fatturapa_attachments = env["fatturapa.attachments"].search([])
+    fatturapa_attachments._l10n_it_link_attachments()

--- a/l10n_it_fatturapa/models/__init__.py
+++ b/l10n_it_fatturapa/models/__init__.py
@@ -1,7 +1,7 @@
 # Copyright 2014 Davide Corio <davide.corio@abstract.it>
 
+from . import link_e_invoice_ir_attachment
 from . import account
 from . import company
 from . import partner
 from . import ir_attachment
-from . import link_e_invoice_ir_attachment

--- a/l10n_it_fatturapa/models/account.py
+++ b/l10n_it_fatturapa/models/account.py
@@ -217,6 +217,7 @@ class FatturaAttachments(models.Model):
     _name = "fatturapa.attachments"
     _description = "E-invoice attachments"
     _inherits = {"ir.attachment": "ir_attachment_id"}
+    _inherit = ["l10n_it_fatturapa.attachment.e_invoice.link"]
 
     ir_attachment_id = fields.Many2one(
         "ir.attachment", "Attachment", required=True, ondelete="cascade"

--- a/l10n_it_fatturapa/readme/CONTRIBUTORS.md
+++ b/l10n_it_fatturapa/readme/CONTRIBUTORS.md
@@ -19,3 +19,5 @@
   > - Giovanni Serra \<<giovanni@gslab.it>\>
 - [Aion Tech](https://aiontech.company/):
   - Simone Rubino \<<simone.rubino@aion-tech.it>\>
+- [Stesi Consulting](https://www.stesi.consulting):
+  - Michele Di Croce \<<dicroce.m@stesi.consulting>\>

--- a/l10n_it_fatturapa/static/description/index.html
+++ b/l10n_it_fatturapa/static/description/index.html
@@ -509,6 +509,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
 </ul>
 </li>
+<li><p class="first"><a class="reference external" href="https://www.stesi.consulting">Stesi Consulting</a>:</p>
+<ul class="simple">
+<li>Michele Di Croce &lt;<a class="reference external" href="mailto:dicroce.m&#64;stesi.consulting">dicroce.m&#64;stesi.consulting</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -1126,6 +1126,28 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         e_invoice = invoices.fatturapa_attachment_in_id
         self.assertTrue(e_invoice.ir_attachment_id.read())
 
+    def test_access_other_user_e_invoice_attachments(self):
+        """A user can see the e-invoice attachments created by other users."""
+        # Arrange
+        access_right_group_xmlid = "base.group_erp_manager"
+        user = self.env.user
+        user.groups_id -= self.env.ref("base.group_system")
+        user.groups_id -= self.env.ref(access_right_group_xmlid)
+        other_user = user.copy(default={"login": "attachment_user"})
+        # pre-condition
+        self.assertFalse(user.has_group(access_right_group_xmlid))
+        self.assertNotEqual(user, other_user)
+        import_action = self.run_wizard(
+            "access_other_user_e_invoice_attachments", "IT02780790107_11004.xml"
+        )
+        # Assert
+        with self.with_user(other_user.login):
+            invoices = self.env[import_action["res_model"]].search(
+                import_action["domain"]
+            )
+            e_invoice = invoices.fatturapa_doc_attachments
+            self.assertTrue(e_invoice.ir_attachment_id.read())
+
 
 class TestFatturaPAEnasarco(FatturapaCommon):
     def setUp(self):


### PR DESCRIPTION
Seguendo questa PR https://github.com/OCA/l10n-italy/pull/4107 il problema rimane sugli eventuali allegati contenuti nella fattura elettronica ( fatturapa.attachments) 
Riuso lo stesso abstract per allineare correttamente fatturapa.attachments

Risolve #4264 