### PR TITLE
[14.0][FIX/IMP]l10n_it_account & l10n_it_fatturapa_out: Nicer XML Validation errors

### DIFF
--- a/l10n_it_account/tools/account_tools.py
+++ b/l10n_it_account/tools/account_tools.py
@@ -14,6 +14,8 @@ reg_whitespace = re.compile(r"\s+")
 
 
 def encode_for_export(string_to_encode, max_chars, encoding="latin"):
+    if not string_to_encode:
+        return ""
     return (
         reg_whitespace.sub(" ", string_to_encode)
         .encode(encoding, errors="replace")

--- a/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
@@ -6,9 +6,11 @@
 
 import base64
 import re
+from unittest.mock import Mock
 
 from psycopg2 import IntegrityError
 
+import odoo
 from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
@@ -885,6 +887,56 @@ class TestFatturaPAXMLValidation(FatturaPACommon):
             invoice.name
         )
         self.assertEqual(ue.exception.args[0], error_message)
+
+    def test_partner_no_address_fail(self):
+        """
+        - create an XML invoice where the customer has no address or city
+
+        expect to fail with a proper message
+        """
+        invoice = self._create_invoice()
+        invoice.partner_id.street = False
+        invoice.partner_id.city = False
+        invoice._post()
+        wizard = self.wizard_model.create({})
+        with self.assertRaises(UserError) as ue:
+            wizard.with_context({"active_ids": [invoice.id]}).exportFatturaPA()
+        error_msg = ue.exception.args[0]
+        error_fragments = (
+            f"Error processing invoice(s) {invoice.name}",
+            "Indirizzo",
+            "Comune",
+            "Activate debug mode to see the full error",
+        )
+        for fragment in error_fragments:
+            self.assertIn(fragment, error_msg)
+
+        try:
+            # Enter debug mode and add details
+            odoo.http._request_stack.push(
+                Mock(
+                    db=self.env.cr.dbname,
+                    env=self.env,
+                    debug=True,
+                    website=False,  # compatibility with website module
+                    is_frontend=False,
+                )
+            )
+            wizard = self.wizard_model.create({})
+            with self.assertRaises(UserError) as ue:
+                wizard.with_context({"active_ids": [invoice.id]}).exportFatturaPA()
+            debug_error_msg = ue.exception.args[0]
+            debug_error_fragments = (
+                "Full error follows",
+                "Reason: value doesn't match any pattern of",
+                "p{IsBasicLatin}",
+                "<Comune xmlns:ns1",
+            )
+            for fragment in error_fragments[:-1] + debug_error_fragments:
+                self.assertIn(fragment, debug_error_msg)
+        finally:
+            # Remove from the stack to not interfere with other tests
+            odoo.http._request_stack.pop()
 
     def test_multicompany_fail(self):
         """

--- a/l10n_it_fatturapa_out/wizard/efattura.py
+++ b/l10n_it_fatturapa_out/wizard/efattura.py
@@ -261,7 +261,26 @@ class EFatturaOut:
             # i controlli precedenti dovrebbero escludere errori di sintassi XML
             # with open("/tmp/fatturaout.xml", "wb") as o:
             #    o.write(etree.tostring(root, xml_declaration=True, encoding="utf-8"))
-            raise UserError("\n".join(str(e) for e in errors))
+            # Print error paths, as they can be helpful even for non-technical people
+            error_path_string = "\n- ".join(
+                err.path[err.path.index(":") + 1 :] for err in errors
+            )
+            error_msg = _(
+                "Error processing invoice(s) %(invoices)s.\n\n"
+                "Errors in the following fields:\n- %(error_path_string)s\n\n",
+                invoices=", ".join(
+                    inv.display_name for inv in template_values["invoices"]
+                ),
+                error_path_string=error_path_string,
+            )
+            # add details in debug mode
+            if env.user.user_has_groups("base.group_no_one"):
+                error_msg += _("Full error follows:\n\n") + "\n".join(
+                    str(e) for e in errors
+                )
+            else:
+                error_msg += _("Activate debug mode to see the full error.")
+            raise UserError(error_msg)
         content = etree.tostring(root, xml_declaration=True, encoding="utf-8")
         return content
 


### PR DESCRIPTION
~~Domani apro la issue, giuro :angel:~~

Issue https://github.com/OCA/l10n-italy/issues/4270

The strategy here is
- do not fail during XML generation, even if e.g. a field is empty (`False`)
- Return a simpler error message for the user during XML validation
- Return a more detailed error message if in debug mode