### PR TITLE
[FIX]l10n_it_fatturapa_in: fix import with type minimo

### DIFF
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -320,6 +320,9 @@ class AccountMove(models.Model):
 
     def process_negative_lines(self):
         self.ensure_one()
+        if not self.invoice_line_ids:
+            return
+
         for line in self.invoice_line_ids:
             if line.price_unit >= 0:
                 return

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -440,6 +440,7 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         self.assertTrue(len(invoices) == 2)
         for invoice in invoices:
             self.assertTrue(len(invoice.invoice_line_ids) == 0)
+            self.assertTrue(invoice.move_type == "in_invoice")
         # allow following tests to reuse the same XML file
         invoices[0].ref = invoices[0].payment_reference = "14165"
         invoices[1].ref = invoices[1].payment_reference = "14166"


### PR DESCRIPTION
Added check if invoice_line_ids is valorize to check the price_unit, if is not valorize stop the method because is not possibile assume the line is negative