### PR TITLE
[14.0] [FIX] l10n_it_delivery_note,l10n_it_delivery_note_order_link: delivery note count in sale order

### DIFF
--- a/l10n_it_delivery_note/models/sale_order.py
+++ b/l10n_it_delivery_note/models/sale_order.py
@@ -9,11 +9,6 @@ from .stock_delivery_note import DOMAIN_DELIVERY_NOTE_STATES, DOMAIN_INVOICE_STA
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    delivery_note_ids = fields.Many2many(
-        "stock.delivery.note", compute="_compute_delivery_notes"
-    )
-    delivery_note_count = fields.Integer(compute="_compute_delivery_notes")
-
     default_transport_condition_id = fields.Many2one(
         "stock.picking.transport.condition",
         string="Condition of transport",
@@ -56,15 +51,6 @@ class SaleOrder(models.Model):
             }
 
         self.update(values)
-
-    def _compute_delivery_notes(self):
-        for order in self:
-            delivery_notes = order.order_line.mapped(
-                "delivery_note_line_ids.delivery_note_id"
-            )
-
-            order.delivery_note_ids = delivery_notes
-            order.delivery_note_count = len(delivery_notes)
 
     def _assign_delivery_notes_invoices(self, invoice_ids):
         order_lines = self.mapped("order_line").filtered(
@@ -125,32 +111,6 @@ class SaleOrder(models.Model):
         self._generate_delivery_note_lines(invoice_ids.ids)
 
         return invoice_ids
-
-    def goto_delivery_notes(self, **kwargs):
-        delivery_notes = self.mapped("delivery_note_ids")
-        action = self.env["ir.actions.act_window"]._for_xml_id(
-            "l10n_it_delivery_note.stock_delivery_note_action"
-        )
-        action.update(kwargs)
-
-        if len(delivery_notes) > 1:
-            action["domain"] = [("id", "in", delivery_notes.ids)]
-
-        elif len(delivery_notes) == 1:
-            action["views"] = [
-                (
-                    self.env.ref(
-                        "l10n_it_delivery_note.stock_delivery_note_form_view"
-                    ).id,
-                    "form",
-                )
-            ]
-            action["res_id"] = delivery_notes.id
-
-        else:
-            action = {"type": "ir.actions.act_window_close"}
-
-        return action
 
 
 class SaleOrderLine(models.Model):

--- a/l10n_it_delivery_note/wizard/sale_advance_payment_inv.py
+++ b/l10n_it_delivery_note/wizard/sale_advance_payment_inv.py
@@ -11,7 +11,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
     _inherit = "sale.advance.payment.inv"
 
     def _default_step(self):
-        states = self.sale_order_ids.mapped("delivery_note_ids.state")
+        states = self.sale_order_ids.mapped("picking_ids.delivery_note_id.state")
 
         if any(s == "draft" for s in states):
             return DOMAIN_WIZARD_STEPS[1]

--- a/l10n_it_delivery_note_order_link/README.rst
+++ b/l10n_it_delivery_note_order_link/README.rst
@@ -103,10 +103,19 @@ promote its widespread use.
 .. |maintainer-andreampiovesana| image:: https://github.com/andreampiovesana.png?size=40px
     :target: https://github.com/andreampiovesana
     :alt: andreampiovesana
+.. |maintainer-aleuffre| image:: https://github.com/aleuffre.png?size=40px
+    :target: https://github.com/aleuffre
+    :alt: aleuffre
+.. |maintainer-renda-dev| image:: https://github.com/renda-dev.png?size=40px
+    :target: https://github.com/renda-dev
+    :alt: renda-dev
+.. |maintainer-PicchiSeba| image:: https://github.com/PicchiSeba.png?size=40px
+    :target: https://github.com/PicchiSeba
+    :alt: PicchiSeba
 
-Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-andreampiovesana| 
+|maintainer-andreampiovesana| |maintainer-aleuffre| |maintainer-renda-dev| |maintainer-PicchiSeba| 
 
 This module is part of the `OCA/l10n-italy <https://github.com/OCA/l10n-italy/tree/14.0/l10n_it_delivery_note_order_link>`_ project on GitHub.
 

--- a/l10n_it_delivery_note_order_link/__manifest__.py
+++ b/l10n_it_delivery_note_order_link/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/OCA/l10n-italy",
     "version": "14.0.1.0.1",
     "license": "AGPL-3",
-    "maintainers": ["andreampiovesana"],
+    "maintainers": ["andreampiovesana", "aleuffre", "renda-dev", "PicchiSeba"],
     "category": "Localization/Italy",
     "depends": [
         "purchase_stock",

--- a/l10n_it_delivery_note_order_link/models/sale_order.py
+++ b/l10n_it_delivery_note_order_link/models/sale_order.py
@@ -20,3 +20,23 @@ class SaleOrder(models.Model):
 
             order.delivery_note_ids = delivery_notes
             order.delivery_note_count = len(delivery_notes)
+
+    def goto_delivery_notes(self, **kwargs):
+        delivery_notes = self.mapped("delivery_note_ids")
+
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "l10n_it_delivery_note.stock_delivery_note_action"
+        )
+        action.update(kwargs)
+        if len(delivery_notes) > 1:
+            action["domain"] = [("id", "in", delivery_notes.ids)]
+        elif len(delivery_notes) == 1:
+            action["views"] = [
+                (
+                    self.env.ref(
+                        "l10n_it_delivery_note.stock_delivery_note_form_view"
+                    ).id,
+                    "form",
+                )
+            ]
+            action["res_id"] = delivery_notes.id

--- a/l10n_it_delivery_note_order_link/models/sale_order.py
+++ b/l10n_it_delivery_note_order_link/models/sale_order.py
@@ -14,9 +14,7 @@ class SaleOrder(models.Model):
 
     def _compute_delivery_notes(self):
         for order in self:
-            delivery_notes = order.order_line.mapped(
-                "delivery_note_line_ids.delivery_note_id"
-            )
+            delivery_notes = order.picking_ids.mapped("delivery_note_id")
 
             order.delivery_note_ids = delivery_notes
             order.delivery_note_count = len(delivery_notes)
@@ -40,3 +38,5 @@ class SaleOrder(models.Model):
                 )
             ]
             action["res_id"] = delivery_notes.id
+
+        return action

--- a/l10n_it_delivery_note_order_link/static/description/index.html
+++ b/l10n_it_delivery_note_order_link/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -428,12 +428,14 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/andreampiovesana"><img alt="andreampiovesana" src="https://github.com/andreampiovesana.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/andreampiovesana"><img alt="andreampiovesana" src="https://github.com/andreampiovesana.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/aleuffre"><img alt="aleuffre" src="https://github.com/aleuffre.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/renda-dev"><img alt="renda-dev" src="https://github.com/renda-dev.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/PicchiSeba"><img alt="PicchiSeba" src="https://github.com/PicchiSeba.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/l10n-italy/tree/14.0/l10n_it_delivery_note_order_link">OCA/l10n-italy</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
Sono presenti un paio di problemi riguardo il contatore dei delivery note collegato agli ordini di vendita:
- Il campo `delivery_note_count` e `delivery_note_ids` sul `sale.order` è duplicato
  -  Rimosso le parti di codice inutilizzate dal modulo base `l10n_it_delivery_note`
- A parer mio, prendere i delivery note collegati all'ordine, dalle righe dell'ordine, è un giro inusuale che può essere confusionario e sbagliato, mentre prendere i delivery note direttamente dai picking collegati all'ordine mi sembra più diretto ed efficiente