### PR TITLE
[16.0] FIX l10n_it_withholding_tax_financial_report: TypeError: _get_data() takes 7 positional arguments but 8 were given

### DIFF
--- a/l10n_it_withholding_tax_financial_report/report/open_items.py
+++ b/l10n_it_withholding_tax_financial_report/report/open_items.py
@@ -14,23 +14,8 @@ class OpenItemsReport(models.AbstractModel):
         amount_net_pay_residual = amount_net_pay_residual
         return amount_net_pay, amount_net_pay_residual
 
-    def _get_data(
-        self,
-        account_ids,
-        partner_ids,
-        date_at_object,
-        only_posted_moves,
-        company_id,
-        date_from,
-    ):
-        res = super()._get_data(
-            account_ids,
-            partner_ids,
-            date_at_object,
-            only_posted_moves,
-            company_id,
-            date_from,
-        )
+    def _get_data(self, *args, **kwargs):
+        res = super()._get_data(*args, **kwargs)
         for move_line_vals in res[0]:
             move_line = self.env["account.move.line"].browse(move_line_vals["id"])
             if move_line.move_id.withholding_tax:


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/4285