### PR TITLE
[IMP][14.0] l10n_it_ricevute_bancarie: small QoL improvements

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account.py
+++ b/l10n_it_ricevute_bancarie/models/account.py
@@ -97,17 +97,20 @@ class AccountMove(models.Model):
 
     @api.onchange("partner_id", "invoice_payment_term_id", "move_type")
     def _onchange_riba_partner_bank_id(self):
+        allowed_banks = (
+            self.partner_id.bank_ids or self.partner_id.commercial_partner_id.bank_ids
+        )
         if (
             not self.riba_partner_bank_id
-            or self.riba_partner_bank_id not in self.partner_id.bank_ids
+            or self.riba_partner_bank_id not in allowed_banks
         ):
             bank_ids = self.env["res.partner.bank"]
             if (
                 self.partner_id
-                and self.invoice_payment_term_id.riba
+                and self.is_riba_payment
                 and self.move_type in ["out_invoice", "out_refund"]
             ):
-                bank_ids = self.partner_id.bank_ids
+                bank_ids = allowed_banks
             self.riba_partner_bank_id = bank_ids[0] if bank_ids else None
 
     def month_check(self, invoice_date_due, all_date_due):

--- a/l10n_it_ricevute_bancarie/tests/test_riba.py
+++ b/l10n_it_ricevute_bancarie/tests/test_riba.py
@@ -550,3 +550,17 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         exc_message = ue.exception.args[0]
         self.assertIn(self.env.company.name, exc_message)
         self.assertIn(self.company2_bank.acc_number, exc_message)
+
+    def test_riba_inv_no_bank(self):
+        """
+        Test that a riba invoice without a bank defined
+        cannot be confirmed (e.g. via the list view)
+        """
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        self.invoice.riba_partner_bank_id = False
+        with self.assertRaises(UserError) as err:
+            self.invoice.action_post()
+        err_msg = err.exception.args[0]
+        self.assertIn("Cannot post invoices", err_msg)
+        self.assertIn(self.invoice.partner_id.display_name, err_msg)
+        self.assertIn(str(self.invoice.amount_total), err_msg)

--- a/l10n_it_ricevute_bancarie/views/account_view.xml
+++ b/l10n_it_ricevute_bancarie/views/account_view.xml
@@ -140,11 +140,16 @@
             <xpath expr="//field[@name='invoice_payment_term_id']" position="after">
                 <field name="is_riba_payment" invisible="1" />
                 <field name="commercial_partner_id" invisible="1" />
-                 <field
-                    name="riba_partner_bank_id"
-                    attrs="{'invisible': ['|',('is_riba_payment','=', False),('move_type','!=','out_invoice')], 'required': ['&amp;',('is_riba_payment','=', True),('move_type','=', 'out_invoice')]}"
-                    domain="[('partner_id','=', commercial_partner_id)]"
-                />
+                <div
+                    attrs="{'invisible': ['|',('is_riba_payment','=', False),('move_type','!=','out_invoice')]}"
+                >
+                    <span class="oe_read_only">&amp;nbsp;- </span>
+                    <field
+                        name="riba_partner_bank_id"
+                        attrs="{'required': ['&amp;',('is_riba_payment','=', True),('move_type','=', 'out_invoice')]}"
+                        domain="[('partner_id','=', commercial_partner_id)]"
+                    />
+                </div>
                 <field
                     name="is_unsolved"
                     string="Past Due"


### PR DESCRIPTION
1. Improve readability between fields "Payment Term" and "Bank"
2. Stop invoice confirmation if bank is not set. Closes #4304 for 14.0
3. Fall back on commercial partner's bank if bank is not set for invoice's contact. Closes #4303 for 14.0