### PR TITLE
[16.0] [FIX] l10n_it_split_payment: build writeoff for sale docs only

### DIFF
--- a/l10n_it_split_payment/models/account_move_line.py
+++ b/l10n_it_split_payment/models/account_move_line.py
@@ -51,6 +51,7 @@ class AccountMoveLine(models.Model):
             if (
                 line.display_type == "tax"
                 and line.move_id.split_payment
+                and line.move_id.is_sale_document(include_receipts=True)
                 and not line.is_split_payment
                 and not any(ml.is_split_payment for ml in line.move_id.line_ids)
             ):


### PR DESCRIPTION
Otherwise, in case of customers with split payment fiscal position, in case they send us e-invoices, the system raises "Any journal item on a payable account must have a due date and vice versa"

See https://github.com/OCA/l10n-italy/issues/4330