### PR TITLE
[14.0][FIX] l10n_it_delivery_note: get right dn when creating invoice

### DIFF
--- a/l10n_it_delivery_note/models/account_invoice.py
+++ b/l10n_it_delivery_note/models/account_invoice.py
@@ -125,10 +125,7 @@ class AccountInvoice(models.Model):
             else:
                 sequence = 1
                 done_invoice_lines = self.env["account.move.line"]
-                for dn in invoice.mapped(
-                    "invoice_line_ids.sale_line_ids.delivery_note_line_ids."
-                    "delivery_note_id"
-                ).sorted(key="name"):
+                for dn in invoice.mapped("delivery_note_ids").sorted(key="name"):
                     dn_invoice_lines = invoice.invoice_line_ids.filtered(
                         lambda x: x not in done_invoice_lines
                         and dn
@@ -157,9 +154,10 @@ class AccountInvoice(models.Model):
                                 self._prepare_note_dn_value(sequence, dn),
                             )
                         )
-                    for invoice_line in dn_invoice_lines:
                         sequence += 1
+                    for invoice_line in dn_invoice_lines:
                         invoice_line.sequence = sequence
+                        sequence += 1
 
             invoice.write({"line_ids": new_lines})
 


### PR DESCRIPTION
Closes https://github.com/OCA/l10n-italy/issues/4309 for 14.0

Previously, all delivery notes related to the sale line would be considered, even if not relevant to the invoice in question.

Luckily, we already have the information on the invoice about which delivery notes are related, so we can limit our search to those.