### PR TITLE
[FIX]l10n_it_vat_statement_communication: fix name type encoding miss…

### DIFF
--- a/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
+++ b/l10n_it_vat_statement_communication/models/comunicazione_liquidazione.py
@@ -140,7 +140,7 @@ class ComunicazioneLiquidazione(models.Model):
 
         xml_string = etree.tostring(
             x1_Fornitura,
-            encoding="utf8",
+            encoding="utf-8",
             method="xml",
             pretty_print=True,
             xml_declaration=True,


### PR DESCRIPTION
sembra che avevo scordato un trattino

![image](https://github.com/user-attachments/assets/ad08974e-69ab-4e47-bdb7-db9374b7cde0)
