### PR TITLE
[FIX] l10n_it_intrastat: compute weight in case of variants

### DIFF
--- a/l10n_it_intrastat/models/account.py
+++ b/l10n_it_intrastat/models/account.py
@@ -34,7 +34,7 @@ class AccountMoveLine(models.Model):
         self._prepare_intrastat_line_amount(res)
 
         # Weight
-        weight_kg = self._prepare_intrastat_line_weight(product_template, res)
+        weight_kg = self._prepare_intrastat_line_weight(self.product_id, res)
 
         # Additional Units
         self._prepare_intrastat_line_additional_units(
@@ -218,16 +218,16 @@ class AccountMoveLine(models.Model):
                 additional_units = self.quantity
         res.update({"additional_units": additional_units})
 
-    def _prepare_intrastat_line_weight(self, product_template, res):
+    def _prepare_intrastat_line_weight(self, product, res):
         self.ensure_one()
         intrastat_uom_kg = self.move_id.company_id.intrastat_uom_kg_id
         # ...Weight compute in Kg
         # ...If Uom has the same category of kg -> Convert to Kg
         # ...Else the weight will be product weight * qty
-        product_weight = product_template.weight or 0
+        product_weight = product.weight or 0
         if (
             intrastat_uom_kg
-            and product_template.uom_id.category_id == intrastat_uom_kg.category_id
+            and product.uom_id.category_id == intrastat_uom_kg.category_id
         ):
             weight_kg = self.product_uom_id._compute_quantity(
                 qty=self.quantity, to_unit=intrastat_uom_kg


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/4060 per `16.0`.

Forward port di https://github.com/OCA/l10n-italy/pull/4061 + test.