### PR TITLE
[FIX] Righe negative, note e sezioni in fattura fornitore con inversione contabile

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -24,11 +24,7 @@ class AccountMoveLine(models.Model):
         for line in self:
             move = line.move_id
             # see invoice_line_ids field definition
-            is_invoice_line = line.display_type in (
-                "product",
-                "line_section",
-                "line_note",
-            )
+            is_invoice_line = line.display_type == "product"
             is_rc = (
                 move.is_purchase_document()
                 and move.fiscal_position_id.rc_type_id
@@ -427,7 +423,8 @@ class AccountMove(models.Model):
                 )
                 if line_tax_ids and mapped_taxes:
                     rc_invoice_line["tax_ids"] = [(6, False, mapped_taxes.ids)]
-                rc_invoice_line["account_id"] = rc_type.transitory_account_id.id
+                if line.account_id:
+                    rc_invoice_line["account_id"] = rc_type.transitory_account_id.id
                 rc_invoice_lines.append([0, False, rc_invoice_line])
         if rc_invoice_lines:
             inv_vals = self.rc_inv_vals(
@@ -497,7 +494,8 @@ class AccountMove(models.Model):
                 line_vals["tax_ids"] = [
                     (6, False, mapped_taxes.ids),
                 ]
-            line_vals["account_id"] = rc_type.transitory_account_id.id
+            if inv_line.account_id:
+                line_vals["account_id"] = rc_type.transitory_account_id.id
             invoice_line_vals.append((0, 0, line_vals))
         supplier_invoice.write({"invoice_line_ids": invoice_line_vals})
         self.rc_self_purchase_invoice_id = supplier_invoice.id

--- a/l10n_it_reverse_charge/tests/test_rc.py
+++ b/l10n_it_reverse_charge/tests/test_rc.py
@@ -236,3 +236,38 @@ class TestReverseCharge(ReverseChargeCommon):
 
         # Assert
         self.assertEqual(invoice.state, "posted")
+
+    def test_description_lines(self):
+        """A Reverse Charge Bill can be confirmed
+        when contains notes and sections."""
+        # Arrange: Create a Reverse Charge Bill with notes and sections
+        bill = self.create_invoice(
+            self.supplier_extraEU,
+            amounts=[100],
+            taxes=self.tax_0_pur,
+            post=False,
+        )
+        bill.invoice_line_ids = [
+            (
+                0,
+                0,
+                {
+                    "display_type": "line_note",
+                    "name": "Test note",
+                },
+            ),
+            (
+                0,
+                0,
+                {
+                    "display_type": "line_section",
+                    "name": "Test section",
+                },
+            ),
+        ]
+
+        # Act
+        bill.action_post()
+
+        # Assert
+        self.assertEqual(bill.state, "posted")

--- a/l10n_it_reverse_charge/tests/test_rc.py
+++ b/l10n_it_reverse_charge/tests/test_rc.py
@@ -271,3 +271,16 @@ class TestReverseCharge(ReverseChargeCommon):
 
         # Assert
         self.assertEqual(bill.state, "posted")
+
+    def test_negative_lines(self):
+        """A Reverse Charge Bill can be confirmed
+        when contains negative lines."""
+        # Arrange: Create a Reverse Charge Bill with negative lines
+        bill = self.create_invoice(
+            self.supplier_extraEU,
+            amounts=[100, -10],
+            taxes=self.tax_0_pur,
+        )
+
+        # Assert
+        self.assertEqual(bill.state, "posted")


### PR DESCRIPTION
Corregge https://github.com/OCA/l10n-italy/issues/3503 per `16.0`.

https://github.com/OCA/l10n-italy/issues/3504 non si verifica in `16.0` quindi porto solo il test.

Forward port di https://github.com/OCA/l10n-italy/pull/3505.