### PR TITLE
[FIX] XML di pagamento rifiutato: Valore SEPA non è un codice valido per Category Purpose

### DIFF
--- a/l10n_it_sct_cbi/models/account_payment_order.py
+++ b/l10n_it_sct_cbi/models/account_payment_order.py
@@ -349,7 +349,7 @@ class AccountPaymentOrder(models.Model):
         payment_identification_CtgyPurp_Cd = etree.SubElement(
             payment_identification_CtgyPurp, "Cd"
         )
-        payment_identification_CtgyPurp_Cd.text = "SEPA"
+        payment_identification_CtgyPurp_Cd.text = "SUPP"
         instruction_identification = etree.SubElement(payment_identification, "InstrId")
         instruction_identification.text = self._prepare_field(
             "Instruction Identification",


### PR DESCRIPTION
**Passi**:

1. Installare e configurare `l10n_it_sct_cbi`
2. Inviare un XML di pagamento alla banca

**Attuale**:
Il file viene rifiutato:
![image](https://github.com/user-attachments/assets/f08b5c3f-481c-4dc4-9ae7-216558a3a317)

**Atteso**:
Il file viene accettato

**Altre info**:
Nella documentazione[^1] è scritto:
> Il campo Code del campo Category Purpose (\<CtgyPurp>) deve assumere uno dei valori presenti nella lista esterna disponibile all'indirizzo ﻿[﻿http://www.iso20022.org/external_code_list.page﻿](http://www.iso20022.org/external_code_list.page)﻿. (“NARR”, “Category Purpose non valida”)

Dalla pagina linkata è possibile scaricare la lista dei codici accettati, tra questi c'è SUPP che viene descritto come:
> Transaction is related to a payment to a supplier.

che direi essere abbastanza generico, quindi uso questo invece di SEPA per correggere.

La prima scelta sarebbe stata rimuovere il nodo `CtgyPurp` perché da schema è opzionale: https://github.com/OCA/l10n-italy/blob/f22405a446ead2ec0e4510e7ba237dcb73b5e8ff/l10n_it_sct_cbi/data/standards/CBIPaymentRequest.00.04.01.xsd#L374
però sempre nella documentazione[^1] è indicato come obbligatorio quando si fanno pagamenti verso IBAN italiani:
> Il blocco Category Purpose <CtgyPurp> deve essere obbligatoriamente presente in caso di IBAN del Creditor Account <CdtrAcct> radicato su IT (primi due chrt IBAN = IT) (“NARR”, “Category Purpose non presente”)

[^1]: https://www.cbi-org.eu/My-Menu/Servizio-CBI-Documentazione/Servizio-CBI-Documentazione-Standard, il link è già nel README