### PR TITLE
[14.0] [FIX] l10n_it_reverse_charge setting original invoice date in supplier self invoice

### DIFF
--- a/l10n_it_reverse_charge/models/account_move.py
+++ b/l10n_it_reverse_charge/models/account_move.py
@@ -441,7 +441,7 @@ class AccountMove(models.Model):
         supplier_invoice_vals["partner_bank_id"] = None
         # because this field has copy=False
         supplier_invoice_vals["date"] = self.date
-        supplier_invoice_vals["invoice_date"] = self.date
+        supplier_invoice_vals["invoice_date"] = self.invoice_date
         supplier_invoice_vals["invoice_origin"] = self.ref or self.name
         supplier_invoice_vals["partner_id"] = rc_type.partner_id.id
         supplier_invoice_vals["journal_id"] = rc_type.supplier_journal_id.id


### PR DESCRIPTION


This way, VAT registry of supplier self invoices will contain the correct value for DATA FATT.

From https://github.com/OCA/l10n-italy/pull/4329