### PR TITLE
[16.0][FIX] p7m file encoded twice

### DIFF
--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "ITA - Fattura elettronica - Base",
-    "version": "16.0.1.3.0",
+    "version": "16.0.1.3.1",
     "category": "Localization/Italy",
     "summary": "Fatture elettroniche",
     "author": "Davide Corio, Agile Business Group, Innoviu, "

--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "ITA - Fattura elettronica - Base",
-    "version": "16.0.1.3.1",
+    "version": "16.0.1.3.0",
     "category": "Localization/Italy",
     "summary": "Fatture elettroniche",
     "author": "Davide Corio, Agile Business Group, Innoviu, "

--- a/l10n_it_fatturapa/models/ir_attachment.py
+++ b/l10n_it_fatturapa/models/ir_attachment.py
@@ -117,7 +117,7 @@ class FatturaPAAttachment(models.Model):
         except binascii.Error as e:
             raise UserError(_("Corrupted attachment %s.") % e.args) from e
 
-        if is_base64(data):
+        while is_base64(data):
             try:
                 data = base64.b64decode(data)
             except binascii.Error as e:


### PR DESCRIPTION
Sometimes suppliers encode the file twice. The first step to decode the file is not enough. Change the behaviour to be able to decode the file until it not coded in b64