### PR TITLE
[16.0][FIX]l10n_it_intrastat_statement: adapt report format to correct version

### DIFF
--- a/l10n_it_intrastat_statement/report/reports.xml
+++ b/l10n_it_intrastat_statement/report/reports.xml
@@ -111,16 +111,19 @@
     </record>
 
     <!-- Mod. Intra-1 quater -->
-    <report
-        string="INTRA-1 Quater Model"
-        id="print_intrastat_mod1_quater"
-        model="account.intrastat.statement"
-        report_type="qweb-pdf"
-        name="l10n_it_intrastat_statement.report_intrastat_mod1_quater"
-        file="l10n_it_intrastat_statement.report_intrastat_mod1_quater"
-    />
 
     <record id="print_intrastat_mod1_quater" model="ir.actions.report">
+        <field name="name">INTRA-1 Quater Model</field>
+        <field name="model">account.intrastat.statement</field>
+        <field name="report_type">qweb-pdf</field>
+        <field
+            name="report_name"
+        >l10n_it_intrastat_statement.report_intrastat_mod1_quater</field>
+        <field
+            name="report_file"
+        >l10n_it_intrastat_statement.report_intrastat_mod1_quater</field>
+        <field name="binding_model_id" ref="model_account_intrastat_statement" />
+        <field name="binding_type">report</field>
         <field
             name="paperformat_id"
             ref="l10n_it_intrastat_statement.no_header_format_a4_landscape"
@@ -128,16 +131,19 @@
     </record>
 
     <!-- Mod. Intra-1 quinquies -->
-    <report
-        string="INTRA-1 Quinquies Model"
-        id="print_intrastat_mod1_quinquies"
-        model="account.intrastat.statement"
-        report_type="qweb-pdf"
-        name="l10n_it_intrastat_statement.report_intrastat_mod1_quinquies"
-        file="l10n_it_intrastat_statement.report_intrastat_mod1_quinquies"
-    />
 
     <record id="print_intrastat_mod1_quinquies" model="ir.actions.report">
+        <field name="name">INTRA-1 Quinquies Model</field>
+        <field name="model">account.intrastat.statement</field>
+        <field name="report_type">qweb-pdf</field>
+        <field
+            name="report_name"
+        >l10n_it_intrastat_statement.report_intrastat_mod1_quinquies</field>
+        <field
+            name="report_file"
+        >l10n_it_intrastat_statement.report_intrastat_mod1_quinquies</field>
+        <field name="binding_model_id" ref="model_account_intrastat_statement" />
+        <field name="binding_type">report</field>
         <field
             name="paperformat_id"
             ref="l10n_it_intrastat_statement.no_header_format_a4_landscape"
@@ -145,16 +151,18 @@
     </record>
 
     <!-- Mod. Intra-2 quater -->
-    <report
-        string="INTRA-2 Quater Model"
-        id="print_intrastat_mod2_quater"
-        model="account.intrastat.statement"
-        report_type="qweb-pdf"
-        name="l10n_it_intrastat_statement.report_intrastat_mod2_quater"
-        file="l10n_it_intrastat_statement.report_intrastat_mod2_quater"
-    />
-
     <record id="print_intrastat_mod2_quater" model="ir.actions.report">
+        <field name="name">INTRA-2 Quater Model</field>
+        <field name="model">account.intrastat.statement</field>
+        <field name="report_type">qweb-pdf</field>
+        <field
+            name="report_name"
+        >l10n_it_intrastat_statement.report_intrastat_mod2_quater</field>
+        <field
+            name="report_file"
+        >l10n_it_intrastat_statement.report_intrastat_mod2_quater</field>
+        <field name="binding_model_id" ref="model_account_intrastat_statement" />
+        <field name="binding_type">report</field>
         <field
             name="paperformat_id"
             ref="l10n_it_intrastat_statement.no_header_format_a4_landscape"
@@ -162,16 +170,18 @@
     </record>
 
     <!-- Mod. Intra-2 quinquies -->
-    <report
-        string="INTRA-2 Quinquies Model"
-        id="print_intrastat_mod2_quinquies"
-        model="account.intrastat.statement"
-        report_type="qweb-pdf"
-        name="l10n_it_intrastat_statement.report_intrastat_mod2_quinquies"
-        file="l10n_it_intrastat_statement.report_intrastat_mod2_quinquies"
-    />
-
     <record id="print_intrastat_mod2_quinquies" model="ir.actions.report">
+        <field name="name">INTRA-2 Quinquies Model</field>
+        <field name="model">account.intrastat.statement</field>
+        <field name="report_type">qweb-pdf</field>
+        <field
+            name="report_name"
+        >l10n_it_intrastat_statement.report_intrastat_mod2_quinquies</field>
+        <field
+            name="report_file"
+        >l10n_it_intrastat_statement.report_intrastat_mod2_quinquies</field>
+        <field name="binding_model_id" ref="model_account_intrastat_statement" />
+        <field name="binding_type">report</field>
         <field
             name="paperformat_id"
             ref="l10n_it_intrastat_statement.no_header_format_a4_landscape"


### PR DESCRIPTION
Corretto il formato di diversi report per rimuovere warning del tipo

```
warnings.warn(f"The <report> tag is deprecated, use a <record> tag for {xml_id!r}.", DeprecationWarning)
```