### PR TITLE
FIX l10n_it_account avoiding check_balance_sign_coherence for non IT countries

### DIFF
--- a/l10n_it_account/models/account_group.py
+++ b/l10n_it_account/models/account_group.py
@@ -28,6 +28,10 @@ class AccountGroup(models.Model):
         """
         if self.env.context.get("skip_check_balance_sign_coherence"):
             return
+        if self.company_id.country_id != self.env.ref("base.it"):
+            # skip check for other countries
+            # as other CoA do not follow this requirement
+            return
         done_group_ids, progenitor_ids = [], []
         for group in self:
             if group.id in done_group_ids:

--- a/l10n_it_account/tests/test_l10n_it_account.py
+++ b/l10n_it_account/tests/test_l10n_it_account.py
@@ -20,6 +20,7 @@ class TestAccount(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):
         super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.env.company.country_id = cls.env.ref("base.it").id
         cls.group_1 = cls.env["account.group"].create(
             {
                 "name": "1",


### PR DESCRIPTION

Otherwise, installing for instance French chart of account you would get something like "Incoherent balance signs for '42  Personnel et comptes rattachés' and its subgroups."