### PR TITLE
[16.0] FIX l10n_it_fatturapa_in when getting tax from product

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -623,7 +623,10 @@ class WizardImportFatturapa(models.TransientModel):
         elif len(account.tax_ids) == 1:
             new_tax = account.tax_ids[0]
         line_tax = self.env["account.tax"]
-        if line_vals.get("tax_ids") and line_vals["tax_ids"][0] == fields.Command.SET:
+        if (
+            line_vals.get("tax_ids")
+            and line_vals["tax_ids"][0][0] == fields.Command.SET
+        ):
             line_tax_id = line_vals["tax_ids"][0][2][0]
             line_tax = self.env["account.tax"].browse(line_tax_id)
         if new_tax and line_tax and new_tax != line_tax:


### PR DESCRIPTION
Steps:

 - Configure a supplier product "telefonia" with "IVA al 22% detraibile al 50%"
 - Configure a supplier setting "telefonia" in  "Prodotto predefinito per e-fattura"
 - Import XML invoice from that supplier

Observed:

Standard tx is used

Desired:

"IVA al 22% detraibile al 50%" is used