### PR TITLE
[14.0][IMP] l10n_it_fatturapa_out: use parent codice_destinatario if not set in partner

### DIFF
--- a/l10n_it_fatturapa/README.rst
+++ b/l10n_it_fatturapa/README.rst
@@ -164,6 +164,7 @@ Contributors
 * `Ooops <https://www.ooops404.com>`_:
 
    * Giovanni Serra <giovanni@gslab.it>
+   * Eduard Brahas <eduard@ooops404.com>
 
 * `Aion Tech <https://aiontech.company/>`_:
 

--- a/l10n_it_fatturapa/__manifest__.py
+++ b/l10n_it_fatturapa/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "ITA - Fattura elettronica - Base",
-    "version": "14.0.2.3.2",
+    "version": "14.0.2.4.2",
     "category": "Localization/Italy",
     "summary": "Fatture elettroniche",
     "author": "Davide Corio, Agile Business Group, Innoviu, "

--- a/l10n_it_fatturapa/models/partner.py
+++ b/l10n_it_fatturapa/models/partner.py
@@ -29,11 +29,21 @@ class ResPartner(models.Model):
     # 1.1.4
     codice_destinatario = fields.Char(
         "Addressee Code",
+        compute="_compute_codice_destinatario",
+        inverse="_inverse_codice_destinatario",
+        store=True,
         help="The code, 7 characters long, assigned by ES to subjects with an "
         "accredited channel; if the addressee didn't accredit a channel "
         "to ES and invoices are received by PEC, the field must be "
         "the standard value ('%s')." % STANDARD_ADDRESSEE_CODE,
         default=STANDARD_ADDRESSEE_CODE,
+    )
+    l10n_it_use_parent_codice_destinatario = fields.Boolean(
+        string="Use addressee code for child contacts",
+        store=True,
+        default=False,
+        help="Instead of using the deafult 0000000 code"
+        " uses for the childs the one set in the parent",
     )
     # 1.1.6
     pec_destinatario = fields.Char(
@@ -54,7 +64,7 @@ class ResPartner(models.Model):
     )
 
     electronic_invoice_use_this_address = fields.Boolean(
-        "Use this e-invoicing data when invoicing to this address",
+        "Use different e-invoicing data when invoicing to this address",
         help="Set this when the main company has got several Addressee Codes or PEC",
     )
 
@@ -168,12 +178,59 @@ class ResPartner(models.Model):
                         % partner.name
                     )
 
-    @api.onchange("country_id")
-    def onchange_country_id_e_inv(self):
-        if self.country_id.code == "IT":
-            self.codice_destinatario = STANDARD_ADDRESSEE_CODE
-        else:
-            self.codice_destinatario = "XXXXXXX"
+    @api.depends(
+        "country_id",
+        "parent_id",
+        "is_company",
+        "electronic_invoice_subjected",
+        "electronic_invoice_obliged_subject",
+    )
+    def _compute_codice_destinatario(self):
+        for partner in self:
+            codice_destinatario = None
+            if (
+                not partner.is_company
+                and not partner.electronic_invoice_use_this_address
+                and partner.parent_id.l10n_it_use_parent_codice_destinatario
+            ):
+                codice_destinatario = self._recursive_parent_codice_destinatario(
+                    partner.parent_id
+                )
+            if codice_destinatario is None:
+                if partner.country_id.code == "IT":
+                    codice_destinatario = STANDARD_ADDRESSEE_CODE
+                else:
+                    codice_destinatario = "XXXXXXX"
+
+            partner.codice_destinatario = codice_destinatario
+
+    def _inverse_codice_destinatario(self):
+        """
+        Inverse method to propagate changes in codice_destinatario to child records.
+        """
+        for record in self:
+            # Find child records that inherit codice_destinatario from this parent
+            child_records = self.search(
+                [
+                    ("parent_id", "=", record.id),
+                    ("l10n_it_use_parent_codice_destinatario", "=", False),
+                ]
+            )
+            # Update the codice_destinatario of each child record to match the parent
+            for child in child_records:
+                child.codice_destinatario = record.codice_destinatario
+
+    def _recursive_parent_codice_destinatario(self, parent):
+        """
+        Recursively finds the codice_destinatario from the first ancestor
+        that has set the flag l10n_it_use_parent_codice_destinatario.
+        Returns None if no codice_destinatario is found.
+        """
+        if parent.l10n_it_use_parent_codice_destinatario:
+            return parent.codice_destinatario
+        elif parent.parent_id:
+            return self._recursive_parent_codice_destinatario(parent.parent_id)
+        return None
 
     @api.onchange("electronic_invoice_subjected")
     def onchange_electronic_invoice_subjected(self):
@@ -181,12 +238,12 @@ class ResPartner(models.Model):
             self.electronic_invoice_obliged_subject = False
         else:
             if self.supplier_rank > 0:
-                self.onchange_country_id_e_inv()
+                self._compute_codice_destinatario()
                 self.electronic_invoice_obliged_subject = True
 
     @api.onchange("electronic_invoice_obliged_subject")
     def onchange_e_inv_obliged_subject(self):
         if not self.electronic_invoice_obliged_subject:
-            self.onchange_country_id_e_inv()
+            self._compute_codice_destinatario()
             self.pec_destinatario = ""
             self.eori_code = ""

--- a/l10n_it_fatturapa/readme/CONTRIBUTORS.rst
+++ b/l10n_it_fatturapa/readme/CONTRIBUTORS.rst
@@ -9,6 +9,7 @@
 * `Ooops <https://www.ooops404.com>`_:
 
    * Giovanni Serra <giovanni@gslab.it>
+   * Eduard Brahas <eduard@ooops404.com>
 
 * `Aion Tech <https://aiontech.company/>`_:
 

--- a/l10n_it_fatturapa/static/description/index.html
+++ b/l10n_it_fatturapa/static/description/index.html
@@ -501,6 +501,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <blockquote>
 <ul class="simple">
 <li>Giovanni Serra &lt;<a class="reference external" href="mailto:giovanni&#64;gslab.it">giovanni&#64;gslab.it</a>&gt;</li>
+<li>Eduard Brahas &lt;<a class="reference external" href="mailto:eduard&#64;ooops404.com">eduard&#64;ooops404.com</a>&gt;</li>
 </ul>
 </blockquote>
 </li>

--- a/l10n_it_fatturapa/views/partner_view.xml
+++ b/l10n_it_fatturapa/views/partner_view.xml
@@ -33,8 +33,14 @@
                                 attrs="{'invisible': [('is_pa','=', False)]}"
                             />
                         <field
+                                name="l10n_it_use_parent_codice_destinatario"
+                                attrs="{'invisible': [('is_company', '=', False)]}"
+                            />
+                        <field
                                 name="codice_destinatario"
-                                attrs="{'invisible': [('is_pa', '=', True)]}"
+                                attrs="{'invisible': [('is_pa', '=', True)],
+                                        'readonly': [('l10n_it_use_parent_codice_destinatario', '=', False), ('is_company', '=', False)]
+                                        }"
                             />
                         <field
                                 name="pec_destinatario"

--- a/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
@@ -518,7 +518,7 @@ class TestFatturaPAXMLValidation(FatturaPACommon):
         partner.country_id = self.env.ref("base.si").id
         partner.vat = "SI12345679"
         partner.fiscalcode = False
-        partner.onchange_country_id_e_inv()
+        partner._compute_codice_destinatario()
         partner.write(partner._convert_to_write(partner._cache))
         self.assertEqual(partner.codice_destinatario, "XXXXXXX")
         invoice = self.invoice_model.create(


### PR DESCRIPTION
Se il campo `use_parent_codice_destinatario` è abilitato ogni child userà il suo codice_destinatario del proprio parent. Tiene conto del campo `electronic_invoice_use_this_address`.