### PR TITLE
[FIX] Precisione decimale non usata durante l'importazione della fattura elettronica

### DIFF
--- a/l10n_it_fatturapa_in/__init__.py
+++ b/l10n_it_fatturapa_in/__init__.py
@@ -1,2 +1,3 @@
+from . import fields
 from . import models
 from . import wizard

--- a/l10n_it_fatturapa_in/fields.py
+++ b/l10n_it_fatturapa_in/fields.py
@@ -1,0 +1,47 @@
+#  Copyright 2024 Simone Rubino - Aion Tech
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.fields import Float
+
+orig_convert_to_cache = Float.convert_to_cache
+orig_get_digits = Float.get_digits
+
+E_INVOICE_PRECISION_TO_FIELD = {
+    "Discount": "discount_decimal_digits",
+    "Product Price": "price_decimal_digits",
+    "Product Unit of Measure": "quantity_decimal_digits",
+}
+# Map a `decimal.precision` to the name of the field in `fatturapa.attachment`
+# that stores the value used during import
+
+
+def get_digits(self, env):
+    digits = orig_get_digits(self, env)
+    if e_invoice_precision := env.context.get("l10n_it_fatturapa_in_precision"):
+        digits = digits[0], e_invoice_precision
+    return digits
+
+
+def convert_to_cache(self, value, record, validate=True):
+    if record._name in ("account.move", "account.move.line"):
+        e_invoice = record.fatturapa_attachment_in_id
+        if e_invoice:
+            # The invoice [line] has been created by importing an e-invoice.
+            # If a different precision has been used,
+            # keep using that precision to read values that have it.
+            field_precision = self._digits
+            if isinstance(field_precision, str):
+                e_invoice_precision_field = E_INVOICE_PRECISION_TO_FIELD.get(
+                    field_precision
+                )
+                if e_invoice_precision_field:
+                    if e_invoice_precision := e_invoice[e_invoice_precision_field]:
+                        record = record.with_context(
+                            l10n_it_fatturapa_in_precision=e_invoice_precision
+                        )
+
+    return orig_convert_to_cache(self, value, record, validate=validate)
+
+
+Float.convert_to_cache = convert_to_cache
+Float.get_digits = get_digits

--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -77,6 +77,24 @@ class FatturaPAAttachmentIn(models.Model):
         compute="_compute_linked_invoice_id_xml",
         store=True,
     )
+    price_decimal_digits = fields.Integer(
+        string="Prices decimal digits",
+        help="Value used during import of this e-invoice "
+        'to override "Product Price" precision.',
+        readonly=True,
+    )
+    quantity_decimal_digits = fields.Integer(
+        string="Quantities decimal digits",
+        help="Value used during import of this e-invoice "
+        'to override "Product Unit of Measure" precision.',
+        readonly=True,
+    )
+    discount_decimal_digits = fields.Integer(
+        string="Discounts decimal digits",
+        help="Value used during import of this e-invoice "
+        'to override "Discount" precision.',
+        readonly=True,
+    )
 
     _sql_constraints = [
         (

--- a/l10n_it_fatturapa_in/tests/data/IT01234567890_FPR16.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT01234567890_FPR16.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<q1:FatturaElettronica xmlns:q1="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" versione="FPR12">
+   <FatturaElettronicaHeader>
+      <DatiTrasmissione>
+         <IdTrasmittente>
+            <IdPaese>IT</IdPaese>
+            <IdCodice>02780790107</IdCodice>
+         </IdTrasmittente>
+         <ProgressivoInvio>FPR14</ProgressivoInvio>
+         <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+         <CodiceDestinatario>0000000</CodiceDestinatario>
+         <ContattiTrasmittente>
+            <Telefono>06543534343</Telefono>
+            <Email>info@yourcompany.example.com</Email>
+         </ContattiTrasmittente>
+         <PECDestinatario>test@pec.it</PECDestinatario>
+      </DatiTrasmissione>
+      <CedentePrestatore>
+         <DatiAnagrafici>
+            <IdFiscaleIVA>
+               <IdPaese>IT</IdPaese>
+               <IdCodice>02780790107</IdCodice>
+            </IdFiscaleIVA>
+            <Anagrafica>
+               <Denominazione>YourCompany</Denominazione>
+            </Anagrafica>
+            <RegimeFiscale>RF01</RegimeFiscale>
+         </DatiAnagrafici>
+         <Sede>
+            <Indirizzo>Via Milano, 1</Indirizzo>
+            <CAP>00100</CAP>
+            <Comune>Roma</Comune>
+            <Provincia>AK</Provincia>
+            <Nazione>IT</Nazione>
+         </Sede>
+         <Contatti>
+            <Telefono>06543534343</Telefono>
+            <Email>info@yourcompany.example.com</Email>
+         </Contatti>
+      </CedentePrestatore>
+      <CessionarioCommittente>
+         <DatiAnagrafici>
+            <IdFiscaleIVA>
+               <IdPaese>IT</IdPaese>
+               <IdCodice>07973780013</IdCodice>
+            </IdFiscaleIVA>
+            <CodiceFiscale>07973780013</CodiceFiscale>
+            <Anagrafica>
+               <Denominazione>B2B Customer</Denominazione>
+            </Anagrafica>
+         </DatiAnagrafici>
+         <Sede>
+            <Indirizzo>Via Roma, 1</Indirizzo>
+            <CAP>16100</CAP>
+            <Comune>Genova</Comune>
+            <Provincia>AK</Provincia>
+            <Nazione>IT</Nazione>
+         </Sede>
+      </CessionarioCommittente>
+   </FatturaElettronicaHeader>
+   <FatturaElettronicaBody>
+      <DatiGenerali>
+         <DatiGeneraliDocumento>
+            <TipoDocumento>TD01</TipoDocumento>
+            <Divisa>EUR</Divisa>
+            <Data>2020-09-30</Data>
+            <Numero>14481</Numero>
+            <ImportoTotaleDocumento>81.49</ImportoTotaleDocumento>
+         </DatiGeneraliDocumento>
+      </DatiGenerali>
+      <DatiBeniServizi>
+         <DettaglioLinee>
+            <NumeroLinea>1</NumeroLinea>
+            <Descrizione>Test precisione decimale</Descrizione>
+            <Quantita>69.00</Quantita>
+            <PrezzoUnitario>0.968</PrezzoUnitario>
+            <PrezzoTotale>66.792</PrezzoTotale>
+            <AliquotaIVA>22.00</AliquotaIVA>
+         </DettaglioLinee>
+         <DatiRiepilogo>
+            <AliquotaIVA>22.00</AliquotaIVA>
+            <ImponibileImporto>66.79</ImponibileImporto>
+            <Imposta>14.69</Imposta>
+         </DatiRiepilogo>
+      </DatiBeniServizi>
+   </FatturaElettronicaBody>
+</q1:FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/fatturapa_common.py
+++ b/l10n_it_fatturapa_in/tests/fatturapa_common.py
@@ -288,6 +288,8 @@ class FatturapaCommon(SingleTransactionCase):
     ):
         if module_name is None:
             module_name = "l10n_it_fatturapa_in"
+        if wiz_values is None:
+            wiz_values = dict()
         attach = self.create_attachment(name, file_name, module_name=module_name)
         attach.e_invoice_received_date = fields.Datetime.now()
         attach_id = attach.id
@@ -297,6 +299,8 @@ class FatturapaCommon(SingleTransactionCase):
                     active_ids=[attach_id], active_model="fatturapa.attachment.in"
                 )
             )
+            for wiz_field, wiz_value in wiz_values.items():
+                setattr(wizard_form, wiz_field, wiz_value)
             wizard = wizard_form.save()
             return wizard.importFatturaPA()
         if mode == "link":

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -6,7 +6,7 @@ import logging
 import re
 from datetime import datetime
 
-from odoo import api, fields, models, registry
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 from odoo.fields import first
 from odoo.osv import expression
@@ -1792,28 +1792,14 @@ class WizardImportFatturapa(models.TransientModel):
         )
         different_precisions = original_precision = None
         if precision:
-            precision_id = precision.id
             original_precision = precision.digits
             different_precisions = self[field_name] != original_precision
             if different_precisions:
-                with registry(self.env.cr.dbname).cursor() as new_cr:
-                    # We need a new env (and cursor) because 'digits' property of Float
-                    # fields is retrieved with a new LazyCursor,
-                    # see class Float at odoo.fields,
-                    # so we need to write (commit) to DB in order to make the new
-                    # precision available
-                    new_env = api.Environment(new_cr, self.env.uid, self.env.context)
-                    new_precision = new_env["decimal.precision"].browse(precision_id)
-                    new_precision.sudo().write({"digits": self[field_name]})
-                    new_cr.commit()
+                precision.sudo().digits = self[field_name]
         return precision, different_precisions, original_precision
 
     def _restore_original_precision(self, precision, original_precision):
-        with registry(self.env.cr.dbname).cursor() as new_cr:
-            new_env = api.Environment(new_cr, self.env.uid, self.env.context)
-            new_price_precision = new_env["decimal.precision"].browse(precision.id)
-            new_price_precision.sudo().write({"digits": original_precision})
-            new_cr.commit()
+        precision.sudo().digits = original_precision
 
     def _get_invoice_partner_id(self, fatt):
         cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore

--- a/l10n_it_fatturapa_pec/models/mail_thread.py
+++ b/l10n_it_fatturapa_pec/models/mail_thread.py
@@ -45,6 +45,7 @@ class MailThread(models.AbstractModel):
         del message_dict["bounced_partner"]
         del message_dict["bounced_msg_id"]
         del message_dict["bounced_message"]
+        del message_dict["x_odoo_message_id"]
 
     @api.model
     def message_route(


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/4445 per `16.0`.

Sostituisce https://github.com/OCA/l10n-italy/pull/3843 per risolvere https://github.com/OCA/l10n-italy/pull/3843#pullrequestreview-1911224225.
Non ho incluso un test perché il codice che imposta la precisione decimale quando eseguito nei test solleva l'errore:
<details><summary>Stack</summary>
<pre>
  File "/path/to/l10n-italy/l10n_it_fatturapa_in/tests/fatturapa_common.py", line 305, in run_wizard
    return wizard.importFatturaPA()
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/l10n-italy/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 1830, in importFatturaPA
    ) = self._set_decimal_precision("Product Price", "price_decimal_digits")
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/l10n-italy/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py", line 1808, in _set_decimal_precision
    new_cr.commit()
  File "/path/to/odoo/odoo/sql_db.py", line 461, in commit
    self.flush()
  File "/path/to/odoo/odoo/sql_db.py", line 134, in flush
    self.transaction.flush()
  File "/path/to/odoo/odoo/api.py", line 883, in flush
    env_to_flush.flush_all()
  File "/path/to/odoo/odoo/api.py", line 747, in flush_all
    self[model_name].flush_model()
  File "/path/to/odoo/odoo/models.py", line 5630, in flush_model
    self._flush(fnames)
  File "/path/to/odoo/odoo/models.py", line 5731, in _flush
    model.browse(ids)._write(vals)
  File "/path/to/odoo/odoo/models.py", line 3882, in _write
    cr.execute(query, params + [sub_ids])
  File "/path/to/odoo/odoo/sql_db.py", line 321, in execute
    res = self._obj.execute(query, params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.ForeignKeyViolation: insert or update on table "decimal_precision" violates foreign key constraint "decimal_precision_write_uid_fkey"
DETAIL:  Key (write_uid)=(80) is not present in table "res_users".</pre>
</details> 

----

Ho aggiunto un commit per correggere l'errore nei test https://github.com/OCA/l10n-italy/actions/runs/12313495777/job/34367636978#step:8:1717:
<details><summary>Stack</summary>
<pre>
2024-12-13 10:22:13,191 528 ERROR odoo odoo.addons.l10n_it_fatturapa_pec.tests.test_e_invoice_response: ERROR: TestEInvoiceResponse.test_process_response_RC
Traceback (most recent call last):
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_pec/tests/test_e_invoice_response.py", line 41, in test_process_response_RC
    ).message_process(False, incoming_mail)
  File "/opt/odoo/addons/mail/models/mail_thread.py", line 1298, in message_process
    routes = self.message_route(message, msg_dict, model, thread_id, custom_values)
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_pec/models/mail_thread.py", line 77, in message_route
    return self.manage_pec_sdi_notification(message, message_dict)
  File "/__w/l10n-italy/l10n-italy/l10n_it_fatturapa_pec/models/mail_thread.py", line 138, in manage_pec_sdi_notification
    ).create(message_dict)
  File "<decorator-gen-148>", line 2, in create
  File "/opt/odoo/odoo/api.py", line 414, in _model_create_multi
    return create(self, [arg])
  File "/opt/odoo/addons/mail/models/mail_message.py", line 606, in create
    messages = super(Message, self).create(values_list)
  File "<decorator-gen-68>", line 2, in create
  File "/opt/odoo/odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/odoo/addons/base/models/ir_fields.py", line 670, in create
    recs = super().create(vals_list)
  File "<decorator-gen-15>", line 2, in create
  File "/opt/odoo/odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/odoo/models.py", line 3958, in create
    raise ValueError("Invalid field %r on model %r" % (key, self._name))
ValueError: Invalid field 'x_odoo_message_id' on model 'mail.message'</pre>
</details> 

Dovuto al commit https://github.com/odoo/odoo/commit/43041dfd66e984978ad743c4f720e580f82bd1aa che è solo in `16.0`.