### PR TITLE
[FIX] [l10n_it_intrastat_statement] Bug sulla compensazione delle note di credito emesse/ricevute

### DIFF
--- a/l10n_it_intrastat_statement/tests/test_intrastat_statement.py
+++ b/l10n_it_intrastat_statement/tests/test_intrastat_statement.py
@@ -89,7 +89,7 @@ class TestIntrastatStatement(TransactionCase):
         )
 
     def _get_intrastat_computed_bill(
-        self, product=None, currency=None, price_unit=100.0
+        self, product=None, currency=None, price_unit=100.0, date=None
     ):
         if product is None:
             product = self.product01
@@ -99,13 +99,18 @@ class TestIntrastatStatement(TransactionCase):
             product=product,
             taxes=self.tax22_purchase,
             amount=price_unit,
+            date=date,
         )
         if currency:
             invoice.currency_id = currency
         invoice.action_post()
         return invoice
 
-    def _get_intrastat_computed_invoice(self, price_unit=100.0):
+    def _get_intrastat_computed_invoice(
+        self,
+        price_unit=100.0,
+        date=None,
+    ):
         invoice = self._create_move(
             "out_invoice",
             partner=self.partner01,
@@ -113,6 +118,7 @@ class TestIntrastatStatement(TransactionCase):
             taxes=self.tax22_sale,
             amount=price_unit,
             post=True,
+            date=date,
         )
         return invoice
 
@@ -221,6 +227,11 @@ class TestIntrastatStatement(TransactionCase):
             statement.generate_file_export()
 
         statement.compute_statement()
+
+        # Check compensation, we expect only purchase section 1 having one line
+        self.assertEqual(len(statement.purchase_section1_ids), 1)
+        self.assertEqual(len(statement.purchase_section2_ids), 0)
+
         file_content = statement.with_context(purchase=True).generate_file_export()
         self.assertIn(bill_refund.partner_id.vat[2:], file_content)
 
@@ -231,6 +242,38 @@ class TestIntrastatStatement(TransactionCase):
         file_lines = file_content.splitlines()
         self.assertEqual(len(file_lines), 3)
         self.assertSetEqual({len(line) for line in file_lines}, {75, 130, 119})
+
+    def test_statement_purchase_refund_no_compensation(self):
+        bill = self._get_intrastat_computed_bill(date="2018-12-15")
+        self._get_intrastat_computed_bill(date="2019-01-05")
+
+        bill_refund = self._create_move_refund(bill, date="2019-01-10")
+        # This refund will be subtracted from bill
+        bill_refund.update(
+            {
+                "intrastat": True,
+            }
+        )
+        bill_refund.action_post()
+        bill_refund.compute_intrastat_lines()
+
+        statement = self.statement_model.create(
+            {
+                "period_number": bill_refund.invoice_date.month,
+                "fiscalyear": bill_refund.invoice_date.year,
+            }
+        )
+
+        # We have created 2 bills, one in 2018 and another in 2019, we make a
+        # refund in 2019 of the bill made in 2018. We expect that the refund,
+        # in the generated statement, is not compensated because the original
+        # bill referenced by the refund belongs to a different period
+        statement.compute_statement()
+
+        # No compensation should happen, we expect both purchase section 1 and 2
+        # to have 1 entry
+        self.assertEqual(len(statement.purchase_section1_ids), 1)
+        self.assertEqual(len(statement.purchase_section2_ids), 1)
 
     def test_statement_purchase_refund_no_subtract(self):
         bill = self._get_intrastat_computed_bill()
@@ -507,11 +550,14 @@ class TestIntrastatStatement(TransactionCase):
         product=None,
         amount=None,
         taxes=None,
+        date=None,
     ):
         move_form = Form(
             self.env["account.move"].with_context(default_move_type=move_type)
         )
-        move_form.invoice_date = invoice_date or fields.Date.from_string("2019-01-01")
+        move_form.invoice_date = invoice_date or fields.Date.from_string(
+            date or "2019-01-01"
+        )
         move_form.partner_id = partner or self.partner_a
         move_form.intrastat = True
 
@@ -529,13 +575,13 @@ class TestIntrastatStatement(TransactionCase):
 
         return rslt
 
-    def _create_move_refund(self, move):
+    def _create_move_refund(self, move, date=None):
         move_reversal = (
             self.env["account.move.reversal"]
             .with_context(active_model="account.move", active_ids=move.ids)
             .create(
                 {
-                    "date": fields.Date.from_string("2019-01-01"),
+                    "date": fields.Date.from_string(date or "2019-01-01"),
                     "reason": "no reason",
                     "refund_method": "refund",
                     "journal_id": move.journal_id.id,

--- a/l10n_it_intrastat_statement/views/intrastat.xml
+++ b/l10n_it_intrastat_statement/views/intrastat.xml
@@ -282,15 +282,15 @@
             <field name="model">account.intrastat.statement.sale.section1</field>
             <field name="arch" type="xml">
                 <tree>
-                   <field name="sequence" />
-                   <field name="invoice_id" />
-                   <field name="partner_id" string="Buyer" />
-                   <field name="country_partner_id" string="Buyer State" />
-                   <field name="intrastat_code_id" string="Goods Code" />
-                   <field name="weight_kg" />
-                   <field name="country_destination_id" />
-                   <field name="province_origin_id" />
-                   <field name="amount_euro" sum="Total" />
+                    <field name="sequence" />
+                    <field name="invoice_id" />
+                    <field name="partner_id" string="Buyer" />
+                    <field name="country_partner_id" string="Buyer State" />
+                    <field name="intrastat_code_id" string="Goods Code" />
+                    <field name="weight_kg" />
+                    <field name="country_destination_id" />
+                    <field name="province_origin_id" />
+                    <field name="amount_euro" sum="Total" />
                </tree>
             </field>
         </record>
@@ -355,16 +355,17 @@
             <field name="model">account.intrastat.statement.sale.section2</field>
             <field name="arch" type="xml">
                 <tree>
-                   <field name="sequence" />
-                   <field name="year_id" />
-                   <field name="quarterly" />
-                   <field name="month" />
-                   <field name="country_partner_id" string="Buyer State" />
-                   <field name="partner_id" string="Buyer" />
-                   <field name="vat_code" string="Buyer VAT Code" />
-                   <field name="intrastat_code_id" string="Goods Code" />
-                   <field name="sign_variation" />
-                   <field name="amount_euro" sum="Total" />
+                    <field name="sequence" />
+                    <field name="invoice_id" />
+                    <field name="year_id" />
+                    <field name="quarterly" />
+                    <field name="month" />
+                    <field name="country_partner_id" string="Buyer State" />
+                    <field name="partner_id" string="Buyer" />
+                    <field name="vat_code" string="Buyer VAT Code" />
+                    <field name="intrastat_code_id" string="Goods Code" />
+                    <field name="sign_variation" />
+                    <field name="amount_euro" sum="Total" />
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/3890 per `16.0`.

Sostituisce https://github.com/OCA/l10n-italy/pull/3897 perché l'autore è disperso.