### PR TITLE
[14.0][IMP]l10n_it_ricevute_bancarie: improvements for is_unsolved field

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account.py
+++ b/l10n_it_ricevute_bancarie/models/account.py
@@ -282,6 +282,7 @@ class AccountMove(models.Model):
                     {"invoice_line_ids": [(2, id, 0) for id in due_cost_line_ids]}
                 )
                 invoice._recompute_tax_lines()
+            invoice.is_unsolved = False
         return invoice
 
     def get_due_cost_line_ids(self):

--- a/l10n_it_ricevute_bancarie/views/account_view.xml
+++ b/l10n_it_ricevute_bancarie/views/account_view.xml
@@ -150,6 +150,10 @@
                         domain="[('partner_id','=', commercial_partner_id)]"
                     />
                 </div>
+
+            </xpath>
+
+            <xpath expr="//label[@for='invoice_payment_term_id']" position="before">
                 <field
                     name="is_unsolved"
                     string="Past Due"


### PR DESCRIPTION
improvements for is_unsolved field

- Changed placement to see the label better
- When a invoice is duplicated the field is set to
  false. This behavior that was not present
  before this PR