### PR TITLE
[14.0] FIX l10n_it_vat_settlement_date with l10n_it_vat_statement_communication: VAT comunication must use statement base amounts

### DIFF
--- a/l10n_it_vat_settlement_date/__manifest__.py
+++ b/l10n_it_vat_settlement_date/__manifest__.py
@@ -16,6 +16,7 @@
         "account_tax_balance",
         "account_vat_period_end_statement",
         "l10n_it_vat_registries",
+        "l10n_it_vat_statement_communication",
     ],
     "data": [
         "views/account_move_views.xml",

--- a/l10n_it_vat_settlement_date/models/__init__.py
+++ b/l10n_it_vat_settlement_date/models/__init__.py
@@ -4,3 +4,4 @@ from . import account_move
 from . import account_move_line
 from . import account_tax
 from . import account_vat_period_end_statement
+from . import comunicazione_liquidazione

--- a/l10n_it_vat_settlement_date/models/comunicazione_liquidazione.py
+++ b/l10n_it_vat_settlement_date/models/comunicazione_liquidazione.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class ComunicazioneLiquidazioneVp(models.Model):
+    _inherit = "comunicazione.liquidazione.vp"
+
+    def _get_tax_context(self, period):
+        res = super()._get_tax_context(period)
+        res["use_l10n_it_vat_settlement_date"] = True
+        return res


### PR DESCRIPTION
v16: https://github.com/OCA/l10n-italy/pull/4475