### PR TITLE
[16.0] FIX l10n_it_vat_settlement_date: avoid to copy l10n_it_vat_settlement_date

### DIFF
--- a/l10n_it_vat_settlement_date/models/account_move.py
+++ b/l10n_it_vat_settlement_date/models/account_move.py
@@ -13,6 +13,7 @@ class AccountMove(models.Model):
         compute="_compute_l10n_it_vat_settlement_date",
         store=True,
         readonly=False,
+        copy=False,
     )
 
     @api.depends(


### PR DESCRIPTION

For instance, bad case, when creating out refunds, settlement date could be set to previous month, causing wrong amounts in VAT statment

v14: https://github.com/OCA/l10n-italy/pull/4473