### PR TITLE
[IMP] Impostare data di chiusura alla conferma della liquidazione IVA

### DIFF
--- a/account_vat_period_end_statement/README.rst
+++ b/account_vat_period_end_statement/README.rst
@@ -120,6 +120,11 @@ Per calcolare gli interessi, è possibile aggiungere le informazioni da
 utilizzare (conto e percentuale) nei dati aziendali, nella scheda
 'Liquidazione IVA'.
 
+Per impostare la "Data di blocco dichiarazione fiscale" alla conferma
+della dichiarazione, abilitare "Impostare data di chiusura per
+non-consulenti" nella scheda "Liquidazione IVA" della vista scheda
+dell'azienda.
+
 **English**
 
 In order to generate VAT statement's periods, open Accounting >
@@ -145,6 +150,10 @@ associated to the account involved in the statement:
 
 If you need to calculate interest, you can add default information in
 your company data (percentage and account), in the 'VAT statement' tab.
+
+In order to set the "Tax Return Lock Date" when a statement is
+confirmed, enable "Set Lock Date on Confirmation" in the "VAT statement"
+tab of the Company form view.
 
 Bug Tracker
 ===========

--- a/account_vat_period_end_statement/README.rst
+++ b/account_vat_period_end_statement/README.rst
@@ -30,60 +30,59 @@ ITA - Liquidazione IVA
 
 **Italiano**
 
-   Per fare la liquidazione IVA, aprire Fatturazione > Contabilità >
-   Liquidazioni IVA, il menù è visibile solo quando è abilitato il
-   gruppo 'Mostrare funzionalità contabili complete'. Selezionare un
-   registro che conterrà le registrazioni contabili della liquidazione.
-   Il campo 'Conto IVA erario' contiene il conto dove verrà effettuata
-   la registrazione della liquidazione IVA.
+Per fare la liquidazione IVA, aprire Fatturazione > Contabilità >
+Liquidazioni IVA, il menù è visibile solo quando è abilitato il gruppo
+'Mostrare funzionalità contabili complete'. Selezionare un registro che
+conterrà le registrazioni contabili della liquidazione. Il campo 'Conto
+IVA erario' contiene il conto dove verrà effettuata la registrazione
+della liquidazione IVA.
 
-   L'oggetto 'Liquidazione IVA' permette di specificare ogni importo e
-   il conto utilizzato dalla liquidazione. Di norma, gli importi di
-   debito e credito delle imposte vengono caricati automaticamente dai
-   periodi selezionati (vedere Configurazione per generare correttamente
-   i periodi). I debiti e crediti precedenti vengono caricati dalle
-   liquidazioni IVA precedenti, in base allo stato del loro pagamento.
+L'oggetto 'Liquidazione IVA' permette di specificare ogni importo e il
+conto utilizzato dalla liquidazione. Di norma, gli importi di debito e
+credito delle imposte vengono caricati automaticamente dai periodi
+selezionati (vedere Configurazione per generare correttamente i
+periodi). I debiti e crediti precedenti vengono caricati dalle
+liquidazioni IVA precedenti, in base allo stato del loro pagamento.
 
-   Per creare la registrazione contabile, fare clic sul pulsante 'Crea
-   movimento', dentro la scheda 'Conti'. Se i termini di pagamento sono
-   impostati viene scritta anche la scadenza (o le scadenze).
+Per creare la registrazione contabile, fare clic sul pulsante 'Crea
+movimento', dentro la scheda 'Conti'. Se i termini di pagamento sono
+impostati viene scritta anche la scadenza (o le scadenze).
 
-   La scheda 'Erario' contiene informazioni sui pagamenti, qui si
-   possono visualizzare i risultati della liquidazione ('Importo IVA
-   erario') e l'importo residuo da pagare ('Importo a saldo'). La
-   liquidazione può essere pagata come qualunque altro debito, con la
-   riconciliazione delle registrazioni contabili.
+La scheda 'Erario' contiene informazioni sui pagamenti, qui si possono
+visualizzare i risultati della liquidazione ('Importo IVA erario') e
+l'importo residuo da pagare ('Importo a saldo'). La liquidazione può
+essere pagata come qualunque altro debito, con la riconciliazione delle
+registrazioni contabili.
 
-   È inoltre possibile stampare la liquidazione IVA facendo clic su
-   Stampa > Stampa liquidazione IVA.
+È inoltre possibile stampare la liquidazione IVA facendo clic su Stampa
+> Stampa liquidazione IVA.
 
 **English**
 
-   In order to create a 'VAT Statement', open Accounting > Adviser > VAT
-   Statements, this menu is only visible when the group 'Show Full
-   Accounting Features' is enabled. Select a Journal that will contain
-   the journal entries of the statement. The field 'Tax authority VAT'
-   account contains the account where the statement balance will be
-   registered.
+In order to create a 'VAT Statement', open Accounting > Adviser > VAT
+Statements, this menu is only visible when the group 'Show Full
+Accounting Features' is enabled. Select a Journal that will contain the
+journal entries of the statement. The field 'Tax authority VAT' account
+contains the account where the statement balance will be registered.
 
-   The 'VAT statement' object allows to specify every amount and
-   relative account used by the statement. By default, amounts of debit
-   and credit taxes are automatically loaded from taxes of the selected
-   periods (see Configuration to correctly generate the periods).
-   Previous debit or credit is loaded from previous VAT statement,
-   according to its payments status.
+The 'VAT statement' object allows to specify every amount and relative
+account used by the statement. By default, amounts of debit and credit
+taxes are automatically loaded from taxes of the selected periods (see
+Configuration to correctly generate the periods). Previous debit or
+credit is loaded from previous VAT statement, according to its payments
+status.
 
-   In order to generate the journal entry, click on 'Create move'
-   button, inside the 'Accounts' tab. If you select a payment term, the
-   due date(s) will be set.
+In order to generate the journal entry, click on 'Create move' button,
+inside the 'Accounts' tab. If you select a payment term, the due date(s)
+will be set.
 
-   The 'tax authority' tab contains information about payment(s), here
-   you can see statement's result ('authority VAT amount') and residual
-   amount to pay ('Balance'). The statement can be paid like every other
-   debit, by journal item reconciliation.
+The 'tax authority' tab contains information about payment(s), here you
+can see statement's result ('authority VAT amount') and residual amount
+to pay ('Balance'). The statement can be paid like every other debit, by
+journal item reconciliation.
 
-   It is also possible to print the 'VAT statement' clicking on print >
-   Print VAT period end statement.
+It is also possible to print the 'VAT statement' clicking on print >
+Print VAT period end statement.
 
 **Table of contents**
 
@@ -95,58 +94,57 @@ Configuration
 
 **Italiano**
 
-   Per generare i periodi della dichiarazione IVA, aprire Fatturazione >
-   Configurazione > Contabilità > Intervalli date > Generazione
-   intervalli data (visibile solo in modalità debug):
+Per generare i periodi della dichiarazione IVA, aprire Fatturazione >
+Configurazione > Contabilità > Intervalli date > Generazione intervalli
+data (visibile solo in modalità debug):
 
-   - prefisso nome intervallo: prefisso identificativo per i periodi da
-     generare (tipicamente l'anno)
-   - durata: 1 mese
-   - numero di intervalli da generare: 12
-   - tipo: creare un tipo o utilizzarne uno esistente, non è richiesta
-     una configurazione particolare
-   - data iniziale: primo giorno del primo periodo che sarà generato
-     (tipicamente il primo giorno dell'anno i.e. 01/01/2018)
+-  prefisso nome intervallo: prefisso identificativo per i periodi da
+   generare (tipicamente l'anno)
+-  durata: 1 mese
+-  numero di intervalli da generare: 12
+-  tipo: creare un tipo o utilizzarne uno esistente, non è richiesta una
+   configurazione particolare
+-  data iniziale: primo giorno del primo periodo che sarà generato
+   (tipicamente il primo giorno dell'anno i.e. 01/01/2018)
 
-   Per caricare l'importo corretto, un'imposta deve essere associata al
-   conto utilizzato nella liquidazione:
+Per caricare l'importo corretto, un'imposta deve essere associata al
+conto utilizzato nella liquidazione:
 
-   1. aprire l'imposta da Fatturazione > Configurazione > Contabilità >
-      Imposte,
-   2. nella scheda 'Opzioni avanzate' selezionare il conto corretto (ad
-      esempio IVA debito) per il campo 'Conto utilizzato per la
-      liquidazione IVA'.
+1. aprire l'imposta da Fatturazione > Configurazione > Contabilità >
+   Imposte,
+2. nella scheda 'Opzioni avanzate' selezionare il conto corretto (ad
+   esempio IVA debito) per il campo 'Conto utilizzato per la
+   liquidazione IVA'.
 
-   Per calcolare gli interessi, è possibile aggiungere le informazioni
-   da utilizzare (conto e percentuale) nei dati aziendali, nella scheda
-   'Liquidazione IVA'.
+Per calcolare gli interessi, è possibile aggiungere le informazioni da
+utilizzare (conto e percentuale) nei dati aziendali, nella scheda
+'Liquidazione IVA'.
 
 **English**
 
-   In order to generate VAT statement's periods, open Accounting >
-   Configuration > Accounting > Date ranges > Generate Date Ranges
-   (visible only in debug mode):
+In order to generate VAT statement's periods, open Accounting >
+Configuration > Accounting > Date ranges > Generate Date Ranges (visible
+only in debug mode):
 
-   - range name prefix: prefix identifying the periods to be generated
-     (usually the year)
-   - duration: 1 month
-   - number of ranges to generate: 12
-   - type: create a type or use an existing one, no specific
-     configuration is required
-   - date start: first day of the first period to be generated (usually
-     the first day of the year e.g. 01/01/2018)
+-  range name prefix: prefix identifying the periods to be generated
+   (usually the year)
+-  duration: 1 month
+-  number of ranges to generate: 12
+-  type: create a type or use an existing one, no specific configuration
+   is required
+-  date start: first day of the first period to be generated (usually
+   the first day of the year e.g. 01/01/2018)
 
-   In order to load the correct amount from tax, the tax has to be
-   associated to the account involved in the statement:
+In order to load the correct amount from tax, the tax has to be
+associated to the account involved in the statement:
 
-   1. open a tax in Accounting > Configuration > Accounting > Taxes,
-   2. in the tab 'Advanced Options' select the correct account (for
-      instance the account debit VAT) for the field 'Account used for
-      VAT statement'.
+1. open a tax in Accounting > Configuration > Accounting > Taxes,
+2. in the tab 'Advanced Options' select the correct account (for
+   instance the account debit VAT) for the field 'Account used for VAT
+   statement'.
 
-   If you need to calculate interest, you can add default information in
-   your company data (percentage and account), in the 'VAT statement'
-   tab.
+If you need to calculate interest, you can add default information in
+your company data (percentage and account), in the 'VAT statement' tab.
 
 Bug Tracker
 ===========
@@ -170,26 +168,26 @@ Authors
 Contributors
 ------------
 
-- Lorenzo Battistini <https://github.com/eLBati>
-- Elena Carlesso
-- Marco Marchiori <marcomarkiori@gmail.com>
-- Sergio Corato <sergiocorato@gmail.com>
-- Andrea Gallina <a.gallina@apuliasoftware.it>
-- Alex Comba <alex.comba@agilebg.com>
-- Alessandro Camilli <camillialex@gmail.com>
-- Simone Rubino <simone.rubino@agilebg.com>
-- Giacomo Grasso <giacomo.grasso.82@gmail.com>
-- Lara Baggio <http://linkgroup.it/>
-- Gianmarco Conte <gconte@dinamicheaziendali.it>
-- Michele Rusticucci <michele.rusticucci@agilebg.com>
-- Salvo Rapisarda <sdrapisarda@gmail.com>
-- `TAKOBI <https://takobi.online>`__:
+-  Lorenzo Battistini <https://github.com/eLBati>
+-  Elena Carlesso
+-  Marco Marchiori <marcomarkiori@gmail.com>
+-  Sergio Corato <sergiocorato@gmail.com>
+-  Andrea Gallina <a.gallina@apuliasoftware.it>
+-  Alex Comba <alex.comba@agilebg.com>
+-  Alessandro Camilli <camillialex@gmail.com>
+-  Simone Rubino <simone.rubino@agilebg.com>
+-  Giacomo Grasso <giacomo.grasso.82@gmail.com>
+-  Lara Baggio <http://linkgroup.it/>
+-  Gianmarco Conte <gconte@dinamicheaziendali.it>
+-  Michele Rusticucci <michele.rusticucci@agilebg.com>
+-  Salvo Rapisarda <sdrapisarda@gmail.com>
+-  `TAKOBI <https://takobi.online>`__:
 
-  - Simone Rubino <sir@takobi.online>
+   -  Simone Rubino <sir@takobi.online>
 
-- `Aion Tech <https://aiontech.company/>`__:
+-  `Aion Tech <https://aiontech.company/>`__:
 
-  - Simone Rubino <simone.rubino@aion-tech.it>
+   -  Simone Rubino <simone.rubino@aion-tech.it>
 
 Maintainers
 -----------

--- a/account_vat_period_end_statement/__manifest__.py
+++ b/account_vat_period_end_statement/__manifest__.py
@@ -4,6 +4,7 @@
 #  Copyright 2015 Associazione Odoo Italia (<http://www.odoo-italia.org>)
 #  Copyright 2021 Gianmarco Conte
 #                 - Dinamiche Aziendali Srl (<www.dinamicheaziendali.it>)
+#  Copyright 2022 ~ 2023 Simone Rubino - TAKOBI
 #  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {

--- a/account_vat_period_end_statement/models/account.py
+++ b/account_vat_period_end_statement/models/account.py
@@ -2,7 +2,7 @@
 # Copyright 2012-15 Agile Business Group sagl (<http://www.agilebg.com>)
 # Copyright 2015 Associazione Odoo Italia (<http://www.odoo-italia.org>)
 # Copyright 2021 Gianmarco Conte - Dinamiche Aziendali Srl (<www.dinamicheaziendali.it>)
-# Copyright 2022 Simone Rubino - TAKOBI
+# Copyright 2022 ~ 2023 Simone Rubino - TAKOBI
 # Copyright 2023 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -393,9 +393,31 @@ class AccountVatPeriodEndStatement(models.Model):
         for statement in self:
             statement.state = "paid"
 
+    def _get_end_date(self):
+        self.ensure_one()
+        periods = self.date_range_ids
+        end_date = max(
+            periods.mapped("date_end"),
+            default=None,
+        )
+        return end_date
+
+    def _set_company_lock_date(self):
+        self.ensure_one()
+        company = self.company_id or self.env.company
+        if company.account_vat_period_end_statement_set_lock_date:
+            end_date = self._get_end_date()
+            if end_date:
+                lock_date_values = {
+                    "tax_lock_date": end_date,
+                }
+                company.update(lock_date_values)
+        return True
+
     def statement_confirmed(self):
         for statement in self:
             statement.state = "confirmed"
+            statement._set_company_lock_date()
 
     def _prepare_account_move_line(
         self, name, account_id, move_id, statement, statement_date, partner_id=False
@@ -453,7 +475,7 @@ class AccountVatPeriodEndStatement(models.Model):
 
             move.line_ids = lines_to_create
             move.action_post()
-            statement.state = "confirmed"
+            statement.statement_confirmed()
 
         return True
 

--- a/account_vat_period_end_statement/models/config.py
+++ b/account_vat_period_end_statement/models/config.py
@@ -1,4 +1,5 @@
 # Copyright 2015 Alessandro Camilli (a.camilli@openforce.it)
+# Copyright 2023 Simone Rubino - TAKOBI
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
@@ -17,4 +18,9 @@ class ResCompany(models.Model):
         "account.account",
         "Interest on End Vat Statement - Account",
         help="Apply interest on end vat statement",
+    )
+    account_vat_period_end_statement_set_lock_date = fields.Boolean(
+        string="Set Lock Date on Confirmation",
+        help="When confirming the VAT period end statement, "
+        "the Tax Return Lock Date is set to the Statement's end date.",
     )

--- a/account_vat_period_end_statement/readme/CONFIGURE.md
+++ b/account_vat_period_end_statement/readme/CONFIGURE.md
@@ -26,6 +26,8 @@ Per calcolare gli interessi, è possibile aggiungere le informazioni da
 utilizzare (conto e percentuale) nei dati aziendali, nella scheda
 'Liquidazione IVA'.
 
+Per impostare la "Data di blocco dichiarazione fiscale" alla conferma della dichiarazione, abilitare "Impostare data di chiusura per non-consulenti" nella scheda "Liquidazione IVA" della vista scheda dell'azienda.
+
 **English**
 
 In order to generate VAT statement's periods, open Accounting \>
@@ -52,3 +54,5 @@ associated to the account involved in the statement:
 If you need to calculate interest, you can add default information in
 your company data (percentage and account), in the 'VAT statement'
 tab.
+
+In order to set the "Tax Return Lock Date" when a statement is confirmed, enable "Set Lock Date on Confirmation" in the "VAT statement" tab of the Company form view.

--- a/account_vat_period_end_statement/readme/CONFIGURE.md
+++ b/account_vat_period_end_statement/readme/CONFIGURE.md
@@ -1,54 +1,54 @@
 **Italiano**
 
-> Per generare i periodi della dichiarazione IVA, aprire Fatturazione \>
-> Configurazione \> Contabilità \> Intervalli date \> Generazione
-> intervalli data (visibile solo in modalità debug):
->
-> - prefisso nome intervallo: prefisso identificativo per i periodi da
->   generare (tipicamente l'anno)
-> - durata: 1 mese
-> - numero di intervalli da generare: 12
-> - tipo: creare un tipo o utilizzarne uno esistente, non è richiesta
->   una configurazione particolare
-> - data iniziale: primo giorno del primo periodo che sarà generato
->   (tipicamente il primo giorno dell'anno i.e. 01/01/2018)
->
-> Per caricare l'importo corretto, un'imposta deve essere associata al
-> conto utilizzato nella liquidazione:
->
-> 1.  aprire l'imposta da Fatturazione \> Configurazione \> Contabilità
->     \> Imposte,
-> 2.  nella scheda 'Opzioni avanzate' selezionare il conto corretto (ad
->     esempio IVA debito) per il campo 'Conto utilizzato per la
->     liquidazione IVA'.
->
-> Per calcolare gli interessi, è possibile aggiungere le informazioni da
-> utilizzare (conto e percentuale) nei dati aziendali, nella scheda
-> 'Liquidazione IVA'.
+Per generare i periodi della dichiarazione IVA, aprire Fatturazione \>
+Configurazione \> Contabilità \> Intervalli date \> Generazione
+intervalli data (visibile solo in modalità debug):
+
+- prefisso nome intervallo: prefisso identificativo per i periodi da
+  generare (tipicamente l'anno)
+- durata: 1 mese
+- numero di intervalli da generare: 12
+- tipo: creare un tipo o utilizzarne uno esistente, non è richiesta
+  una configurazione particolare
+- data iniziale: primo giorno del primo periodo che sarà generato
+  (tipicamente il primo giorno dell'anno i.e. 01/01/2018)
+
+Per caricare l'importo corretto, un'imposta deve essere associata al
+conto utilizzato nella liquidazione:
+
+1.  aprire l'imposta da Fatturazione \> Configurazione \> Contabilità
+    \> Imposte,
+2.  nella scheda 'Opzioni avanzate' selezionare il conto corretto (ad
+    esempio IVA debito) per il campo 'Conto utilizzato per la
+    liquidazione IVA'.
+
+Per calcolare gli interessi, è possibile aggiungere le informazioni da
+utilizzare (conto e percentuale) nei dati aziendali, nella scheda
+'Liquidazione IVA'.
 
 **English**
 
-> In order to generate VAT statement's periods, open Accounting \>
-> Configuration \> Accounting \> Date ranges \> Generate Date Ranges
-> (visible only in debug mode):
->
-> - range name prefix: prefix identifying the periods to be generated
->   (usually the year)
-> - duration: 1 month
-> - number of ranges to generate: 12
-> - type: create a type or use an existing one, no specific
->   configuration is required
-> - date start: first day of the first period to be generated (usually
->   the first day of the year e.g. 01/01/2018)
->
-> In order to load the correct amount from tax, the tax has to be
-> associated to the account involved in the statement:
->
-> 1.  open a tax in Accounting \> Configuration \> Accounting \> Taxes,
-> 2.  in the tab 'Advanced Options' select the correct account (for
->     instance the account debit VAT) for the field 'Account used for
->     VAT statement'.
->
-> If you need to calculate interest, you can add default information in
-> your company data (percentage and account), in the 'VAT statement'
-> tab.
+In order to generate VAT statement's periods, open Accounting \>
+Configuration \> Accounting \> Date ranges \> Generate Date Ranges
+(visible only in debug mode):
+
+- range name prefix: prefix identifying the periods to be generated
+  (usually the year)
+- duration: 1 month
+- number of ranges to generate: 12
+- type: create a type or use an existing one, no specific
+  configuration is required
+- date start: first day of the first period to be generated (usually
+  the first day of the year e.g. 01/01/2018)
+
+In order to load the correct amount from tax, the tax has to be
+associated to the account involved in the statement:
+
+1.  open a tax in Accounting \> Configuration \> Accounting \> Taxes,
+2.  in the tab 'Advanced Options' select the correct account (for
+    instance the account debit VAT) for the field 'Account used for
+    VAT statement'.
+
+If you need to calculate interest, you can add default information in
+your company data (percentage and account), in the 'VAT statement'
+tab.

--- a/account_vat_period_end_statement/readme/DESCRIPTION.md
+++ b/account_vat_period_end_statement/readme/DESCRIPTION.md
@@ -1,56 +1,56 @@
 **Italiano**
 
-> Per fare la liquidazione IVA, aprire Fatturazione \> Contabilità \>
-> Liquidazioni IVA, il menù è visibile solo quando è abilitato il gruppo
-> 'Mostrare funzionalità contabili complete'. Selezionare un registro
-> che conterrà le registrazioni contabili della liquidazione. Il campo
-> 'Conto IVA erario' contiene il conto dove verrà effettuata la
-> registrazione della liquidazione IVA.
->
-> L'oggetto 'Liquidazione IVA' permette di specificare ogni importo e il
-> conto utilizzato dalla liquidazione. Di norma, gli importi di debito e
-> credito delle imposte vengono caricati automaticamente dai periodi
-> selezionati (vedere Configurazione per generare correttamente i
-> periodi). I debiti e crediti precedenti vengono caricati dalle
-> liquidazioni IVA precedenti, in base allo stato del loro pagamento.
->
-> Per creare la registrazione contabile, fare clic sul pulsante 'Crea
-> movimento', dentro la scheda 'Conti'. Se i termini di pagamento sono
-> impostati viene scritta anche la scadenza (o le scadenze).
->
-> La scheda 'Erario' contiene informazioni sui pagamenti, qui si possono
-> visualizzare i risultati della liquidazione ('Importo IVA erario') e
-> l'importo residuo da pagare ('Importo a saldo'). La liquidazione può
-> essere pagata come qualunque altro debito, con la riconciliazione
-> delle registrazioni contabili.
->
-> È inoltre possibile stampare la liquidazione IVA facendo clic su
-> Stampa \> Stampa liquidazione IVA.
+Per fare la liquidazione IVA, aprire Fatturazione \> Contabilità \>
+Liquidazioni IVA, il menù è visibile solo quando è abilitato il gruppo
+'Mostrare funzionalità contabili complete'. Selezionare un registro
+che conterrà le registrazioni contabili della liquidazione. Il campo
+'Conto IVA erario' contiene il conto dove verrà effettuata la
+registrazione della liquidazione IVA.
+
+L'oggetto 'Liquidazione IVA' permette di specificare ogni importo e il
+conto utilizzato dalla liquidazione. Di norma, gli importi di debito e
+credito delle imposte vengono caricati automaticamente dai periodi
+selezionati (vedere Configurazione per generare correttamente i
+periodi). I debiti e crediti precedenti vengono caricati dalle
+liquidazioni IVA precedenti, in base allo stato del loro pagamento.
+
+Per creare la registrazione contabile, fare clic sul pulsante 'Crea
+movimento', dentro la scheda 'Conti'. Se i termini di pagamento sono
+impostati viene scritta anche la scadenza (o le scadenze).
+
+La scheda 'Erario' contiene informazioni sui pagamenti, qui si possono
+visualizzare i risultati della liquidazione ('Importo IVA erario') e
+l'importo residuo da pagare ('Importo a saldo'). La liquidazione può
+essere pagata come qualunque altro debito, con la riconciliazione
+delle registrazioni contabili.
+
+È inoltre possibile stampare la liquidazione IVA facendo clic su
+Stampa \> Stampa liquidazione IVA.
 
 **English**
 
-> In order to create a 'VAT Statement', open Accounting \> Adviser \>
-> VAT Statements, this menu is only visible when the group 'Show Full
-> Accounting Features' is enabled. Select a Journal that will contain
-> the journal entries of the statement. The field 'Tax authority VAT'
-> account contains the account where the statement balance will be
-> registered.
->
-> The 'VAT statement' object allows to specify every amount and relative
-> account used by the statement. By default, amounts of debit and credit
-> taxes are automatically loaded from taxes of the selected periods (see
-> Configuration to correctly generate the periods). Previous debit or
-> credit is loaded from previous VAT statement, according to its
-> payments status.
->
-> In order to generate the journal entry, click on 'Create move' button,
-> inside the 'Accounts' tab. If you select a payment term, the due
-> date(s) will be set.
->
-> The 'tax authority' tab contains information about payment(s), here
-> you can see statement's result ('authority VAT amount') and residual
-> amount to pay ('Balance'). The statement can be paid like every other
-> debit, by journal item reconciliation.
->
-> It is also possible to print the 'VAT statement' clicking on print \>
-> Print VAT period end statement.
+In order to create a 'VAT Statement', open Accounting \> Adviser \>
+VAT Statements, this menu is only visible when the group 'Show Full
+Accounting Features' is enabled. Select a Journal that will contain
+the journal entries of the statement. The field 'Tax authority VAT'
+account contains the account where the statement balance will be
+registered.
+
+The 'VAT statement' object allows to specify every amount and relative
+account used by the statement. By default, amounts of debit and credit
+taxes are automatically loaded from taxes of the selected periods (see
+Configuration to correctly generate the periods). Previous debit or
+credit is loaded from previous VAT statement, according to its
+payments status.
+
+In order to generate the journal entry, click on 'Create move' button,
+inside the 'Accounts' tab. If you select a payment term, the due
+date(s) will be set.
+
+The 'tax authority' tab contains information about payment(s), here
+you can see statement's result ('authority VAT amount') and residual
+amount to pay ('Balance'). The statement can be paid like every other
+debit, by journal item reconciliation.
+
+It is also possible to print the 'VAT statement' clicking on print \>
+Print VAT period end statement.

--- a/account_vat_period_end_statement/static/description/index.html
+++ b/account_vat_period_end_statement/static/description/index.html
@@ -371,54 +371,49 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/l10n-italy/tree/16.0/account_vat_period_end_statement"><img alt="OCA/l10n-italy" src="https://img.shields.io/badge/github-OCA%2Fl10n--italy-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/l10n-italy-16-0/l10n-italy-16-0-account_vat_period_end_statement"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/l10n-italy&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p><strong>Italiano</strong></p>
-<blockquote>
 <p>Per fare la liquidazione IVA, aprire Fatturazione &gt; Contabilità &gt;
-Liquidazioni IVA, il menù è visibile solo quando è abilitato il
-gruppo ‘Mostrare funzionalità contabili complete’. Selezionare un
-registro che conterrà le registrazioni contabili della liquidazione.
-Il campo ‘Conto IVA erario’ contiene il conto dove verrà effettuata
-la registrazione della liquidazione IVA.</p>
-<p>L’oggetto ‘Liquidazione IVA’ permette di specificare ogni importo e
-il conto utilizzato dalla liquidazione. Di norma, gli importi di
-debito e credito delle imposte vengono caricati automaticamente dai
-periodi selezionati (vedere Configurazione per generare correttamente
-i periodi). I debiti e crediti precedenti vengono caricati dalle
+Liquidazioni IVA, il menù è visibile solo quando è abilitato il gruppo
+‘Mostrare funzionalità contabili complete’. Selezionare un registro che
+conterrà le registrazioni contabili della liquidazione. Il campo ‘Conto
+IVA erario’ contiene il conto dove verrà effettuata la registrazione
+della liquidazione IVA.</p>
+<p>L’oggetto ‘Liquidazione IVA’ permette di specificare ogni importo e il
+conto utilizzato dalla liquidazione. Di norma, gli importi di debito e
+credito delle imposte vengono caricati automaticamente dai periodi
+selezionati (vedere Configurazione per generare correttamente i
+periodi). I debiti e crediti precedenti vengono caricati dalle
 liquidazioni IVA precedenti, in base allo stato del loro pagamento.</p>
 <p>Per creare la registrazione contabile, fare clic sul pulsante ‘Crea
 movimento’, dentro la scheda ‘Conti’. Se i termini di pagamento sono
 impostati viene scritta anche la scadenza (o le scadenze).</p>
-<p>La scheda ‘Erario’ contiene informazioni sui pagamenti, qui si
-possono visualizzare i risultati della liquidazione (‘Importo IVA
-erario’) e l’importo residuo da pagare (‘Importo a saldo’). La
-liquidazione può essere pagata come qualunque altro debito, con la
-riconciliazione delle registrazioni contabili.</p>
-<p>È inoltre possibile stampare la liquidazione IVA facendo clic su
-Stampa &gt; Stampa liquidazione IVA.</p>
-</blockquote>
+<p>La scheda ‘Erario’ contiene informazioni sui pagamenti, qui si possono
+visualizzare i risultati della liquidazione (‘Importo IVA erario’) e
+l’importo residuo da pagare (‘Importo a saldo’). La liquidazione può
+essere pagata come qualunque altro debito, con la riconciliazione delle
+registrazioni contabili.</p>
+<p>È inoltre possibile stampare la liquidazione IVA facendo clic su Stampa
+&gt; Stampa liquidazione IVA.</p>
 <p><strong>English</strong></p>
-<blockquote>
 <p>In order to create a ‘VAT Statement’, open Accounting &gt; Adviser &gt; VAT
 Statements, this menu is only visible when the group ‘Show Full
-Accounting Features’ is enabled. Select a Journal that will contain
-the journal entries of the statement. The field ‘Tax authority VAT’
-account contains the account where the statement balance will be
-registered.</p>
-<p>The ‘VAT statement’ object allows to specify every amount and
-relative account used by the statement. By default, amounts of debit
-and credit taxes are automatically loaded from taxes of the selected
-periods (see Configuration to correctly generate the periods).
-Previous debit or credit is loaded from previous VAT statement,
-according to its payments status.</p>
-<p>In order to generate the journal entry, click on ‘Create move’
-button, inside the ‘Accounts’ tab. If you select a payment term, the
-due date(s) will be set.</p>
-<p>The ‘tax authority’ tab contains information about payment(s), here
-you can see statement’s result (‘authority VAT amount’) and residual
-amount to pay (‘Balance’). The statement can be paid like every other
-debit, by journal item reconciliation.</p>
+Accounting Features’ is enabled. Select a Journal that will contain the
+journal entries of the statement. The field ‘Tax authority VAT’ account
+contains the account where the statement balance will be registered.</p>
+<p>The ‘VAT statement’ object allows to specify every amount and relative
+account used by the statement. By default, amounts of debit and credit
+taxes are automatically loaded from taxes of the selected periods (see
+Configuration to correctly generate the periods). Previous debit or
+credit is loaded from previous VAT statement, according to its payments
+status.</p>
+<p>In order to generate the journal entry, click on ‘Create move’ button,
+inside the ‘Accounts’ tab. If you select a payment term, the due date(s)
+will be set.</p>
+<p>The ‘tax authority’ tab contains information about payment(s), here you
+can see statement’s result (‘authority VAT amount’) and residual amount
+to pay (‘Balance’). The statement can be paid like every other debit, by
+journal item reconciliation.</p>
 <p>It is also possible to print the ‘VAT statement’ clicking on print &gt;
 Print VAT period end statement.</p>
-</blockquote>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -435,17 +430,16 @@ Print VAT period end statement.</p>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
 <p><strong>Italiano</strong></p>
-<blockquote>
 <p>Per generare i periodi della dichiarazione IVA, aprire Fatturazione &gt;
-Configurazione &gt; Contabilità &gt; Intervalli date &gt; Generazione
-intervalli data (visibile solo in modalità debug):</p>
+Configurazione &gt; Contabilità &gt; Intervalli date &gt; Generazione intervalli
+data (visibile solo in modalità debug):</p>
 <ul class="simple">
 <li>prefisso nome intervallo: prefisso identificativo per i periodi da
 generare (tipicamente l’anno)</li>
 <li>durata: 1 mese</li>
 <li>numero di intervalli da generare: 12</li>
-<li>tipo: creare un tipo o utilizzarne uno esistente, non è richiesta
-una configurazione particolare</li>
+<li>tipo: creare un tipo o utilizzarne uno esistente, non è richiesta una
+configurazione particolare</li>
 <li>data iniziale: primo giorno del primo periodo che sarà generato
 (tipicamente il primo giorno dell’anno i.e. 01/01/2018)</li>
 </ul>
@@ -458,22 +452,20 @@ Imposte,</li>
 esempio IVA debito) per il campo ‘Conto utilizzato per la
 liquidazione IVA’.</li>
 </ol>
-<p>Per calcolare gli interessi, è possibile aggiungere le informazioni
-da utilizzare (conto e percentuale) nei dati aziendali, nella scheda
+<p>Per calcolare gli interessi, è possibile aggiungere le informazioni da
+utilizzare (conto e percentuale) nei dati aziendali, nella scheda
 ‘Liquidazione IVA’.</p>
-</blockquote>
 <p><strong>English</strong></p>
-<blockquote>
 <p>In order to generate VAT statement’s periods, open Accounting &gt;
-Configuration &gt; Accounting &gt; Date ranges &gt; Generate Date Ranges
-(visible only in debug mode):</p>
+Configuration &gt; Accounting &gt; Date ranges &gt; Generate Date Ranges (visible
+only in debug mode):</p>
 <ul class="simple">
 <li>range name prefix: prefix identifying the periods to be generated
 (usually the year)</li>
 <li>duration: 1 month</li>
 <li>number of ranges to generate: 12</li>
-<li>type: create a type or use an existing one, no specific
-configuration is required</li>
+<li>type: create a type or use an existing one, no specific configuration
+is required</li>
 <li>date start: first day of the first period to be generated (usually
 the first day of the year e.g. 01/01/2018)</li>
 </ul>
@@ -482,13 +474,11 @@ associated to the account involved in the statement:</p>
 <ol class="arabic simple">
 <li>open a tax in Accounting &gt; Configuration &gt; Accounting &gt; Taxes,</li>
 <li>in the tab ‘Advanced Options’ select the correct account (for
-instance the account debit VAT) for the field ‘Account used for
-VAT statement’.</li>
+instance the account debit VAT) for the field ‘Account used for VAT
+statement’.</li>
 </ol>
 <p>If you need to calculate interest, you can add default information in
-your company data (percentage and account), in the ‘VAT statement’
-tab.</p>
-</blockquote>
+your company data (percentage and account), in the ‘VAT statement’ tab.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>

--- a/account_vat_period_end_statement/static/description/index.html
+++ b/account_vat_period_end_statement/static/description/index.html
@@ -455,6 +455,10 @@ liquidazione IVA’.</li>
 <p>Per calcolare gli interessi, è possibile aggiungere le informazioni da
 utilizzare (conto e percentuale) nei dati aziendali, nella scheda
 ‘Liquidazione IVA’.</p>
+<p>Per impostare la “Data di blocco dichiarazione fiscale” alla conferma
+della dichiarazione, abilitare “Impostare data di chiusura per
+non-consulenti” nella scheda “Liquidazione IVA” della vista scheda
+dell’azienda.</p>
 <p><strong>English</strong></p>
 <p>In order to generate VAT statement’s periods, open Accounting &gt;
 Configuration &gt; Accounting &gt; Date ranges &gt; Generate Date Ranges (visible
@@ -479,6 +483,9 @@ statement’.</li>
 </ol>
 <p>If you need to calculate interest, you can add default information in
 your company data (percentage and account), in the ‘VAT statement’ tab.</p>
+<p>In order to set the “Tax Return Lock Date” when a statement is
+confirmed, enable “Set Lock Date on Confirmation” in the “VAT statement”
+tab of the Company form view.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>

--- a/account_vat_period_end_statement/tests/test_vat_statement.py
+++ b/account_vat_period_end_statement/tests/test_vat_statement.py
@@ -328,3 +328,36 @@ class TestTax(TestVATStatementCommon):
             report_content.decode(),
         )
         self.assertEqual(len(payment_infos), 1)
+
+    def test_set_lock_date(self):
+        """
+        Confirming the statement sets the lock date.
+        """
+        # Arrange
+        period = self.current_period
+        self.init_invoice(
+            "out_invoice",
+            invoice_date=self.recent_date,
+            amounts=[100],
+            taxes=self.account_tax_22,
+            post=True,
+        )
+        statement = self._get_statement(
+            period,
+            self.last_year_date,
+            self.env["account.account"].browse(),
+            payment_term=self.env.ref("account.account_payment_term_advance_60days"),
+        )
+        company = statement.company_id
+        company.account_vat_period_end_statement_set_lock_date = True
+        # pre-condition
+        self.assertFalse(company.tax_lock_date)
+
+        # Act
+        statement.create_move()
+
+        # Assert
+        self.assertEqual(
+            period.date_end,
+            company.tax_lock_date,
+        )

--- a/account_vat_period_end_statement/views/config.xml
+++ b/account_vat_period_end_statement/views/config.xml
@@ -18,6 +18,7 @@
                         <field
                             name="of_account_end_vat_statement_interest_account_id"
                         />
+                        <field name="account_vat_period_end_statement_set_lock_date" />
                     </group>
                 </page>
                </xpath>


### PR DESCRIPTION
Implementa #3524 per `16.0`.

Forward port di https://github.com/OCA/l10n-italy/pull/3525.
Rispetto all'implementazione della PR linkata:

- viene usata la "data di blocco per la dichiarazione fiscale" (`tax_lock_date`) invece della "data di blocco per non consiglieri" (`period_lock_date`), perché la prima in `12.0` non esisteva;
- ~~è stata aggiunta la dipendenza da **account_lock**, la cui funzionalità in `12.0` era inglobata in **account**~~ la dipendenza da **account_lock** non è tecnicamente necessaria e il modulo impone vincoli molto restrittivi quindi non ho aggiunto la dipendenza.

Queste differenze si vedono bene confrontando il codice di `12.0` https://github.com/odoo/odoo/blob/c50e82c127082f5202cced4bf30bc166bdb9efca/addons/account/models/company.py#L148-L151 con l'analogo di `16.0` https://github.com/odoo/odoo/blob/17d44d6617baf302bf01e5d0f5c3c32a2c8d5007/addons/account_lock/models/res_company.py#L25-L27