### PR TITLE
[FIX] l10n_it_withholding_tax, l10n_it_financial_statements_report: fix for payment_reference cannot be located in parent view, fix for KeyError 'grouped_key'

### DIFF
--- a/l10n_it_financial_statements_report/wizard/wizard_financial_statements_report.py
+++ b/l10n_it_financial_statements_report/wizard/wizard_financial_statements_report.py
@@ -51,6 +51,7 @@ class ReportFinancialStatementsWizard(models.TransientModel):
             "show_partner_details": self.show_partner_details,
             "unaffected_earnings_account": self.unaffected_earnings_account.id,
             "account_financial_report_lang": self.env.lang,
+            "grouped_by": False,
         }
 
     def _print_report(self, report_type):

--- a/l10n_it_withholding_tax/views/account.xml
+++ b/l10n_it_withholding_tax/views/account.xml
@@ -112,8 +112,8 @@
                     /></group></xpath>
 
                 <xpath
-                expr="//group/group/field[@name='payment_reference']"
-                position="after"
+                expr="//group/group/field[@name='partner_bank_id']"
+                position="before"
             >
                     <field name="withholding_tax" invisible="1" />
                 </xpath>


### PR DESCRIPTION
Fix per
`Element '<xpath expr="//group/group/field[@name='payment_reference']">' cannot be located in parent view`
e
`fix for KeyError 'grouped_key'`

presente su tutte le ultime PR e si presenta se si installa account_payment_order prima di l10n_it_withholding_tax

Fixes https://github.com/OCA/l10n-italy/issues/4487 
Fixes https://github.com/OCA/l10n-italy/issues/4461