### PR TITLE
[FIX] l10n_it_delivery_note: check only on incoming picking presence to avoid DN invoicing

### DIFF
--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -625,11 +625,8 @@ class StockDeliveryNote(models.Model):
                 raise UserError(
                     _("%s hasn't sale order!") % delivery_note_id.display_name
                 )
-            if (
-                len(
-                    delivery_note_id.mapped("sale_ids.picking_ids.picking_type_id.code")
-                )
-                > 1
+            if "incoming" in delivery_note_id.mapped(
+                "sale_ids.picking_ids.picking_type_id.code"
             ):
                 raise UserError(
                     _(


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/4488