### PR TITLE
[IMP] Data di competenza IVA non modificabile dopo registrazione

### DIFF
--- a/l10n_it_vat_settlement_date/models/account_move.py
+++ b/l10n_it_vat_settlement_date/models/account_move.py
@@ -14,6 +14,11 @@ class AccountMove(models.Model):
         store=True,
         readonly=False,
         copy=False,
+        states={
+            "posted": [
+                ("readonly", True),
+            ],
+        },
     )
 
     @api.depends(

--- a/l10n_it_vat_settlement_date/tests/__init__.py
+++ b/l10n_it_vat_settlement_date/tests/__init__.py
@@ -1,4 +1,5 @@
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import test_account_move
 from . import test_vat_period_end_statement
 from . import test_vat_registry

--- a/l10n_it_vat_settlement_date/tests/test_account_move.py
+++ b/l10n_it_vat_settlement_date/tests/test_account_move.py
@@ -1,0 +1,60 @@
+#  Copyright 2024 Simone Rubino - Aion Tech
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import datetime
+
+from dateutil.relativedelta import relativedelta
+
+from odoo.tests import Form, tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestAccountMove(AccountTestInvoicingCommon):
+    def test_draft_not_readonly(self):
+        """VAT settlement date is not readonly when invoice is in draft."""
+        # Arrange
+        bill = self.init_invoice(
+            "in_invoice",
+            invoice_date=datetime.date(2020, 1, 1),
+            amounts=[
+                100,
+            ],
+        )
+        settlement_date = bill.invoice_date + relativedelta(days=1)
+        # pre-condition
+        self.assertEqual(bill.state, "draft")
+
+        # Act
+        with Form(bill) as bill_form:
+            bill_form.l10n_it_vat_settlement_date = settlement_date
+
+        # Assert
+        self.assertEqual(bill.l10n_it_vat_settlement_date, settlement_date)
+
+    def test_posted_readonly(self):
+        """VAT settlement date is readonly when invoice is posted."""
+        # Arrange
+        bill = self.init_invoice(
+            "in_invoice",
+            invoice_date=datetime.date(2020, 1, 1),
+            amounts=[
+                100,
+            ],
+            post=True,
+        )
+        settlement_date = bill.invoice_date + relativedelta(days=1)
+        # pre-condition
+        self.assertEqual(bill.state, "posted")
+
+        # Act
+        with self.assertRaises(AssertionError) as ae:
+            with Form(bill) as bill_form:
+                bill_form.l10n_it_vat_settlement_date = settlement_date
+
+        # Assert
+        exc_message = ae.exception.args[0]
+        self.assertIn("readonly field", exc_message)
+        self.assertIn("l10n_it_vat_settlement_date", exc_message)
+        self.assertNotEqual(bill.l10n_it_vat_settlement_date, settlement_date)


### PR DESCRIPTION
Implementa https://github.com/OCA/l10n-italy/issues/4513 per `16.0`.