### PR TITLE
[14.0][FIX] l10n_it_declaration_of_intent: force declaration field migration

### DIFF
--- a/l10n_it_declaration_of_intent/hooks.py
+++ b/l10n_it_declaration_of_intent/hooks.py
@@ -143,6 +143,7 @@ WHERE
     aml.move_id = am.id
     AND aml.tax_line_id IS NULL
     AND aml.account_id <> ai.account_id
+    AND ail.name=aml.name
     AND ail.quantity = aml.quantity
     AND ((ail.product_id IS NULL AND aml.product_id IS NULL)
         OR ail.product_id = aml.product_id)


### PR DESCRIPTION
Se le righe fattura contengono solo la descrizione e non sono associate ad alcun prodotto, la migrazione dei valori del campo `force_declaration_of_intent_id` non viene effettuata correttamente.

Questa PR corregge il problema.