### PR TITLE
[16.0] [FIX] l10n_it_account_stamp: messaggio errato dopo applicazione bollo + reimposta a bozza modifica l'addebito del bollo

### DIFF
--- a/l10n_it_account_stamp/README.rst
+++ b/l10n_it_account_stamp/README.rst
@@ -144,12 +144,15 @@ Authors
 Contributors
 ------------
 
--  Lorenzo Battistini <https://github.com/eLBati>
+-  Lorenzo Battistini
+   <`https://github.com/eLBati <https://github.com/eLBati>`__>
 -  Sergio Corato
 -  Ermanno Gnan
 -  Enrico Ganzaroli
--  Sergio Zanchetta <https://github.com/primes2h>
--  Marco Colombo <https://github.com/TheMule71>
+-  Sergio Zanchetta
+   <`https://github.com/primes2h <https://github.com/primes2h>`__>
+-  Marco Colombo
+   <`https://github.com/TheMule71 <https://github.com/TheMule71>`__>
 -  Gianmarco Conte <gconte@dinamicheaziendali.it>
 -  Giovanni Serra <giovanni@gslab.it>
 -  `Aion Tech <https://aiontech.company/>`__:

--- a/l10n_it_account_stamp/__manifest__.py
+++ b/l10n_it_account_stamp/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "ITA - Imposta di bollo",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "category": "Localization/Italy",
     "summary": "Gestione automatica dell'imposta di bollo",
     "author": "Ermanno Gnan, Sergio Corato, Enrico Ganzaroli, "

--- a/l10n_it_account_stamp/migrations/16.0.1.2.0/post-migration.py
+++ b/l10n_it_account_stamp/migrations/16.0.1.2.0/post-migration.py
@@ -1,0 +1,17 @@
+#  Copyright 2025 Sergio Zanchetta
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move_line aml
+        SET
+           is_stamp_line = NULL
+        WHERE aml.product_id IS NOT NULL AND aml.is_stamp_line = True
+        """,
+    )

--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -14,9 +14,9 @@ class AccountMove(models.Model):
         compute="_compute_tax_stamp",
         store=True,
     )
-    tax_stamp_line_present = fields.Boolean(
+    tax_stamp_invoice_line_present = fields.Boolean(
         string="Stamp line is present in invoice",
-        compute="_compute_tax_stamp_line_present",
+        compute="_compute_tax_stamp_invoice_line_present",
     )
     auto_compute_stamp = fields.Boolean(
         related="company_id.tax_stamp_product_id.auto_compute"
@@ -60,7 +60,7 @@ class AccountMove(models.Model):
                 if invoice.manually_apply_tax_stamp:
                     invoice.tax_stamp = True
 
-    def add_tax_stamp_line(self):
+    def add_tax_stamp_invoice_line(self):
         for inv in self:
             if not inv.tax_stamp:
                 raise UserError(_("Tax stamp is not applicable"))
@@ -84,7 +84,6 @@ class AccountMove(models.Model):
             invoice_line_vals = {
                 "move_id": inv.id,
                 "product_id": stamp_product_id.id,
-                "is_stamp_line": True,
                 "name": stamp_product_id.description_sale,
                 "sequence": 99999,
                 "account_id": stamp_account.id,
@@ -108,9 +107,11 @@ class AccountMove(models.Model):
         "invoice_line_ids.product_id",
         "invoice_line_ids.product_id.is_stamp",
     )
-    def _compute_tax_stamp_line_present(self):
+    def _compute_tax_stamp_invoice_line_present(self):
         for invoice in self:
-            invoice.tax_stamp_line_present = invoice.is_tax_stamp_product_present()
+            invoice.tax_stamp_invoice_line_present = (
+                invoice.is_tax_stamp_product_present()
+            )
 
     def is_tax_stamp_product_present(self):
         product_stamp = self.invoice_line_ids.filtered(

--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -110,7 +110,7 @@ class AccountMove(models.Model):
     )
     def _compute_tax_stamp_line_present(self):
         for invoice in self:
-            invoice.tax_stamp_line_present = invoice.is_tax_stamp_line_present()
+            invoice.tax_stamp_line_present = invoice.is_tax_stamp_product_present()
 
     def is_tax_stamp_product_present(self):
         product_stamp = self.invoice_line_ids.filtered(

--- a/l10n_it_account_stamp/static/description/index.html
+++ b/l10n_it_account_stamp/static/description/index.html
@@ -479,12 +479,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
-<li>Lorenzo Battistini &lt;<a class="reference external" href="https://github.com/eLBati">https://github.com/eLBati</a>&gt;</li>
+<li>Lorenzo Battistini
+&lt;<a class="reference external" href="https://github.com/eLBati">https://github.com/eLBati</a>&gt;</li>
 <li>Sergio Corato</li>
 <li>Ermanno Gnan</li>
 <li>Enrico Ganzaroli</li>
-<li>Sergio Zanchetta &lt;<a class="reference external" href="https://github.com/primes2h">https://github.com/primes2h</a>&gt;</li>
-<li>Marco Colombo &lt;<a class="reference external" href="https://github.com/TheMule71">https://github.com/TheMule71</a>&gt;</li>
+<li>Sergio Zanchetta
+&lt;<a class="reference external" href="https://github.com/primes2h">https://github.com/primes2h</a>&gt;</li>
+<li>Marco Colombo
+&lt;<a class="reference external" href="https://github.com/TheMule71">https://github.com/TheMule71</a>&gt;</li>
 <li>Gianmarco Conte &lt;<a class="reference external" href="mailto:gconte&#64;dinamicheaziendali.it">gconte&#64;dinamicheaziendali.it</a>&gt;</li>
 <li>Giovanni Serra &lt;<a class="reference external" href="mailto:giovanni&#64;gslab.it">giovanni&#64;gslab.it</a>&gt;</li>
 <li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>

--- a/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
+++ b/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
@@ -84,7 +84,7 @@ class InvoicingTest(TestAccountInvoiceReport):
         invoice.action_post()
 
         # Add stamp and check that edited description is kept
-        invoice.add_tax_stamp_line()
+        invoice.add_tax_stamp_invoice_line()
         self.assertEqual(invoice.invoice_line_ids[0].name, edited_descr)
 
     def test_amount_total_changing_currency(self):
@@ -102,27 +102,25 @@ class InvoicingTest(TestAccountInvoiceReport):
         invoice.action_post()
         self.assertEqual(total, invoice.amount_total)
 
-    def test_tax_stamp_line_button(self):
-        """Stamp fields show when stamp is added with the button to the invoice."""
-        # Arrange: Create an invoice eligible for tax stamp but without it
-        stamp_tax = self.tax_id
-        invoice = self.init_invoice(
-            "out_invoice",
-            taxes=stamp_tax,
-            amounts=[
-                100,
-            ],
+    def test_reset_invoice_to_draft(self):
+        """Reset an invoice to draft and check that relative tax stamp accounting lines
+        has been deleted."""
+        invoice = first(
+            self.invoices.filtered(lambda inv: inv.move_type == "out_invoice")
         )
-        # pre-condition
-        self.assertTrue(invoice.tax_stamp)
-        self.assertFalse(invoice.tax_stamp_line_present)
 
-        # Act
-        invoice.add_tax_stamp_line()
+        self.assertEqual(len(invoice), 1)
+        self.assertEqual(len(invoice.invoice_line_ids), 2)
 
-        # Assert
-        self.assertTrue(invoice.tax_stamp_line_present)
+        invoice.invoice_line_ids[0].write({"tax_ids": [(6, 0, [self.tax_id.id])]})
+        invoice.action_post()
 
-        # Resetting to draft removes the stamp
+        self.assertEqual(
+            len(invoice.line_ids.filtered(lambda line: line.is_stamp_line)), 2
+        )
+
         invoice.button_draft()
-        self.assertFalse(invoice.tax_stamp_line_present)
+
+        self.assertEqual(
+            len(invoice.line_ids.filtered(lambda line: line.is_stamp_line)), 0
+        )

--- a/l10n_it_account_stamp/views/account_move_view.xml
+++ b/l10n_it_account_stamp/views/account_move_view.xml
@@ -27,7 +27,7 @@
                     name="manually_apply_tax_stamp"
                     attrs="{'invisible': [('auto_compute_stamp', '=', True)]}"
                 />
-                <field name="tax_stamp_line_present" invisible="1" />
+                <field name="tax_stamp_invoice_line_present" invisible="1" />
             </xpath>
             <field name="narration" position="before">
                 <div
@@ -40,13 +40,13 @@
                         alt="Tax stamp"
                     />
                     <span
-                        attrs="{'invisible': [('tax_stamp_line_present', '=', True)]}"
+                        attrs="{'invisible': [('tax_stamp_invoice_line_present', '=', True)]}"
                     >
                         <span attrs="{'invisible': [('state', 'not in', 'draft')]}">
                             <button
                                 type="object"
                                 string="Charge stamp to customer"
-                                name="add_tax_stamp_line"
+                                name="add_tax_stamp_invoice_line"
                             />
                         </span>
                         <span attrs="{'invisible': [('state', '=', 'draft')]}">
@@ -54,7 +54,7 @@
                         </span>
                     </span>
                     <span
-                        attrs="{'invisible': [('tax_stamp_line_present', '=', False)]}"
+                        attrs="{'invisible': [('tax_stamp_invoice_line_present', '=', False)]}"
                     >
                         Stamp charged to customer
                     </span>


### PR DESCRIPTION
Risolve #4528 per 16.0.

Vedi anche https://github.com/OCA/l10n-italy/pull/4414#issuecomment-2574036435 e relativa review della PR.