### PR TITLE
[18.0] [FIX] l10n_it_account_stamp: messaggio errato dopo applicazione bollo + reimposta a bozza modifica l'addebito del bollo

### DIFF
--- a/l10n_it_account_stamp/README.rst
+++ b/l10n_it_account_stamp/README.rst
@@ -57,20 +57,20 @@ necessario abilitare le funzioni complete per la contabilità:
 
 Modalità automatica:
 
-- andare sul prodotto "Imposta di bollo 2 euro" e configurare "Imposte
-  per bollo" (Imposte in esenzione).
-- per ciascuna fattura o ricevuta, l'applicabilità dell'imposta di bollo
-  verrà calcolata in modo automatico in base alla somma degli imponibili
-  relativi alle imposte selezionate.
+-  andare sul prodotto "Imposta di bollo 2 euro" e configurare "Imposte
+   per bollo" (Imposte in esenzione).
+-  per ciascuna fattura o ricevuta, l'applicabilità dell'imposta di
+   bollo verrà calcolata in modo automatico in base alla somma degli
+   imponibili relativi alle imposte selezionate.
 
 Modalità manuale:
 
-- andare sul prodotto "Imposta di bollo 2 euro" e deselezionare la
-  casella "Calcolo automatico".
-- per ciascuna fattura o ricevuta, abilitare manualmente la casella di
-  selezione "Imposta di bollo". L'applicabilità dell'imposta di bollo
-  verrà calcolata in base alla somma degli imponibili relativi alle
-  imposte selezionate.
+-  andare sul prodotto "Imposta di bollo 2 euro" e deselezionare la
+   casella "Calcolo automatico".
+-  per ciascuna fattura o ricevuta, abilitare manualmente la casella di
+   selezione "Imposta di bollo". L'applicabilità dell'imposta di bollo
+   verrà calcolata in base alla somma degli imponibili relativi alle
+   imposte selezionate.
 
 Impostare i conti di ricavo/costo nella scheda "Contabilità",
 generalmente ricavo="Debiti per bolli" e costo="Valori bollati".
@@ -86,17 +86,17 @@ accounting features:
 
 Automatic mode:
 
-- Go to 'Stamp duty 2 euro' product and configure 'Stamp taxes'
-  (exemption taxes).
-- For each invoice or receipt, the base amount for each selected tax
-  will be added up and used to determine the application of the account
-  stamp.
+-  Go to 'Stamp duty 2 euro' product and configure 'Stamp taxes'
+   (exemption taxes).
+-  For each invoice or receipt, the base amount for each selected tax
+   will be added up and used to determine the application of the account
+   stamp.
 
 Manual mode:
 
-- Go to 'Stamp duty 2 euro' product and deselect 'Auto-compute'
-  checkbox.
-- For each invoice or receipt, manually enable 'Stamp Duty' checkbox.
+-  Go to 'Stamp duty 2 euro' product and deselect 'Auto-compute'
+   checkbox.
+-  For each invoice or receipt, manually enable 'Stamp Duty' checkbox.
 
 Also set income/expense accounts, typically income = 'Debiti per bolli'
 and expense = 'Valori bollati'.
@@ -157,17 +157,20 @@ Authors
 Contributors
 ------------
 
-- Lorenzo Battistini <https://github.com/eLBati>
-- Sergio Corato
-- Ermanno Gnan
-- Enrico Ganzaroli
-- Sergio Zanchetta <https://github.com/primes2h>
-- Marco Colombo <https://github.com/TheMule71>
-- Gianmarco Conte <gconte@dinamicheaziendali.it>
-- Giovanni Serra <giovanni@gslab.it>
-- `Aion Tech <https://aiontech.company/>`__:
+-  Lorenzo Battistini
+   <`https://github.com/eLBati <https://github.com/eLBati>`__>
+-  Sergio Corato
+-  Ermanno Gnan
+-  Enrico Ganzaroli
+-  Sergio Zanchetta
+   <`https://github.com/primes2h <https://github.com/primes2h>`__>
+-  Marco Colombo
+   <`https://github.com/TheMule71 <https://github.com/TheMule71>`__>
+-  Gianmarco Conte <gconte@dinamicheaziendali.it>
+-  Giovanni Serra <giovanni@gslab.it>
+-  `Aion Tech <https://aiontech.company/>`__:
 
-  - Simone Rubino <simone.rubino@aion-tech.it>
+   -  Simone Rubino <simone.rubino@aion-tech.it>
 
 Maintainers
 -----------

--- a/l10n_it_account_stamp/__manifest__.py
+++ b/l10n_it_account_stamp/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "ITA - Imposta di bollo",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Localization/Italy",
     "summary": "Gestione automatica dell'imposta di bollo",
     "author": "Ermanno Gnan, Sergio Corato, Enrico Ganzaroli, "

--- a/l10n_it_account_stamp/migrations/18.0.1.1.0/post-migration.py
+++ b/l10n_it_account_stamp/migrations/18.0.1.1.0/post-migration.py
@@ -1,0 +1,17 @@
+#  Copyright 2025 Sergio Zanchetta
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move_line aml
+        SET
+           is_stamp_line = NULL
+        WHERE aml.product_id IS NOT NULL AND aml.is_stamp_line = True
+        """,
+    )

--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -15,9 +15,9 @@ class AccountMove(models.Model):
         compute="_compute_l10n_it_account_stamp_is_stamp_duty_applied",
         store=True,
     )
-    l10n_it_account_stamp_is_stamp_duty_present = fields.Boolean(
+    l10n_it_account_stamp_is_stamp_duty_invoice_line_present = fields.Boolean(
         string="Stamp line is present in invoice",
-        compute="_compute_l10n_it_account_stamp_is_stamp_duty_present",
+        compute="_compute_l10n_it_account_stamp_is_stamp_duty_invoice_line_present",
     )
     l10n_it_account_stamp_auto_compute_stamp_duty = fields.Boolean(
         related="company_id.l10n_it_account_stamp_stamp_duty_product_id.l10n_it_account_stamp_auto_compute",
@@ -70,7 +70,7 @@ class AccountMove(models.Model):
                 if invoice.l10n_it_account_stamp_manually_apply_stamp_duty:
                     invoice.l10n_it_account_stamp_is_stamp_duty_applied = True
 
-    def add_stamp_duty_line(self):
+    def add_stamp_duty_invoice_line(self):
         for inv in self:
             if not inv.l10n_it_account_stamp_is_stamp_duty_applied:
                 raise UserError(_("Stamp duty is not applicable"))
@@ -94,7 +94,6 @@ class AccountMove(models.Model):
             invoice_line_vals = {
                 "move_id": inv.id,
                 "product_id": stamp_product_id.id,
-                "is_stamp_line": True,
                 "name": stamp_product_id.description_sale,
                 "sequence": 99999,
                 "account_id": stamp_account.id,
@@ -118,9 +117,9 @@ class AccountMove(models.Model):
         "invoice_line_ids.product_id",
         "invoice_line_ids.product_id.l10n_it_account_stamp_is_stamp",
     )
-    def _compute_l10n_it_account_stamp_is_stamp_duty_present(self):
+    def _compute_l10n_it_account_stamp_is_stamp_duty_invoice_line_present(self):
         for invoice in self:
-            invoice.l10n_it_account_stamp_is_stamp_duty_present = (
+            invoice.l10n_it_account_stamp_is_stamp_duty_invoice_line_present = (
                 invoice.is_stamp_duty_product_present()
             )
 

--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -121,7 +121,7 @@ class AccountMove(models.Model):
     def _compute_l10n_it_account_stamp_is_stamp_duty_present(self):
         for invoice in self:
             invoice.l10n_it_account_stamp_is_stamp_duty_present = (
-                invoice.is_stamp_duty_line_present()
+                invoice.is_stamp_duty_product_present()
             )
 
     def is_stamp_duty_product_present(self):

--- a/l10n_it_account_stamp/static/description/index.html
+++ b/l10n_it_account_stamp/static/description/index.html
@@ -405,9 +405,9 @@ selezionarlo</li>
 <ul class="simple">
 <li>andare sul prodotto “Imposta di bollo 2 euro” e configurare “Imposte
 per bollo” (Imposte in esenzione).</li>
-<li>per ciascuna fattura o ricevuta, l’applicabilità dell’imposta di bollo
-verrà calcolata in modo automatico in base alla somma degli imponibili
-relativi alle imposte selezionate.</li>
+<li>per ciascuna fattura o ricevuta, l’applicabilità dell’imposta di
+bollo verrà calcolata in modo automatico in base alla somma degli
+imponibili relativi alle imposte selezionate.</li>
 </ul>
 <p>Modalità manuale:</p>
 <ul class="simple">
@@ -489,12 +489,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
-<li>Lorenzo Battistini &lt;<a class="reference external" href="https://github.com/eLBati">https://github.com/eLBati</a>&gt;</li>
+<li>Lorenzo Battistini
+&lt;<a class="reference external" href="https://github.com/eLBati">https://github.com/eLBati</a>&gt;</li>
 <li>Sergio Corato</li>
 <li>Ermanno Gnan</li>
 <li>Enrico Ganzaroli</li>
-<li>Sergio Zanchetta &lt;<a class="reference external" href="https://github.com/primes2h">https://github.com/primes2h</a>&gt;</li>
-<li>Marco Colombo &lt;<a class="reference external" href="https://github.com/TheMule71">https://github.com/TheMule71</a>&gt;</li>
+<li>Sergio Zanchetta
+&lt;<a class="reference external" href="https://github.com/primes2h">https://github.com/primes2h</a>&gt;</li>
+<li>Marco Colombo
+&lt;<a class="reference external" href="https://github.com/TheMule71">https://github.com/TheMule71</a>&gt;</li>
 <li>Gianmarco Conte &lt;<a class="reference external" href="mailto:gconte&#64;dinamicheaziendali.it">gconte&#64;dinamicheaziendali.it</a>&gt;</li>
 <li>Giovanni Serra &lt;<a class="reference external" href="mailto:giovanni&#64;gslab.it">giovanni&#64;gslab.it</a>&gt;</li>
 <li><a class="reference external" href="https://aiontech.company/">Aion Tech</a>:<ul>

--- a/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
+++ b/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
@@ -87,7 +87,7 @@ class InvoicingTest(TestAccountInvoiceReport):
 
         # Add stamp and check that edited description is kept
         invoice.button_draft()
-        invoice.add_stamp_duty_line()
+        invoice.add_stamp_duty_invoice_line()
         self.assertEqual(invoice.invoice_line_ids[0].name, edited_descr)
 
     def test_amount_total_changing_currency(self):
@@ -108,28 +108,25 @@ class InvoicingTest(TestAccountInvoiceReport):
         invoice.action_post()
         self.assertEqual(total, invoice.amount_total)
 
-    def test_stamp_duty_line_button(self):
-        """Stamp fields show when stamp is added with the button to the invoice."""
-        # Arrange: Create an invoice eligible for stamp duty but without it
-        stamp_tax = self.tax_id
-        invoice = self.init_invoice(
-            "out_invoice",
-            taxes=stamp_tax,
-            amounts=[
-                100,
-            ],
+    def test_reset_invoice_to_draft(self):
+        """Reset an invoice to draft and check that relative tax stamp accounting lines
+        has been deleted."""
+        invoice = first(
+            self.invoices.filtered(lambda inv: inv.move_type == "out_invoice")
         )
-        # pre-condition
-        self.assertTrue(invoice.l10n_it_account_stamp_is_stamp_duty_applied)
-        self.assertFalse(invoice.l10n_it_account_stamp_is_stamp_duty_present)
 
-        # Act
-        invoice.add_stamp_duty_line()
+        self.assertEqual(len(invoice), 1)
+        self.assertEqual(len(invoice.invoice_line_ids), 2)
+
+        invoice.invoice_line_ids[0].write({"tax_ids": [(6, 0, [self.tax_id.id])]})
         invoice.action_post()
 
-        # Assert
-        self.assertTrue(invoice.l10n_it_account_stamp_is_stamp_duty_present)
+        self.assertEqual(
+            len(invoice.line_ids.filtered(lambda line: line.is_stamp_line)), 2
+        )
 
-        # Resetting to draft removes the stamp
         invoice.button_draft()
-        self.assertFalse(invoice.l10n_it_account_stamp_is_stamp_duty_present)
+
+        self.assertEqual(
+            len(invoice.line_ids.filtered(lambda line: line.is_stamp_line)), 0
+        )

--- a/l10n_it_account_stamp/views/account_move_view.xml
+++ b/l10n_it_account_stamp/views/account_move_view.xml
@@ -34,7 +34,7 @@
                     invisible="l10n_it_account_stamp_auto_compute_stamp_duty"
                 />
                 <field
-                    name="l10n_it_account_stamp_is_stamp_duty_present"
+                    name="l10n_it_account_stamp_is_stamp_duty_invoice_line_present"
                     invisible="1"
                 />
             </xpath>
@@ -48,19 +48,23 @@
                         src="/l10n_it_account_stamp/static/description/icon.png"
                         alt="Stamp Duty"
                     />
-                    <span invisible="l10n_it_account_stamp_is_stamp_duty_present">
+                    <span
+                        invisible="l10n_it_account_stamp_is_stamp_duty_invoice_line_present"
+                    >
                         <span invisible="state != 'draft'">
                             <button
                                 type="object"
                                 string="Charge stamp to customer"
-                                name="add_stamp_duty_line"
+                                name="add_stamp_duty_invoice_line"
                             />
                         </span>
                         <span invisible="state == 'draft'">
                             Stamp can only be charged to customer when invoice is in draft state
                         </span>
                     </span>
-                    <span invisible="not l10n_it_account_stamp_is_stamp_duty_present">
+                    <span
+                        invisible="not l10n_it_account_stamp_is_stamp_duty_invoice_line_present"
+                    >
                         Stamp charged to customer
                     </span>
                 </div>


### PR DESCRIPTION
Risolve #4528 per 18.0.

Vedi anche https://github.com/OCA/l10n-italy/pull/4414#issuecomment-2574036435 e relativa review della PR.