### PR TITLE
[16.0][IMP]l10n_it_riba: improvements for is_past_due field

### DIFF
--- a/l10n_it_riba/models/account.py
+++ b/l10n_it_riba/models/account.py
@@ -347,6 +347,7 @@ class AccountMove(models.Model):
                 invoice._sync_dynamic_lines(
                     container={"records": invoice, "self": invoice}
                 )
+            invoice.is_past_due = False
         return invoice
 
     def get_due_cost_line_ids(self):

--- a/l10n_it_riba/views/account_view.xml
+++ b/l10n_it_riba/views/account_view.xml
@@ -149,6 +149,9 @@
                     attrs="{'invisible': ['|',('is_riba_payment','=', False),('move_type','!=','out_invoice')], 'required': ['&amp;',('is_riba_payment','=', True),('move_type','=', 'out_invoice')]}"
                     domain="[('partner_id','=', commercial_partner_id)]"
                 />
+            </xpath>
+
+            <xpath expr="//label[@for='invoice_payment_term_id']" position="before">
                 <field
                     name="riba_supplier_company_bank_id"
                     attrs="{


### PR DESCRIPTION
- Changed placement to see the label better
- When a invoice is duplicated the field is set to false. This behavior that was not present before this commit
#4460 