### PR TITLE
[14.0][FIX] l10n_it_central_journal_reportlab: escape Paragraph content

### DIFF
--- a/l10n_it_central_journal_reportlab/wizard/print_giornale.py
+++ b/l10n_it_central_journal_reportlab/wizard/print_giornale.py
@@ -3,6 +3,7 @@
 import base64
 import io
 from datetime import timedelta
+from xml.sax.saxutils import escape
 
 from reportlab.lib import colors
 from reportlab.lib.enums import TA_RIGHT
@@ -310,8 +311,12 @@ class WizardGiornaleReportlab(models.TransientModel):
                 "",
                 "",
                 Paragraph(_("Initial Balance"), style_name),
-                Paragraph(formatLang(self.env, self.progressive_debit2), style_number),
-                Paragraph(formatLang(self.env, self.progressive_credit), style_number),
+                Paragraph(
+                    escape(formatLang(self.env, self.progressive_debit2)), style_number
+                ),
+                Paragraph(
+                    escape(formatLang(self.env, self.progressive_credit)), style_number
+                ),
             ]
         ]
         return initial_balance_data
@@ -334,27 +339,31 @@ class WizardGiornaleReportlab(models.TransientModel):
         ]
         for line in list_grupped_line:
             start_row += 1
-            row = Paragraph(str(start_row), style_name)
-            date = Paragraph(format_date(self.env, line["date"]), style_name)
-            move = Paragraph(line["move_name"], style_name)
+            row = Paragraph(escape(str(start_row)), style_name)
+            date = Paragraph(escape(format_date(self.env, line["date"])), style_name)
+            move = Paragraph(escape(line["move_name"]), style_name)
             account_name = (
                 line["account_code"] + " - " + line["account_name"]
                 if line["account_code"]
                 else line["account_name"]
             )
-            account = Paragraph(account_name, style_name)
-            name = Paragraph(line["name"], style_name)
+            account = Paragraph(escape(account_name), style_name)
+            name = Paragraph(escape(line["name"]), style_name)
             # dato che nel SQL ho la somma dei crediti e debiti potrei avere
             # che un conto ha sia debito che credito
             lines_data = []
             if line["debit"] > 0:
-                debit = Paragraph(formatLang(self.env, line["debit"]), style_number)
-                credit = Paragraph(formatLang(self.env, 0), style_number)
+                debit = Paragraph(
+                    escape(formatLang(self.env, line["debit"])), style_number
+                )
+                credit = Paragraph(escape(formatLang(self.env, 0)), style_number)
                 list_balance.append((line["debit"], 0))
                 lines_data.append([[row, date, move, account, name, debit, credit]])
             if line["credit"] > 0:
-                debit = Paragraph(formatLang(self.env, 0), style_number)
-                credit = Paragraph(formatLang(self.env, line["credit"]), style_number)
+                debit = Paragraph(escape(formatLang(self.env, 0)), style_number)
+                credit = Paragraph(
+                    escape(formatLang(self.env, line["credit"])), style_number
+                )
                 list_balance.append((0, line["credit"]))
                 lines_data.append([[row, date, move, account, name, debit, credit]])
             for line_data in lines_data:
@@ -390,19 +399,19 @@ class WizardGiornaleReportlab(models.TransientModel):
 
         for line in self.env["account.move.line"].browse(move_line_ids):
             start_row += 1
-            row = Paragraph(str(start_row), style_name)
-            date = Paragraph(format_date(self.env, line.date), style_name)
-            ref = Paragraph(str(line.ref or ""), style_name)
+            row = Paragraph(escape(str(start_row)), style_name)
+            date = Paragraph(escape(format_date(self.env, line.date)), style_name)
+            ref = Paragraph(escape(str(line.ref or "")), style_name)
             move_name = line.move_id.name or ""
-            move = Paragraph(move_name, style_name)
+            move = Paragraph(escape(move_name), style_name)
             account_name = self._get_account_name_reportlab(line)
-            account = Paragraph(account_name, style_name)
+            account = Paragraph(escape(account_name), style_name)
             if line.account_id.user_type_id.type in ["receivable", "payable"]:
-                name = Paragraph(str(line.partner_id.name or ""), style_name)
+                name = Paragraph(escape(str(line.partner_id.name or "")), style_name)
             else:
-                name = Paragraph(str(line.name or ""), style_name)
-            debit = Paragraph(formatLang(self.env, line.debit), style_number)
-            credit = Paragraph(formatLang(self.env, line.credit), style_number)
+                name = Paragraph(escape(str(line.name or "")), style_name)
+            debit = Paragraph(escape(formatLang(self.env, line.debit)), style_number)
+            credit = Paragraph(escape(formatLang(self.env, line.credit)), style_number)
             list_balance.append((line.debit, line.credit))
             line_data = [[row, date, ref, move, account, name, debit, credit]]
             if previous_move_name != move_name:
@@ -431,8 +440,8 @@ class WizardGiornaleReportlab(models.TransientModel):
                 "",
                 "",
                 name,
-                Paragraph(formatLang(self.env, tot_debit), style_number),
-                Paragraph(formatLang(self.env, tot_credit), style_number),
+                Paragraph(escape(formatLang(self.env, tot_debit)), style_number),
+                Paragraph(escape(formatLang(self.env, tot_credit)), style_number),
             ]
         ]
         return balance_data


### PR DESCRIPTION
Backporting di #4400 

Paragraph() prende un simil-HTML, un markup con varie direttive tipo <para> ecc.

passandogli dei dati, meglio fare l'escape di tutto.

Fixes: #4396
Fixes: #4153