### PR TITLE
[FIX] l10n_it_intrastat_statement: progressive_to_modify_id is not used

### DIFF
--- a/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section4.py
+++ b/l10n_it_intrastat_statement/models/intrastat_statement_purchase_section4.py
@@ -19,10 +19,6 @@ class IntrastatStatementPurchaseSection4(models.Model):
     quarterly = fields.Integer(string="Ref. Quarter")
     year_id = fields.Integer(string="Ref. Year")
     protocol = fields.Integer(string="Protocol Number")
-    progressive_to_modify_id = fields.Many2one(
-        comodel_name="account.intrastat.statement.purchase.section1",
-        string="Progressive to Adjust ID",
-    )
     progressive_to_modify = fields.Integer(string="Progressive to Adjust")
     invoice_number = fields.Char(string="Invoice Number")
     invoice_date = fields.Date(string="Invoice Date")
@@ -110,7 +106,7 @@ class IntrastatStatementPurchaseSection4(models.Model):
         # Protocollo della dichiarazione da rettificare
         rcd += format_9(self.protocol, 6)
         # Progressivo della sezione 3 da rettificare
-        rcd += format_9(self.progressive_to_modify_id.sequence, 5)
+        rcd += format_9(self.progressive_to_modify, 5)
         # Codice dello Stato membro dell’acquirente
         country_id = self.country_partner_id or self.partner_id.country_id
         rcd += format_x(country_id.code, 2)


### PR DESCRIPTION
Steps:

 - Create a intrastat statement with Purchases Services adjustment - section 4
 - Export file Dogana

File check fails with "Il campo Progressivo Sez. III deve essere maggiore di zero"

Back-port of https://github.com/OCA/l10n-italy/pull/4186.