### PR TITLE
[FIX] l10n_it_delivery_note: name generation

### DIFF
--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -610,6 +610,17 @@ class StockDeliveryNote(models.Model):
 
             if not note.name:
                 note.name = sequence.next_by_id()
+                # Avoid duplicates
+                while True:
+                    name = sequence.with_context(
+                        ir_sequence_date=note.date
+                    ).next_by_id()
+                    if not self.search(
+                        [("name", "=", name), ("company_id", "=", note.company_id.id)]
+                    ):
+                        break
+
+                note.name = name
                 note.sequence_id = sequence
 
     def action_confirm(self):


### PR DESCRIPTION
Keep generating name with sequence number until one is available.
FW-port of https://github.com/OCA/l10n-italy/pull/4052.

Fixes: #4053 #3094  