### PR TITLE
[FIX] l10n_it_intrastat country destination visible in out refund too

### DIFF
--- a/l10n_it_intrastat/views/account.xml
+++ b/l10n_it_intrastat/views/account.xml
@@ -134,9 +134,9 @@
                             name="country_destination_id"
                             attrs="{
                                    'invisible': [
-                                       ('statement_section', 'not in', ['sale_s1'])],
+                                       ('statement_section', 'not in', ['sale_s1', 'sale_s2'])],
                                    'required': [
-                                       ('statement_section', 'in', ['sale_s1'])]}"
+                                       ('statement_section', 'in', ['sale_s1', 'sale_s2'])]}"
                         />
                            </group>
 


### PR DESCRIPTION
Fix https://github.com/OCA/l10n-italy/issues/3901 for `16.0`.
FW-port of https://github.com/OCA/l10n-italy/pull/3865.