### PR TITLE
[14.0] [IMP] l10n_it_fatturapa_in: avoid adding rounding lines when import level is not maximum

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1286,7 +1286,15 @@ class WizardImportFatturapa(models.TransientModel):
             invoice.id, FatturaBody.DatiGenerali.DatiGeneraliDocumento
         )
 
-        if self.e_invoice_detail_level != "1":
+        # Avoid set roundings if import level is not maximum, because adding
+        # roundings generate problems:
+        #  - generate a tax line in account.move.line
+        #    entries with different values for amount_currency and balance
+        #    raising ``check_amount_currency_balance_sign`` constraint in
+        #    account.move
+        #  - If rounding line is the only line the import generate a refund
+        #    instead of an invoice
+        if self.e_invoice_detail_level == "2":
             self.set_roundings(FatturaBody, invoice)
 
         # compute the invoice


### PR DESCRIPTION
Adding rounding line when import level is not set as 'maximum' create a refund instead of an invoice