### PR TITLE
[16.0] [FIX] l10n_it_withholding_tax: amount_net_pay_residual calculated incorrectly due to the mixed use of fields

### DIFF
--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -301,7 +301,7 @@ class AccountMove(models.Model):
 
             for line in reconciled_amls:
                 if not line.withholding_tax_generated_by_move_id:
-                    amount_net_pay_residual -= line.debit or line.credit
+                    amount_net_pay_residual -= abs(line.amount_currency)
             invoice.amount_net_pay_residual = float_round(
                 amount_net_pay_residual, dp_obj.precision_get("Account")
             )


### PR DESCRIPTION

Conditions: Invoice posted in USD currency for a company with the main currency in EUR. Invoice is partially reconciled in USD, one invoice line reconciled with 2 journal items:
- one journal items is exchange rates differences
- another item is partial payment

Basically, amount_net_pay_residual is calculated by taking USD amount and subtracting EUR amount, which leads to inconsistency

![image](https://github.com/user-attachments/assets/f3fa14d6-cf38-40c0-a92b-d1c37185cc86)
