### PR TITLE
[16.0] [FIX] fiscal_epos_print: fix not printing fiscal receipt if no order lines

### DIFF
--- a/fiscal_epos_print/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/fiscal_epos_print/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -25,7 +25,11 @@ odoo.define("fiscal_epos_print.PaymentScreen", function (require) {
             }
 
             async sendToFP90Printer(order) {
-                if (this.env.pos.config.printer_ip && !order.is_to_invoice()) {
+                if (
+                    this.env.pos.config.printer_ip &&
+                    !order.is_to_invoice() &&
+                    order.orderlines.length > 0
+                ) {
                     // TODO self.chrome does not exists
                     // this.chrome.loading_show();
                     // this.chrome.loading_message(_t('Connecting to the fiscal printer'));


### PR DESCRIPTION

Issue: https://github.com/OCA/l10n-italy/issues/4586