### PR TITLE
[FIX] l10n_it_delivery_note: fix delivery note invoice assignment by using invoice IDs

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -352,7 +352,9 @@ class StockPicking(models.Model):
             delivery_note = self._create_delivery_note()
             self.write({"delivery_note_id": delivery_note.id})
             if self.sale_id:
-                self.sale_id._assign_delivery_notes_invoices(self.sale_id.invoice_ids)
+                self.sale_id._assign_delivery_notes_invoices(
+                    self.sale_id.invoice_ids.ids
+                )
         return res
 
     def _create_delivery_note(self):

--- a/l10n_it_delivery_note/wizard/delivery_note_create.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_create.py
@@ -129,7 +129,7 @@ class StockDeliveryNoteCreateWizard(models.TransientModel):
 
         self.selected_picking_ids.write({"delivery_note_id": delivery_note.id})
         if sale_order_id:
-            sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids)
+            sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids.ids)
 
         if self.user_has_groups("l10n_it_delivery_note.use_advanced_delivery_notes"):
             return delivery_note.goto()

--- a/l10n_it_delivery_note/wizard/delivery_note_select.py
+++ b/l10n_it_delivery_note/wizard/delivery_note_select.py
@@ -63,7 +63,7 @@ class StockDeliveryNoteSelectWizard(models.TransientModel):
         sale_order_ids = self.selected_picking_ids.sale_id
         sale_order_id = sale_order_ids and sale_order_ids[0] or self.env["sale.order"]
         if sale_order_id:
-            sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids)
+            sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids.ids)
 
         if self.user_has_groups("l10n_it_delivery_note.use_advanced_delivery_notes"):
             return self.delivery_note_id.goto()


### PR DESCRIPTION
Fix Mixing apples and oranges.



File "/opt/odoo/custom/oca/l10n-italy/l10n_it_delivery_note/wizard/delivery_note_create.py", line 132, in confirm
    sale_order_id._assign_delivery_notes_invoices(sale_order_id.invoice_ids)
  File "/opt/odoo/custom/oca/l10n-italy/l10n_it_delivery_note/models/sale_order.py", line 92, in _assign_delivery_notes_invoices
    ready_invoice_ids = [
  File "/opt/odoo/custom/oca/l10n-italy/l10n_it_delivery_note/models/sale_order.py", line 95, in <listcomp>
    if invoice_id in invoice_ids
  File "/usr/lib/python3/dist-packages/odoo/models.py", line 5601, in contains
    raise TypeError("Mixing apples and oranges: %s in %s" % (item, self))
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 652, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: Mixing apples and oranges: 899717 in account.move(899717,)