### PR TITLE
[16.0] [FIX] l10n_it_account_stamp: stamp lines migration

### DIFF
--- a/l10n_it_account_stamp/migrations/16.0.1.0.0/pre-migration.py
+++ b/l10n_it_account_stamp/migrations/16.0.1.0.0/pre-migration.py
@@ -1,0 +1,18 @@
+#  Copyright 2025 Sergio Zanchetta
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move_line
+        SET
+            display_type = 'cogs'
+        WHERE
+            is_stamp_line = True;
+    """,
+    )


### PR DESCRIPTION
Senza questo script di migrazione nelle righe fattura vengono visualizzate anche le righe di movimento relative al bollo.
Questo perché nella 16.0 il campo `display_type` viene valorizzato in modo predefinito con `product`.
Vedi anche https://github.com/OCA/l10n-italy/pull/3021#issue-1444093842

Dipende da https://github.com/OCA/l10n-italy/pull/4529.

Per la migrazione da versioni precedenti dipende anche da https://github.com/OCA/l10n-italy/pull/4597

![immagine](https://github.com/user-attachments/assets/d2552060-a222-4ad0-a5bd-a7bd5419347a)


