### PR TITLE
[FIX] fiscal_epos_print:  new order lines not saved when changing table on Point of sale when restaurant tables are enabled

### DIFF
--- a/fiscal_epos_print/static/src/js/models.js
+++ b/fiscal_epos_print/static/src/js/models.js
@@ -87,10 +87,9 @@ odoo.define("fiscal_epos_print.models", function (require) {
                 var order = this.pos.get_order();
                 if (order) {
                     var lines = order.orderlines;
-                    order.has_refund =
-                        lines.find(function (line) {
-                            return line.quantity < 0.0;
-                        }) !== undefined;
+                    order.has_refund = lines.some(function (line) {
+                        return line.quantity < 0.0;
+                    });
                     if (order.has_refund) {
                         order.refund_report = this.name.substr(-4);
                         order.refund_doc_num = this.name.substr(-4);


### PR DESCRIPTION
This PR fixes an issue on Point of sale using tables and restaurant 
It improves also the code using "some" instead of "find"
Fixes https://github.com/OCA/l10n-italy/issues/4624