### PR TITLE
[14.0][IMP] l10n_it_ricevute_bancarie: gestione iban archiviati per RiBa

### DIFF
--- a/l10n_it_ricevute_bancarie/models/account.py
+++ b/l10n_it_ricevute_bancarie/models/account.py
@@ -55,7 +55,7 @@ class ResPartnerBankAdd(models.Model):
 
     def unlink(self):
         self._check_protected_records()
-        return super(ResPartnerBankAdd, self).unlink()
+        return super().unlink()
 
 
 class AccountMove(models.Model):
@@ -395,11 +395,19 @@ class AccountMoveLine(models.Model):
         return res
 
     def action_riba_issue(self):
+        for line in self:
+            if not line.move_id.riba_partner_bank_id.active:
+                raise UserError(
+                    _(
+                        "Non è possibile emettere una riba legata ad un IBAN archiviato;"
+                        " riga: %s , contatto: %s"
+                    )
+                    % (line.name, line.partner_id.name)
+                )
         ctx = dict(self.env.context)
         ctx.pop("active_id", None)
         ctx["active_ids"] = self.ids
         ctx["active_model"] = "account.move.line"
-
         return {
             "type": "ir.actions.act_window",
             "name": "Issue C/O",

--- a/l10n_it_ricevute_bancarie/models/account.py
+++ b/l10n_it_ricevute_bancarie/models/account.py
@@ -38,6 +38,25 @@ class ResPartnerBankAdd(models.Model):
         help="Identification Code of the Company in the Interbank System.",
     )
 
+    def _check_protected_records(self):
+        protected_records = (
+            self.env["account.move"]
+            .search([("riba_partner_bank_id", "in", self.ids)])
+            .mapped("riba_partner_bank_id")
+        )
+        if protected_records:
+            message = _(
+                "The bank accounts with accreditation code "
+                f"{[bank.acc_number for bank in protected_records]}"
+                " cannot be deleted as they are used in invoices."
+                " If possible, archive the bank account"
+            )
+            raise UserError(message)
+
+    def unlink(self):
+        self._check_protected_records()
+        return super(ResPartnerBankAdd, self).unlink()
+
 
 class AccountMove(models.Model):
     _inherit = "account.move"
@@ -283,6 +302,10 @@ class AccountMove(models.Model):
                 )
                 invoice._recompute_tax_lines()
             invoice.is_unsolved = False
+
+            # if the bank account is archived do not allow the use in the new invoice
+            if not invoice.riba_partner_bank_id.active:
+                invoice.riba_partner_bank_id = False
         return invoice
 
     def get_due_cost_line_ids(self):


### PR DESCRIPTION
Solves: https://github.com/OCA/l10n-italy/issues/4618
Superseeds : https://github.com/OCA/l10n-italy/pull/4634
Continuando il lavoro di @toita86. Ho bloccato la possibilità di emettere RibA con conti bancari archiviati .