### PR TITLE
[FIX] l10n_it_sdi_channel, l10n_it_fatturapa_pec: use the stored channel_id on attachment instead of the channel linked to the current company or channel on default company

### DIFF
--- a/l10n_it_fatturapa_pec/models/sdi.py
+++ b/l10n_it_fatturapa_pec/models/sdi.py
@@ -133,8 +133,9 @@ class SdiChannel(models.Model):
         self._check_fetchmail()
         self.check_first_pec_sending()
         user = self.env.user
-        company = user.company_id
         for att in attachment_out_ids:
+            company = att.company_id
+            channel_id = att.channel_id
             if not att.datas or not att.name:
                 raise UserError(_("File content and file name are mandatory"))
             mail_message = self.env["mail.message"].create(
@@ -149,7 +150,7 @@ class SdiChannel(models.Model):
                     "attachment_ids": [(6, 0, att.ir_attachment_id.ids)],
                     "email_from": (company.email_from_for_fatturaPA),
                     "reply_to": (company.email_from_for_fatturaPA),
-                    "mail_server_id": company.sdi_channel_id.pec_server_id.id,
+                    "mail_server_id": channel_id.pec_server_id.id,
                 }
             )
 

--- a/l10n_it_sdi_channel/models/fatturapa_attachment_out.py
+++ b/l10n_it_sdi_channel/models/fatturapa_attachment_out.py
@@ -33,9 +33,11 @@ class FatturaPAAttachmentOut(models.Model):
         states = self.mapped("state")
         if set(states) != {"ready"}:
             raise UserError(_("You can only send files in 'Ready to Send' state."))
+        channel_ids = self.mapped("channel_id")
+        if len(channel_ids) > 1:
+            raise UserError(_("You can only send files with the same channel."))
 
-        company = self.env.company
-        sdi_channel = company.sdi_channel_id
+        sdi_channel = self.channel_id
         send_result = sdi_channel.send(self)
         return send_result
 


### PR DESCRIPTION
Sending the PEC it was used the channel linked to the current company or the channel linked to the company default on user instead of the one already stored on the attachment.out.

fixes https://github.com/OCA/l10n-italy/issues/4643