### PR TITLE
[14.0][IMP] l10n_it_ricevute_bancarie: aggiunta spesa incasso insoluto

### DIFF
--- a/l10n_it_ricevute_bancarie/models/riba_config.py
+++ b/l10n_it_ricevute_bancarie/models/riba_config.py
@@ -83,6 +83,9 @@ class RibaConfiguration(models.Model):
         "Past Due Bills Account",
         check_company=True,
     )
+    past_due_fee_amount = fields.Float(
+        "Past due fee",
+    )
     protest_charge_account_id = fields.Many2one(
         "account.account",
         "Protest Fee Account",
@@ -108,12 +111,11 @@ class RibaConfiguration(models.Model):
 
     def get_default_value_by_list_line(self, field_name):
         if not self.env.context.get("active_id", False):
-            return False
+            return False if field_name != "past_due_fee_amount" else 0.0
         ribalist_line = self.env["riba.distinta.line"].browse(
             self.env.context["active_id"]
         )
-        return (
-            ribalist_line.distinta_id.config_id[field_name]
-            and ribalist_line.distinta_id.config_id[field_name].id
-            or False
-        )
+        config = ribalist_line.distinta_id.config_id
+        if field_name == "past_due_fee_amount":
+            return config.past_due_fee_amount
+        return config[field_name] and config[field_name].id or False

--- a/l10n_it_ricevute_bancarie/tests/test_riba.py
+++ b/l10n_it_ricevute_bancarie/tests/test_riba.py
@@ -233,7 +233,7 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
             .create(
                 {
                     "bank_amount": 455,
-                    "expense_amount": 5,
+                    "past_due_fee_amount": 5,
                 }
             )
         )
@@ -410,7 +410,7 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
             .create(
                 {
                     "bank_amount": 102,
-                    "expense_amount": 2,
+                    "past_due_fee_amount": 2,
                 }
             )
         )
@@ -690,3 +690,34 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         self.assertIn("Cannot post invoices", err_msg)
         self.assertIn(self.invoice.partner_id.display_name, err_msg)
         self.assertIn(str(self.invoice.amount_total), err_msg)
+
+    def test_past_due_fee_amount_flow(self):
+        config = self.env["riba.configuration"].create(
+            {
+                "name": "Test Config",
+                "type": "sbf",
+                "bank_id": self.company_bank.id,
+                "past_due_fee_amount": 15.0,
+            }
+        )
+        self.assertEqual(config.past_due_fee_amount, 15.0)
+
+        distinta = self.env["riba.distinta"].create(
+            {
+                "config_id": config.id,
+                "name": "Test Distinta",
+            }
+        )
+        distinta_line = self.env["riba.distinta.line"].create(
+            {"distinta_id": distinta.id, "amount": 100.0}
+        )
+
+        wizard = (
+            self.env["riba.unsolved"]
+            .with_context(
+                active_model="riba.distinta.line",
+                active_id=distinta_line.id,
+            )
+            .create({})
+        )
+        self.assertEqual(wizard.past_due_fee_amount, 15.0)

--- a/l10n_it_ricevute_bancarie/views/configuration_view.xml
+++ b/l10n_it_ricevute_bancarie/views/configuration_view.xml
@@ -54,6 +54,7 @@
                     <separator colspan="4" string="Past Due" />
                     <group>
                         <field name="unsolved_journal_id" />
+                        <field name="past_due_fee_amount" />
                         <field name="overdue_effects_account_id" />
                         <field name="protest_charge_account_id" />
                     </group>

--- a/l10n_it_ricevute_bancarie/views/wizard_unsolved.xml
+++ b/l10n_it_ricevute_bancarie/views/wizard_unsolved.xml
@@ -21,7 +21,7 @@
                     <field name="bank_account_id" />
                     <field name="bank_amount" />
                     <field name="bank_expense_account_id" />
-                    <field name="expense_amount" />
+                    <field name="past_due_fee_amount" />
                 </group>
                 <footer>
                     <button

--- a/l10n_it_ricevute_bancarie/wizard/wizard_unsolved.py
+++ b/l10n_it_ricevute_bancarie/wizard/wizard_unsolved.py
@@ -18,6 +18,12 @@ class RibaUnsolved(models.TransientModel):
         )
 
     @api.model
+    def _get_unsolved_past_due_fee_amount(self):
+        return self.env["riba.configuration"].get_default_value_by_list_line(
+            "past_due_fee_amount"
+        )
+
+    @api.model
     def _get_effects_account_id(self):
         return self.env["riba.configuration"].get_default_value_by_list_line(
             "acceptance_account_id"
@@ -87,11 +93,20 @@ class RibaUnsolved(models.TransientModel):
         domain=[("internal_type", "=", "liquidity")],
         default=_get_bank_account_id,
     )
-    bank_amount = fields.Float("Withdrawn Amount")
+    bank_amount = fields.Float("Withdrawn Amount", compute="_compute_bank_amount")
     bank_expense_account_id = fields.Many2one(
         "account.account", "Bank Fees Account", default=_get_bank_expense_account_id
     )
-    expense_amount = fields.Float("Fees Amount")
+    past_due_fee_amount = fields.Float(
+        "Fees Amount", default=_get_unsolved_past_due_fee_amount
+    )
+
+    @api.depends("overdue_effects_amount", "past_due_fee_amount")
+    def _compute_bank_amount(self):
+        for wizard in self:
+            wizard.bank_amount = (
+                wizard.overdue_effects_amount + wizard.past_due_fee_amount
+            )
 
     def skip(self):
         active_id = self.env.context.get("active_id")
@@ -186,7 +201,7 @@ class RibaUnsolved(models.TransientModel):
             "line_ids": line_ids,
         }
 
-        if wizard.expense_amount:
+        if wizard.past_due_fee_amount:
             move_vals["line_ids"].append(
                 (
                     0,
@@ -194,7 +209,7 @@ class RibaUnsolved(models.TransientModel):
                     {
                         "name": _("Bank Fee"),
                         "account_id": wizard.bank_expense_account_id.id,
-                        "debit": wizard.expense_amount,
+                        "debit": wizard.past_due_fee_amount,
                         "credit": 0.0,
                     },
                 ),


### PR DESCRIPTION
-Aggiunti i seguenti campi nella sezione "insoluti" nel Configuratore RiBa:
  Importo Spese;
-Aggiunto nel Wizard della registrazione insoluti il precompilamento del campo "importo prelevato".