### PR TITLE
[14.0] [FIX] l10n_it_fatturapa_out_oss: OSS invoices with line_is_section_note

### DIFF
--- a/l10n_it_fatturapa_out_oss/data/invoice_it_template.xml
+++ b/l10n_it_fatturapa_out_oss/data/invoice_it_template.xml
@@ -53,10 +53,10 @@
                 name="t-esc"
             >format_numbers(0) if tax_ids and tax_ids.oss_country_id and tax_ids.kind_id else format_numbers(tax_ids.amount)</attribute>
         </xpath>
-        <xpath expr="//AliquotaIVA[@t-if='line_is_section_note']">
+        <xpath expr="//AliquotaIVA[@t-if='line_is_section_note']" position="attributes">
             <attribute
                 name="t-esc"
-            >format_numbers(0) if tax_ids and tax_ids.oss_country_id and tax_ids.kind_id else existing_tax_line['AliquotaIVA']</attribute>
+            >format_numbers(0) if ((tax_ids and tax_ids.oss_country_id and tax_ids.kind_id) or (existing_tax_line.get('Natura') and existing_tax_line.get('Oss Country'))) else existing_tax_line['AliquotaIVA']</attribute>
         </xpath>
         <xpath expr="//DettaglioLinee">
             <AltriDatiGestionali


### PR DESCRIPTION
Otherwise, note line get the existing OSS tax amount (!=0) and SDI reports

> Non c'è corrispondenza tra i valori indicati nell'elemento 2.2.1.12 <AliquotaIVA> o 2.1.1.7.5 <AliquotaIVA> e quelli dell'elemento 2.2.2.1 <AliquotaIVA>

v16: https://github.com/OCA/l10n-italy/pull/4646