### PR TITLE
[16.0] [IMP] l10n_it_riba: improve incasso flow with paid and past due management

### DIFF
--- a/l10n_it_riba/models/riba_config.py
+++ b/l10n_it_riba/models/riba_config.py
@@ -35,13 +35,14 @@ class RibaConfiguration(models.Model):
     acceptance_journal_id = fields.Many2one(
         "account.journal",
         "Acceptance Journal",
+        required=True,
         check_company=True,
-        domain="[('company_id', '=', company_id), ('type', '=', 'bank')]",
         help="Journal used when RiBa is accepted by the bank.",
     )
     acceptance_account_id = fields.Many2one(
         "account.account",
         "Acceptance Account",
+        required=True,
         check_company=True,
         help="Account used when RiBa is accepted by the bank.",
     )
@@ -55,7 +56,6 @@ class RibaConfiguration(models.Model):
         "account.journal",
         "Credit Journal",
         check_company=True,
-        domain="[('company_id', '=', company_id), ('type', '=', 'bank')]",
         help="Journal used when RiBa amount is credited by the bank.",
     )
     credit_account_id = fields.Many2one(
@@ -78,7 +78,6 @@ class RibaConfiguration(models.Model):
         "account.journal",
         "Past Due Journal",
         check_company=True,
-        domain="[('company_id', '=', company_id), ('type', '=', 'bank')]",
         help="Journal used when RiBa is past due.",
     )
     overdue_effects_account_id = fields.Many2one(
@@ -113,8 +112,11 @@ class RibaConfiguration(models.Model):
         if not self.env.context.get("active_id", False):
             return False
         ribalist_line = self.env["riba.slip.line"].browse(self.env.context["active_id"])
-        return (
-            ribalist_line.slip_id.config_id[field_name]
-            and ribalist_line.slip_id.config_id[field_name].id
-            or False
-        )
+        res = ribalist_line.slip_id.config_id[field_name]
+        if res:
+            # we need to check if the field is string like "config_type" or
+            # many2one like journals and accounts
+            if isinstance(res, str):
+                return res
+            return res.id
+        return False

--- a/l10n_it_riba/tests/riba_common.py
+++ b/l10n_it_riba/tests/riba_common.py
@@ -327,5 +327,9 @@ class TestRibaCommon(common.TransactionCase):
                 "bank_id": self.company_bank.id,
                 "acceptance_journal_id": self.bank_journal.id,
                 "acceptance_account_id": self.sbf_effects.id,
+                "past_due_journal_id": self.bank_journal.id,
+                "overdue_effects_account_id": self.past_due_account.id,
+                "protest_charge_account_id": self.expenses_account.id,
+                "settlement_journal_id": self.bank_journal.id,
             }
         )

--- a/l10n_it_riba/tests/test_riba.py
+++ b/l10n_it_riba/tests/test_riba.py
@@ -270,9 +270,9 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                 break
         self.assertTrue(bank_past_due_line)
 
-    def test_riba_incasso_flow(self):
+    def test_riba_incasso_all_paid(self):
         """
-        RiBa of type 'After Collection' pays invoice when accepted.
+        RiBa of type 'After Collection' all paid flow
         """
         self.invoice.company_id.due_cost_service_id = self.service_due_cost
         self.invoice.action_post()
@@ -302,10 +302,86 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         riba_list.confirm()
 
         self.assertEqual(riba_list.state, "accepted")
+        self.assertEqual(self.invoice.state, "posted")
+
+        # invoice should be paid
         self.assertEqual(self.invoice.payment_state, "paid")
 
+        # Action: Pay the RiBa
+        payment_wizard_action = riba_list.settle_all_line()
+        payment_wizard_form = Form(
+            self.env[payment_wizard_action["res_model"]].with_context(
+                **payment_wizard_action["context"]
+            )
+        )
+        # payment_wizard_form.payment_date = datetime.date.today()
+        payment_wizard = payment_wizard_form.save()
+        payment_wizard.pay()
+
+        # Assert
+        self.assertEqual(riba_list.state, "paid")
+        # invoice should be partial paid
+        self.assertEqual(self.invoice.payment_state, "paid")
+
+    def test_riba_incasso_past_due(self):
+        """
+        RiBa of type 'After Collection' past due flow
+        """
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost
+        self.invoice.action_post()
+        self.assertEqual(self.invoice.state, "posted")
+
+        to_issue_action = self.env.ref("l10n_it_riba.action_riba_to_issue")
+        to_issue_model = self.env[to_issue_action.res_model]
+        to_issue_domain = safe_eval.safe_eval(to_issue_action.domain)
+        to_issue_records = (
+            to_issue_model.search(to_issue_domain) & self.invoice.line_ids
+        )
+        self.assertTrue(to_issue_records)
+
+        issue_wizard_context = {
+            "active_model": to_issue_records._name,
+            "active_ids": to_issue_records.ids,
+        }
+        issue_wizard_model = self.env["riba.issue"].with_context(**issue_wizard_context)
+        issue_wizard_form = Form(issue_wizard_model)
+        issue_wizard_form.configuration_id = self.riba_config_incasso
+        issue_wizard = issue_wizard_form.save()
+        issue_result = issue_wizard.create_list()
+
+        riba_list_id = issue_result["res_id"]
+        riba_list_model = issue_result["res_model"]
+        riba_list = self.env[riba_list_model].browse(riba_list_id)
+        riba_list.confirm()
+
+        self.assertEqual(riba_list.state, "accepted")
+        self.assertEqual(self.invoice.state, "posted")
+
+        # invoice should be paid
+        self.assertEqual(self.invoice.payment_state, "paid")
+
+        # past due wizard
+        past_due_wizard = (
+            self.env["riba.past_due"]
+            .with_context(
+                active_model="riba.slip.line",
+                active_ids=[riba_list.line_ids[0].id],
+                active_id=riba_list.line_ids[0].id,
+            )
+            .create({})
+        )
+        past_due_wizard.create_move()
+        self.assertEqual(riba_list.state, "past_due")
+        self.assertEqual(len(riba_list.line_ids), 2)
+        self.assertEqual(riba_list.line_ids[0].state, "past_due")
+        self.assertTrue(self.invoice.past_due_move_line_ids)
+        # invoice should be partial paid
+        self.assertEqual(self.invoice.payment_state, "partial")
+
     def test_past_due_riba(self):
-        # create another invoice to test past due RiBa
+        """
+        RiBa of type 'sbf' past due flow
+        """
         self.partner.property_account_receivable_id = self.account_rec1_id.id
         recent_date = (
             self.env["account.move"]
@@ -623,6 +699,24 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         company_2 = self.company2
         partner_bank = self.company2_bank
         partner_bank.company_id = company_2
+        suspense_account = self.bank_journal.suspense_account_id.copy(
+            {"company_id": company_2.id}
+        )
+        profit_account = self.bank_journal.profit_account_id.copy(
+            {"company_id": company_2.id}
+        )
+        loss_account = self.bank_journal.loss_account_id.copy(
+            {"company_id": company_2.id}
+        )
+        bank_journal = self.bank_journal.copy(
+            {
+                "company_id": company_2.id,
+                "suspense_account_id": suspense_account.id,
+                "profit_account_id": profit_account.id,
+                "loss_account_id": loss_account.id,
+            }
+        )
+        sbf_effects = self.sbf_effects.copy({"company_id": company_2.id})
         # pre-condition
         self.assertEqual(partner_bank.company_id, company_2)
         self.assertNotEqual(current_company, company_2)
@@ -634,6 +728,8 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                     "name": "Subject To Collection",
                     "type": "incasso",
                     "bank_id": partner_bank.id,
+                    "acceptance_journal_id": bank_journal.id,
+                    "acceptance_account_id": sbf_effects.id,
                 }
             )
 

--- a/l10n_it_riba/views/configuration_view.xml
+++ b/l10n_it_riba/views/configuration_view.xml
@@ -37,15 +37,9 @@
                     />
                 </group>
 
-                <group string="Acceptance" attrs="{'invisible': [('type','!=','sbf')]}">
-                    <field
-                        name="acceptance_journal_id"
-                        attrs="{'required':[('type','=','sbf')]}"
-                    />
-                    <field
-                        name="acceptance_account_id"
-                        attrs="{'required':[('type','=','sbf')]}"
-                    />
+                <group string="Acceptance">
+                    <field name="acceptance_journal_id" />
+                    <field name="acceptance_account_id" />
                 </group>
 
                 <group string="Credit" attrs="{'invisible': [('type','!=','sbf')]}">
@@ -55,22 +49,15 @@
                     <field name="bank_expense_account_id" />
                 </group>
 
-                <group string="Past Due" attrs="{'invisible': [('type','!=','sbf')]}">
+                <group string="Past Due">
                     <field name="past_due_journal_id" />
                     <field name="overdue_effects_account_id" />
                     <field name="protest_charge_account_id" />
                 </group>
 
-                <group string="Settlement" attrs="{'invisible': [('type','!=','sbf')]}">
+                <group string="Settlement">
                     <field name="past_due_journal_id" />
                     <field name="settlement_journal_id" />
-                </group>
-                <group
-                    string="Acceptance"
-                    attrs="{'required':[('type','=','incasso')]}"
-                >
-                    <field name="acceptance_journal_id" />
-                    <field name="acceptance_account_id" />
                 </group>
             </form>
         </field>

--- a/l10n_it_riba/views/riba_view.xml
+++ b/l10n_it_riba/views/riba_view.xml
@@ -164,7 +164,7 @@
                         type='object'
                         string="Mark lines as Settled"
                         class="oe_highlight"
-                        attrs="{'invisible':[('state','!=','credited')]}"
+                        attrs="{'invisible':['|','&amp;',('state','!=','credited'),('type','=','sbf'),'&amp;',('state','!=','accepted'),('type','=','incasso')]}"
                     />
                     <button
                         name="action_cancel_draft"
@@ -204,14 +204,14 @@
                                     <button
                                         name="%(riba_past_due_action)d"
                                         type='action'
-                                        attrs="{'invisible':['|',('type','=','incasso'),('state','!=','credited')]}"
+                                        attrs="{'invisible':['|','&amp;',('state','!=','credited'),('type','=','sbf'),'&amp;',('state','!=','confirmed'),('type','=','incasso')]}"
                                         string="Mark as Past Due"
                                         icon="fa-exclamation-triangle"
                                     />
                                     <button
                                         name="button_settle"
                                         type='object'
-                                        attrs="{'invisible':['|',('type','=','incasso'),('state','!=','credited')]}"
+                                        attrs="{'invisible':['|','&amp;',('state','!=','credited'),('type','=','sbf'),'&amp;',('state','!=','confirmed'),('type','=','incasso')]}"
                                         string="Mark as Settled"
                                         icon="fa-check"
                                     />

--- a/l10n_it_riba/views/wizard_past_due.xml
+++ b/l10n_it_riba/views/wizard_past_due.xml
@@ -14,15 +14,28 @@
                     colspan="4"
                 />
                 <group>
+                    <field name="config_type" invisible="1" />
                     <field name="past_due_journal_id" />
                     <field name="effects_account_id" />
                     <field name="effects_amount" />
-                    <field name="riba_bank_account_id" />
-                    <field name="riba_bank_amount" />
+                    <field
+                        name="riba_bank_account_id"
+                        attrs="{'invisible':[('config_type','=','incasso')]}"
+                    />
+                    <field
+                        name="riba_bank_amount"
+                        attrs="{'invisible':[('config_type','=','incasso')]}"
+                    />
                     <field name="overdue_effects_account_id" />
                     <field name="overdue_effects_amount" />
-                    <field name="bank_account_id" />
-                    <field name="bank_amount" />
+                    <field
+                        name="bank_account_id"
+                        attrs="{'invisible':[('config_type','=','incasso')]}"
+                    />
+                    <field
+                        name="bank_amount"
+                        attrs="{'invisible':[('config_type','=','incasso')]}"
+                    />
                     <field name="bank_expense_account_id" />
                     <field name="expense_amount" />
                     <field name="date" />

--- a/l10n_it_riba/wizard/wizard_past_due.py
+++ b/l10n_it_riba/wizard/wizard_past_due.py
@@ -13,6 +13,10 @@ from odoo.exceptions import UserError
 
 class RibaPastDue(models.TransientModel):
     @api.model
+    def _get_config_type(self):
+        return self.env["riba.configuration"].get_default_value_by_list_line("type")
+
+    @api.model
     def _get_past_due_journal_id(self):
         return self.env["riba.configuration"].get_default_value_by_list_line(
             "past_due_journal_id"
@@ -56,6 +60,11 @@ class RibaPastDue(models.TransientModel):
 
     _name = "riba.past_due"
     _description = "Manage Past Due RiBas"
+    config_type = fields.Selection(
+        [("sbf", "Subject To Collection"), ("incasso", "After Collection")],
+        "Issue Mode",
+        default=_get_config_type,
+    )
     past_due_journal_id = fields.Many2one(
         "account.journal",
         "Past Due Journal",
@@ -117,18 +126,63 @@ class RibaPastDue(models.TransientModel):
         slip_line = self.env["riba.slip.line"].browse(active_id)
         wizard = self
         sbf_immediate = slip_line.slip_id.config_id.sbf_collection_type == "immediate"
-        if (
+        riba_type = slip_line.slip_id.config_id.type
+        account_check = (
             not wizard.past_due_journal_id
             or not wizard.effects_account_id
-            or not wizard.riba_bank_account_id
             or not wizard.overdue_effects_account_id
-            or not wizard.bank_account_id
             or not wizard.bank_expense_account_id
-        ):
+        )
+        # only sbf type needs "RiBa Account" and "A/C Bank Account"
+        if riba_type == "sbf":
+            account_check = (
+                account_check
+                or not wizard.riba_bank_account_id
+                or not wizard.bank_account_id
+            )
+        if account_check:
             raise UserError(_("Every account is mandatory."))
-
         date = self.date or slip_line.due_date
-        line_ids = [
+        # when incasso type, "Past Due Bills" aml needs to be linked to
+        # a "Bills Account" aml
+        line_ids = []
+        if riba_type == "incasso":
+            aml_name = _("Bills Account")
+            aml_account_id = wizard.effects_account_id.id
+            aml_credit = wizard.effects_amount
+        # when incasso type, "Past Due Bills" aml needs to be linked to
+        # an "A/C Bank" aml
+        else:
+            aml_name = (_("A/C Bank"),)
+            aml_account_id = wizard.bank_account_id.id
+            aml_credit = wizard.bank_amount
+            # when sbf type and immediate collection, we need to create
+            # a "Bills" aml and a "RiBa" aml
+            if sbf_immediate:
+                line_ids = [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": _("Bills"),
+                            "account_id": wizard.effects_account_id.id,
+                            "partner_id": slip_line.partner_id.id,
+                            "credit": wizard.effects_amount,
+                            "debit": 0.0,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": _("RiBa"),
+                            "account_id": wizard.riba_bank_account_id.id,
+                            "debit": wizard.riba_bank_amount,
+                            "credit": 0.0,
+                        },
+                    ),
+                ]
+        line_ids += [
             (
                 0,
                 0,
@@ -145,50 +199,16 @@ class RibaPastDue(models.TransientModel):
                 0,
                 0,
                 {
-                    "name": _("A/C Bank"),
-                    "account_id": wizard.bank_account_id.id,
-                    "credit": wizard.bank_amount,
+                    "name": aml_name,
+                    "account_id": aml_account_id,
+                    "credit": aml_credit,
                     "debit": 0.0,
                 },
             ),
         ]
-        if sbf_immediate:
-            line_ids += [
-                (
-                    0,
-                    0,
-                    {
-                        "name": _("Bills"),
-                        "account_id": wizard.effects_account_id.id,
-                        "partner_id": slip_line.partner_id.id,
-                        "credit": wizard.effects_amount,
-                        "debit": 0.0,
-                    },
-                ),
-                (
-                    0,
-                    0,
-                    {
-                        "name": _("RiBa"),
-                        "account_id": wizard.riba_bank_account_id.id,
-                        "debit": wizard.riba_bank_amount,
-                        "credit": 0.0,
-                    },
-                ),
-            ]
-        move_vals = {
-            "ref": _("Past Due RiBa %(name)s - Line %(sequence)s")
-            % {
-                "name": slip_line.slip_id.name,
-                "sequence": slip_line.sequence,
-            },
-            "journal_id": wizard.past_due_journal_id.id,
-            "date": date,
-            "line_ids": line_ids,
-        }
-
+        # add bank fees aml
         if wizard.expense_amount:
-            move_vals["line_ids"].append(
+            line_ids += [
                 (
                     0,
                     0,
@@ -199,7 +219,18 @@ class RibaPastDue(models.TransientModel):
                         "credit": 0.0,
                     },
                 ),
-            )
+            ]
+
+        move_vals = {
+            "ref": _("Past Due RiBa %(name)s - Line %(sequence)s")
+            % {
+                "name": slip_line.slip_id.name,
+                "sequence": slip_line.sequence,
+            },
+            "journal_id": wizard.past_due_journal_id.id,
+            "date": date,
+            "line_ids": line_ids,
+        }
 
         move = move_model.create(move_vals)
         move.action_post()
@@ -216,8 +247,6 @@ class RibaPastDue(models.TransientModel):
                             i.id
                             for i in riba_move_line.move_line_id.past_due_invoice_ids
                         ]
-                    if sbf_immediate:
-                        riba_move_line.move_line_id.remove_move_reconcile()
                     move_model.browse(invoice_ids).write(
                         {
                             "past_due_move_line_ids": [(4, move_line.id)],
@@ -228,7 +257,9 @@ class RibaPastDue(models.TransientModel):
         for acceptance_move_line in slip_line.acceptance_move_id.line_ids:
             if acceptance_move_line.account_id.id == wizard.effects_account_id.id:
                 to_be_reconciled.append(acceptance_move_line.id)
-
+        # remove payments reconciliations linked to past due line for both
+        # incasso and sbf type to set linked invoices as unpaid again
+        slip_line.move_line_ids.move_line_id.remove_move_reconcile()
         slip_line.write(
             {
                 "past_due_move_id": move.id,

--- a/l10n_it_riba/wizard/wizard_riba_multiple_payment.py
+++ b/l10n_it_riba/wizard/wizard_riba_multiple_payment.py
@@ -30,12 +30,15 @@ class RibaPaymentMultiple(models.TransientModel):
         domain="["
         "'&',"
         "('slip_id', 'in', riba_ids),"
-        "'!',"
         # The following domain must match the domain
         # that shows the 'Pay' button in each RiBa line
         "'|',"
+        "'&',"
+        "('type', '=', 'sbf'),"
+        "('state', '=', 'credited'),"
+        "'&',"
         "('type', '=', 'incasso'),"
-        "('state', '!=', 'credited'),"
+        "('state', '=', 'confirmed'),"
         "]",
         readonly=False,
         store=True,
@@ -79,6 +82,16 @@ class RibaPaymentMultiple(models.TransientModel):
         lines = self.riba_line_ids
         if not lines:
             raise UserError(_("Please select the RiBa lines to be paid"))
-        lines.riba_line_settlement(
+        incasso_lines = lines.filtered(lambda line: line.type == "incasso")
+        sbf_lines = lines - incasso_lines
+        # type "incasso" lines need to be set as paid only without settlement
+        # and account moves creation
+        incasso_lines.state = "paid"
+        # type "sbf" lines need to be settled and account moves created
+        sbf_lines.riba_line_settlement(
             date=self.payment_date,
         )
+        # set the state of the RiBa slips to 'paid' if all their lines are paid
+        for slip in lines.slip_id:
+            if list(set(slip.line_ids.mapped("state"))) == ["paid"]:
+                slip.state = "paid"


### PR DESCRIPTION
Migliora il flusso delle Riba al dopo incasso aggiungendo lo stato "paid" nelle distinte e nelle righe e la gestione dell'insoluto.
https://github.com/OCA/l10n-italy/issues/4640

1. Con questa PR nella configurazione della Riba al dopo incasso si possono aggiungere i dati per la gestione dell'insoluto

![image](https://github.com/user-attachments/assets/7558a10c-c068-4c0f-b6c7-7632c579ba57)

2. Ora una distinta accettata può essere pagata interamente, mentre ogni riga può essere segnata come pagata o insoluta individualmente come accade per le SBF.

![image](https://github.com/user-attachments/assets/a55dd499-0dde-4814-b76f-32efcb242707)

3. Segnare una distinta o una riga come pagata comporta unicamente il cambio di stato senza generare scritture in contabilità.

![image](https://github.com/user-attachments/assets/8cb30ca8-96ce-4beb-940f-def180093665)

4. Per segnare come insoluta la riga di una distinta viene proposto lo stesso wizard usato per le SBF senza i campi relativi a "RiBa Account".

![image](https://github.com/user-attachments/assets/6973f77e-6508-4f7b-9348-170eb84e556b)

5. Confermando la distinta e la riga passano in stato "past due" ed in contabilità viene creata la riga per l'insoluto.

![image](https://github.com/user-attachments/assets/e721a776-af7e-4201-8131-033469e286e3)
![image](https://github.com/user-attachments/assets/0271b267-09b7-45d8-b876-afd5c405b98a)

6. La fattura torna in stato "not paid".
Se ci fossero più righe di Riba, alcune pagate ed altre no, lo stato sarebbe "partial".
<ins>_Questo meccanismo non era presente per le Riba di tipo SBF ed è stato esteso anche a questa modalità_</ins> 

![image](https://github.com/user-attachments/assets/e12e9793-1f14-4eae-b08e-174996998047)
