### PR TITLE
[16.0] [FIX] l10n_it_bill_of_entry: only invoice product lines in boe storno prep

### DIFF
--- a/l10n_it_bill_of_entry/models/account_move.py
+++ b/l10n_it_bill_of_entry/models/account_move.py
@@ -151,7 +151,9 @@ class AccountMove(models.Model):
             "date": self.invoice_date,
         }
         move_lines = []
-        for inv_line in self.invoice_line_ids:
+        for inv_line in self.invoice_line_ids.filtered(
+            lambda line: line.display_type == "product"
+        ):
             if inv_line.advance_customs_vat:
                 line_vals = {
                     "name": _("Customs expenses"),
@@ -177,7 +179,9 @@ class AccountMove(models.Model):
                 "partner_id": bill_of_entry.partner_id.id,
             }
             move_lines.append((0, 0, line_vals))
-            for boe_line in bill_of_entry.invoice_line_ids:
+            for boe_line in bill_of_entry.invoice_line_ids.filtered(
+                lambda line: line.display_type == "product"
+            ):
                 if boe_line.tax_ids:
                     if len(boe_line.tax_ids) > 1:
                         raise UserError(

--- a/l10n_it_bill_of_entry/tests/test_bill_of_entry.py
+++ b/l10n_it_bill_of_entry/tests/test_bill_of_entry.py
@@ -13,7 +13,9 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 @tagged("post_install", "-at_install")
 class TestBillOfEntry(AccountTestInvoicingCommon):
-    def _create_invoice(self, partner, customs_doc_type, journal, products_list):
+    def _create_invoice(
+        self, partner, customs_doc_type, journal, products_list, notes_sections_list
+    ):
         invoice = self.init_invoice(
             "in_invoice",
             partner=partner,
@@ -25,9 +27,14 @@ class TestBillOfEntry(AccountTestInvoicingCommon):
             invoice_form.journal_id = journal
         for product, qty, price in products_list:
             with invoice_form.invoice_line_ids.new() as line:
+                line.name = product.name
                 line.product_id = product
                 line.price_unit = price
                 line.quantity = qty
+        for name, display_type in notes_sections_list:
+            with invoice_form.invoice_line_ids.new() as line:
+                line.name = name
+                line.display_type = display_type
 
         invoice = invoice_form.save()
         return invoice
@@ -144,6 +151,7 @@ class TestBillOfEntry(AccountTestInvoicingCommon):
             [
                 (self.product1, 1, 2500),
             ],
+            [],
         )
 
         # Bill of Entry - draft state
@@ -153,6 +161,9 @@ class TestBillOfEntry(AccountTestInvoicingCommon):
             self.journal,
             [
                 (self.product_extra, 1, 2500),
+            ],
+            [
+                ("nota", "line_note"),
             ],
         )
         bill_of_entry_form = Form(self.bill_of_entry)
@@ -169,6 +180,7 @@ class TestBillOfEntry(AccountTestInvoicingCommon):
                 (self.product_delivery, 1, 300),
                 (self.adv_customs_expense, 1, 550),
             ],
+            [],
         )
         forwarder_invoice_form = Form(self.forwarder_invoice)
         with forwarder_invoice_form.invoice_line_ids.edit(1) as line:


### PR DESCRIPTION
https://github.com/OCA/l10n-italy/issues/4651