### PR TITLE
[16.0] [FIX] l10n_it_riba: fix tot_amount rounding in slip report

### DIFF
--- a/l10n_it_riba/views/slip_report.xml
+++ b/l10n_it_riba/views/slip_report.xml
@@ -126,7 +126,10 @@
                                                 name="td_amount_total"
                                                 class="text-right"
                                             >
-                                                <span t-esc="tot_amount" />
+                                                <span
+                                                    t-out="tot_amount"
+                                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
+                                                />
                                             </td>
                                         </tr>
                                     </table>


### PR DESCRIPTION
Il report qweb della distinta potrebbe avere un totale con più di 2 decimali perchè il campo non è formattato con il widget `monetary`.

<img width="324" alt="image" src="https://github.com/user-attachments/assets/5f14c758-25aa-4955-aabd-6a1572040c9f" />

Non penso sia necessaria una issue perchè è un fix davvero banale e l'ho già riportato nella 18.0.
Per la 14.0: https://github.com/OCA/l10n-italy/pull/4656