### PR TITLE
[16.0][IMP] l10n_it_declaration_of_intent: add chatter

### DIFF
--- a/l10n_it_declaration_of_intent/models/declaration.py
+++ b/l10n_it_declaration_of_intent/models/declaration.py
@@ -34,6 +34,7 @@ class DeclarationOfIntentYearlyLimit(models.Model):
 
 class DeclarationOfIntent(models.Model):
     _name = "l10n_it_declaration_of_intent.declaration"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Declaration of intent"
     _order = "date_start desc,date_end desc"
 

--- a/l10n_it_declaration_of_intent/views/declaration_of_intent_view.xml
+++ b/l10n_it_declaration_of_intent/views/declaration_of_intent_view.xml
@@ -119,6 +119,11 @@
                         </page>
                     </notebook>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers" />
+                    <field name="activity_ids" widget="mail_activity" />
+                    <field name="message_ids" widget="mail_thread" />
+                </div>
             </form>
         </field>
     </record>


### PR DESCRIPTION
Aggiunge il chatter + activities alle dichiarazioni.
Può servire per organizzare l'attività (controllare sforamento plafond, in genere interagire col cliente/fornitore).