### PR TITLE
[IMP] l10n_it_fatturapa_in: only invoices with the same partner of the xml can be selected

### DIFF
--- a/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.py
+++ b/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.py
@@ -21,6 +21,9 @@ class WizardLinkToInvoiceLine(models.TransientModel):
     invoice_id = fields.Many2one(
         comodel_name="account.move",
     )
+    xml_supplier_id = fields.Many2one(
+        "res.partner", related="wizard_id.attachment_id.xml_supplier_id"
+    )
 
     def link(self):
         self.ensure_one()

--- a/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.xml
+++ b/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.xml
@@ -11,9 +11,10 @@
                         <tree editable="top" create="false">
                             <field name="wizard_id" invisible="True" />
                             <field name="e_invoice_descr" />
+                            <field name="xml_supplier_id" invisible="1" />
                             <field
                                 name="invoice_id"
-                                domain="[
+                                domain="[('partner_id','child_of',xml_supplier_id),
                                           ('move_type', 'in', ('in_invoice', 'in_refund')),
                                           ('state', '!=', 'cancel'),
                                           ('fatturapa_attachment_in_id', '=', False)]"


### PR DESCRIPTION
With this PR only invoices with the same partner_id can be selected in the wizard link xml to existing invoice 