### PR TITLE
[IMP]l10n_it_split_payment: Add copy method for split payments

### DIFF
--- a/l10n_it_split_payment/models/account_move.py
+++ b/l10n_it_split_payment/models/account_move.py
@@ -4,7 +4,8 @@
 # Copyright 2023  Giuseppe Borruso <gborruso@dinamicheaziendali.it>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import Command, fields, models
+from odoo.tools import float_compare
 
 
 class AccountMove(models.Model):
@@ -40,3 +41,45 @@ class AccountMove(models.Model):
             else:
                 move.amount_sp = 0.0
         return res
+
+    def write(self, vals):
+        res = super().write(vals)
+        if self.env.context.get("skip_split_payment_computation"):
+            return res
+        self.compute_split_payment()
+        return res
+
+    def copy(self, default=None):
+        if self.split_payment:
+            res = super(AccountMove, self.with_context(check_move_validity=False)).copy(
+                default=default
+            )
+            res.compute_split_payment()
+            return res
+        else:
+            return super().copy(default=default)
+
+    def compute_split_payment(self):
+        for move in self:
+            if move.split_payment:
+                line_sp = fields.first(
+                    move.line_ids.filtered(lambda move_line: move_line.is_split_payment)
+                )
+                for line in move.line_ids:
+                    if line.display_type == "tax" and not line.is_split_payment:
+                        write_off_line_vals = line._build_writeoff_line()
+                        if line_sp:
+                            if (
+                                float_compare(
+                                    line_sp.price_unit,
+                                    write_off_line_vals["price_unit"],
+                                    precision_rounding=move.currency_id.rounding,
+                                )
+                                != 0
+                            ):
+                                line_sp.write(write_off_line_vals)
+                        else:
+                            if move.amount_sp:
+                                move.with_context(
+                                    skip_split_payment_computation=True
+                                ).line_ids = [Command.create(write_off_line_vals)]


### PR DESCRIPTION
Forced recalculation of split payment lines when copying an account.move