### PR TITLE
[16.0][FIX] l10n_it_ricevute_bancarie: prevent duplicate Riba emission

### DIFF
--- a/l10n_it_riba/tests/test_riba.py
+++ b/l10n_it_riba/tests/test_riba.py
@@ -981,3 +981,67 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
 
         # Assert
         self.assertEqual(bill.riba_supplier_company_bank_id, bank_account)
+
+    def test_duplicate_riba_emission_block(self):
+        """Verifica che non sia possibile emettere una RIBA
+        se ne esiste già una accreditata sulla fattura."""
+        # Set Service in Company Config
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost
+        # Validate Invoice
+        self.invoice.action_post()
+        self.assertEqual(self.invoice.state, "posted")
+
+        # 1. Emissione e accredito prima RIBA
+        to_issue_action = self.env.ref("l10n_it_riba.action_riba_to_issue")
+        to_issue_model = self.env[to_issue_action.res_model]
+        to_issue_domain = safe_eval.safe_eval(to_issue_action.domain)
+        to_issue_records = (
+            to_issue_model.search(to_issue_domain) & self.invoice.line_ids
+        )
+
+        issue_wizard_context = {
+            "active_model": to_issue_records._name,
+            "active_ids": to_issue_records.ids,
+        }
+        issue_wizard = (
+            self.env["riba.issue"]
+            .with_context(**issue_wizard_context)
+            .create(
+                {
+                    "configuration_id": self.riba_config_incasso.id,
+                }
+            )
+        )
+
+        issue_result = issue_wizard.create_list()
+        riba_list = self.env[issue_result["res_model"]].browse(issue_result["res_id"])
+        riba_list.confirm()
+
+        credit_wizard = (
+            self.env["riba.credit"]
+            .with_context(
+                active_model="riba.slip",
+                active_ids=[riba_list.id],
+                active_id=riba_list.id,
+            )
+            .create({"bank_amount": 100, "expense_amount": 0})
+        )
+        credit_wizard.create_move()
+        self.assertEqual(riba_list.state, "credited")
+
+        # 2. Tentativo di nuova emissione su stessa fattura
+        with self.assertRaises(UserError) as error:
+            new_issue_wizard = (
+                self.env["riba.issue"]
+                .with_context(**issue_wizard_context)
+                .create(
+                    {
+                        "configuration_id": self.riba_config_incasso.id,
+                    }
+                )
+            )
+            new_issue_wizard.create_list()
+
+        self.assertIn(
+            "È già presente una RIBA accreditata", str(error.exception).lower()
+        )

--- a/l10n_it_riba/wizard/wizard_riba_issue.py
+++ b/l10n_it_riba/wizard/wizard_riba_issue.py
@@ -8,8 +8,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, fields, models
-from odoo.tools.misc import formatLang
 from odoo.exceptions import UserError
+from odoo.tools.misc import formatLang
 
 
 # -------------------------------------------------------
@@ -36,6 +36,7 @@ class RibaIssue(models.TransientModel):
                 "acceptance_account_id": acceptance_account_id,
             }
             return riba_list_line.create(rdl)
+
         self.ensure_one()
         # controllo che non siano presenti riba già emesse
         self._check_duplicate_riba_emission()
@@ -152,38 +153,62 @@ class RibaIssue(models.TransientModel):
 
     def _check_duplicate_riba_emission(self):
         # recupero linee dove fare riba
-        move_lines = self.env["account.move.line"].search([("id", "in", self._context["active_ids"])])
+        move_lines = self.env["account.move.line"].search(
+            [("id", "in", self._context["active_ids"])]
+        )
         # preparo variabili strettamente collegate da cui proviene l'errore
         move_lines_error = self.env["account.move.line"]
-        riba_line_error = self.env['riba.slip.line']
-        bank_move_error = self.env['account.move']
+        riba_line_error = self.env["riba.slip.line"]
+        bank_move_error = self.env["account.move"]
         # ciclo le righe da emettere
         for move in move_lines:
-            slip_line_ids = move.mapped('slip_line_ids')
-            if slip_line_ids.mapped('riba_line_id'):
+            slip_line_ids = move.mapped("slip_line_ids")
+            if slip_line_ids.mapped("riba_line_id"):
                 # riporto l'errore per dettaglio distinta riba
-                riba_line_error |= slip_line_ids.mapped('riba_line_id')
-                if slip_line_ids.mapped('riba_line_id').mapped('acceptance_move_id'):
+                riba_line_error |= slip_line_ids.mapped("riba_line_id")
+                if slip_line_ids.mapped("riba_line_id").mapped("acceptance_move_id"):
                     # filtro le righe valide (accreditate)
-                    bank_move_lines = slip_line_ids.mapped('riba_line_id').mapped('acceptance_move_id').filtered(lambda l: l.state not in ['cancel'])
+                    bank_move_lines = (
+                        slip_line_ids.mapped("riba_line_id")
+                        .mapped("acceptance_move_id")
+                        .filtered(lambda line: line.state not in ["cancel"])
+                    )
                     if bank_move_lines:
-                        # riporto l'errore per annullare il movimento contabile di accredito
+                        # riporto l'errore per annullare il movimento contabile
                         bank_move_error |= bank_move_lines
                 move_lines_error |= move
         if move_lines_error or riba_line_error or bank_move_error:
             # errore su collegamenti
-            invoice_ids = move_lines_error.mapped('move_id')
+            invoice_ids = move_lines_error.mapped("move_id")
             # imposto il messaggio
             currency_simbol = self.env.user.company_id.currency_id.symbol
+            invoices_ref = ", ".join(inv.display_name for inv in invoice_ids)
+            bank_moves_ref = ", ".join(
+                b_line.display_name for b_line in bank_move_error
+            )
+            riba_lines_ref = ", ".join(
+                (
+                    str(r_line.sequence)
+                    + " "
+                    + r_line.invoice_number
+                    + " "
+                    + formatLang(self.env, r_line.amount)
+                    + currency_simbol
+                )
+                for r_line in riba_line_error
+            )
             message = _(
-                """Cannot issue a new RiBa on the following invoices: %s
-You need to delete the credit and riba bill detail first.
-Order of elimination: Journal Entries ➜ Slips Detail
-Ref. Journal Entries: %s
-Ref. Slips Detail: %s
-After deleting, issue a new RiBa!
-"""
-            ) % (', '.join(inv.display_name for inv in invoice_ids), ', '.join(b_line.display_name for b_line in bank_move_error),
-                 ', '.join((str(r_line.sequence) + " " + r_line.invoice_number + " " + formatLang(self.env, r_line.amount) + currency_simbol) for r_line in riba_line_error))
+                "Cannot issue a new RiBa on the following invoices: %(invoices)s\n"
+                "You need to delete the credit and riba bill detail first.\n"
+                "Order of elimination: Journal Entries -> Slips Detail\n"
+                "Ref. Journal Entries: %(moves)s\n"
+                "Ref. Slips Detail: %(slips)s\n"
+                "After deleting, issue a new RiBa!\n"
+            ) % {
+                "invoices": invoices_ref,
+                "moves": bank_moves_ref,
+                "slips": riba_lines_ref,
+            }
+
             raise UserError(message)
         return True

--- a/l10n_it_riba/wizard/wizard_riba_issue.py
+++ b/l10n_it_riba/wizard/wizard_riba_issue.py
@@ -8,6 +8,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, fields, models
+from odoo.tools.misc import formatLang
 from odoo.exceptions import UserError
 
 
@@ -35,8 +36,9 @@ class RibaIssue(models.TransientModel):
                 "acceptance_account_id": acceptance_account_id,
             }
             return riba_list_line.create(rdl)
-
         self.ensure_one()
+        # controllo che non siano presenti riba già emesse
+        self._check_duplicate_riba_emission()
         # Qui creiamo la distinta
         # wizard_obj = self.browse(cr, uid, ids)[0]
         # active_ids = context and context.get('active_ids', [])
@@ -147,3 +149,41 @@ class RibaIssue(models.TransientModel):
         )
         action_vals["res_id"] = rd_id
         return action_vals
+
+    def _check_duplicate_riba_emission(self):
+        # recupero linee dove fare riba
+        move_lines = self.env["account.move.line"].search([("id", "in", self._context["active_ids"])])
+        # preparo variabili strettamente collegate da cui proviene l'errore
+        move_lines_error = self.env["account.move.line"]
+        riba_line_error = self.env['riba.slip.line']
+        bank_move_error = self.env['account.move']
+        # ciclo le righe da emettere
+        for move in move_lines:
+            slip_line_ids = move.mapped('slip_line_ids')
+            if slip_line_ids.mapped('riba_line_id'):
+                # riporto l'errore per dettaglio distinta riba
+                riba_line_error |= slip_line_ids.mapped('riba_line_id')
+                if slip_line_ids.mapped('riba_line_id').mapped('acceptance_move_id'):
+                    # filtro le righe valide (accreditate)
+                    bank_move_lines = slip_line_ids.mapped('riba_line_id').mapped('acceptance_move_id').filtered(lambda l: l.state not in ['cancel'])
+                    if bank_move_lines:
+                        # riporto l'errore per annullare il movimento contabile di accredito
+                        bank_move_error |= bank_move_lines
+                move_lines_error |= move
+        if move_lines_error or riba_line_error or bank_move_error:
+            # errore su collegamenti
+            invoice_ids = move_lines_error.mapped('move_id')
+            # imposto il messaggio
+            currency_simbol = self.env.user.company_id.currency_id.symbol
+            message = _(
+                """Cannot issue a new RiBa on the following invoices: %s
+You need to delete the credit and riba bill detail first.
+Order of elimination: Journal Entries ➜ Slips Detail
+Ref. Journal Entries: %s
+Ref. Slips Detail: %s
+After deleting, issue a new RiBa!
+"""
+            ) % (', '.join(inv.display_name for inv in invoice_ids), ', '.join(b_line.display_name for b_line in bank_move_error),
+                 ', '.join((str(r_line.sequence) + " " + r_line.invoice_number + " " + formatLang(self.env, r_line.amount) + currency_simbol) for r_line in riba_line_error))
+            raise UserError(message)
+        return True


### PR DESCRIPTION
### Descrizione:

Closes OCA/l10n-italy#4708 (for branch 16.0)

### Replica-Passaggi

1. Fai una fattura con RIBA
2. Confermi ed emetti la riba
3. Segni come accredita
4. Confermi la registrazione contabili per far passare la fattura a pagata

_L'operatore si accorge di aver sbagliato prezzo e va a modificare ma ha già emesso una RiBa_
1. Reimposta fattura in bozza
2. Cambia prezzo ad almeno una riga
3. Conferma fattura
4. Emetti nuova riba

Prima permetteva di emetterla con anche già una registrazione contabile confermata.
Ora blocca l'emissione e riporta in errore la procedura da seguire

### Vincoli applicati

- Controlli su wizard di emissione
- Registrazione contabile **deve essere eliminata o con stato cancellato**
- Dettaglio distinta riba **deve essere eliminata**