### PR TITLE
[16.0][FIX] Adds optional chaining for cashier property (fiscal_epos_print -> fiscal_operator_number error)

### DIFF
--- a/fiscal_epos_print/static/src/js/ChromeWidgets/EpsonFP81IIComponent.js
+++ b/fiscal_epos_print/static/src/js/ChromeWidgets/EpsonFP81IIComponent.js
@@ -134,7 +134,10 @@ odoo.define("fiscal_epos_print.EpsonFP81IIComponent", function (require) {
             });
             if (confirmed) {
                 fp90.printFiscalReprintLast(
-                    this.env.pos.cashier.fiscal_operator_number || "1"
+                    (this.env.pos &&
+                        this.env.pos.cashier &&
+                        this.env.pos.cashier.fiscal_operator_number) ||
+                        "1"
                 );
             } else {
                 // TODO not exist
@@ -167,7 +170,10 @@ odoo.define("fiscal_epos_print.EpsonFP81IIComponent", function (require) {
             if (confirmed) {
                 // Fp90.printFiscalReport();
                 fp90.printFiscalXZReport(
-                    this.env.pos.cashier.fiscal_operator_number || "1"
+                    (this.env.pos &&
+                        this.env.pos.cashier &&
+                        this.env.pos.cashier.fiscal_operator_number) ||
+                        "1"
                 );
             } else {
                 // TODO not exist
@@ -191,7 +197,10 @@ odoo.define("fiscal_epos_print.EpsonFP81IIComponent", function (require) {
             });
             if (confirmed) {
                 fp90.printFiscalXReport(
-                    this.env.pos.cashier.fiscal_operator_number || "1"
+                    (this.env.pos &&
+                        this.env.pos.cashier &&
+                        this.env.pos.cashier.fiscal_operator_number) ||
+                        "1"
                 );
             } else {
                 // TODO not exist


### PR DESCRIPTION
Problem:
1. Open POS
2. click `Closure Report Z (Fiscal)`
<img width="275" alt="image" src="https://github.com/user-attachments/assets/51235596-91ba-408c-b694-e70b0116e4fa" />

3. Error:

```
TypeError: Cannot read properties of undefined (reading 'fiscal_operator_number')
    at EpsonFP81IIComponent.fiscalClosing (https://my-instance.com/web/assets/debug/point_of_sale.assets.js:52856:42) (/fiscal_epos_print/static/src/js/ChromeWidgets/EpsonFP81IIComponent.js:170)
```

![image](https://github.com/user-attachments/assets/24196b87-a0b9-4095-a47a-74cdc35dfe16)

Suggested Fix:
- Use optional chaining to prevent errors when cashier is undefined.

