### PR TITLE
[FIX] l10n_it_asset_management: add group on hide_link_asset_button to prevent error when user has readonly_access

### DIFF
--- a/l10n_it_asset_management/views/account_move.xml
+++ b/l10n_it_asset_management/views/account_move.xml
@@ -11,7 +11,11 @@
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
             <xpath expr="//header/field[@name='state']" position="before">
-                <field name="hide_link_asset_button" invisible="1" />
+                <field
+                    name="hide_link_asset_button"
+                    invisible="1"
+                    groups="l10n_it_asset_management.group_asset_user"
+                />
                 <button
                     name="open_wizard_manage_asset"
                     type="object"


### PR DESCRIPTION
Attualmente esce errore se un utente ha accesso readonly alla contabilità e accede alla fattura perchè prova ad accedere ad asset.category per computare il campo hide_link_asset_button. Non ha senso computarlo per i gruppi che non hanno accesso asset_user