### PR TITLE
[FIX] l10n_it_sct_cbi: fix for tests failed because new Ccy element

### DIFF
--- a/l10n_it_sct_cbi/data/standards/CBIPaymentRequest.00.04.01.xsd
+++ b/l10n_it_sct_cbi/data/standards/CBIPaymentRequest.00.04.01.xsd
@@ -169,6 +169,7 @@
 		<xs:sequence>
 			<xs:element name="Id" type="CBIAccountIdentification1"/>
 			<xs:element name="Tp" type="CashAccountType2Choice" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Ccy" type="ActiveOrHistoricCurrencyCode" minOccurs="0" maxOccurs="1"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="CBICashAccount3">


### PR DESCRIPTION
This PR: https://github.com/OCA/bank-payment/commit/c3df4ef7893c102aea0a2a73782c2a6d20c39dff
add new Ccy element . The tests fail because this element is not in xsd schema