### PR TITLE
[FIX] l10n_it_split_payment: fix compute of split payment writeoff when creating two lines at once with different vat amount

### DIFF
--- a/l10n_it_split_payment/README.rst
+++ b/l10n_it_split_payment/README.rst
@@ -52,19 +52,19 @@ Configuration
 
 Per configurare questo modulo è necessario:
 
-- andare in Contabilità → Configurazione → Impostazioni e configura
-  "Conto storno scissione pagamenti" (es. 'IVA n/debito sospesa SP'). Il
-  conto storno dovrebbe essere diverso dall'IVA a debito standard, in
-  modo da aggiungerlo separatamente nella dichiarazione IVA.
+-  andare in Contabilità → Configurazione → Impostazioni e configura
+   "Conto storno scissione pagamenti" (es. 'IVA n/debito sospesa SP').
+   Il conto storno dovrebbe essere diverso dall'IVA a debito standard,
+   in modo da aggiungerlo separatamente nella dichiarazione IVA.
 
 **English**
 
 To configure this module, you need to:
 
-- go to Accounting → Configuration → Settings and configure 'Split
-  Payment Write-off account' (like 'IVA n/debito sospesa SP'). Write-off
-  account should be different from standard debit VAT, in order to
-  separately add it in VAT statement.
+-  go to Accounting → Configuration → Settings and configure 'Split
+   Payment Write-off account' (like 'IVA n/debito sospesa SP').
+   Write-off account should be different from standard debit VAT, in
+   order to separately add it in VAT statement.
 
 |image1|
 
@@ -72,14 +72,14 @@ To configure this module, you need to:
 
 **Italiano**
 
-- aggiungere una nuova imposta (Contabilità → Configurazione →
-  Contabilità → Imposte). IVA al 22% SPL deve essere configurata nel
-  modo seguente:
+-  aggiungere una nuova imposta (Contabilità → Configurazione →
+   Contabilità → Imposte). IVA al 22% SPL deve essere configurata nel
+   modo seguente:
 
 **English**
 
-- add a new tax (Accounting → Configuration → Accounting → Taxes). IVA
-  al 22% SPL should be configured like the following:
+-  add a new tax (Accounting → Configuration → Accounting → Taxes). IVA
+   al 22% SPL should be configured like the following:
 
 |image2|
 
@@ -89,17 +89,18 @@ To configure this module, you need to:
 
 **Italiano**
 
-- configurare la posizione fiscale (Contabilità → Configurazione →
-  Contabilità → Posizioni fiscali) usata per la scissione dei pagamenti,
-  selezionando la casella "Scissione pagamenti". Nella posizione fiscale
-  mappare l'IVA standard con l'IVA SP, come indicato di seguito:
+-  configurare la posizione fiscale (Contabilità → Configurazione →
+   Contabilità → Posizioni fiscali) usata per la scissione dei
+   pagamenti, selezionando la casella "Scissione pagamenti". Nella
+   posizione fiscale mappare l'IVA standard con l'IVA SP, come indicato
+   di seguito:
 
 **English**
 
-- configure the fiscal position (Accounting → Configuration → Accounting
-  → Fiscal Positions) used for split payment, setting 'Split Payment'
-  flag. In fiscal position, map standard VAT with SP VAT, like the
-  following:
+-  configure the fiscal position (Accounting → Configuration →
+   Accounting → Fiscal Positions) used for split payment, setting 'Split
+   Payment' flag. In fiscal position, map standard VAT with SP VAT, like
+   the following:
 
 |image4|
 
@@ -143,17 +144,21 @@ Authors
 Contributors
 ------------
 
-- Davide Corio <davide.corio@abstract.it>
-- Lorenzo Battistini <lorenzo.battistini@agilebg.com>
-- Alessio Gerace <alessio.gerace@agilebg.com>
-- Giacomo Grasso <giacomo.grasso.82@gmail.com>
-- Ruben Tonetto <https://github.com/ruben-tonetto>
-- Giuseppe Borruso - Dinamiche Aziendali srl
-  <gborruso@dinamicheaziendali.it>
-- Alex Comba <alex.comba@agilebg.com>
-- `Ooops <https://www.ooops404.com>`__:
+-  Davide Corio <davide.corio@abstract.it>
+-  Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+-  Alessio Gerace <alessio.gerace@agilebg.com>
+-  Giacomo Grasso <giacomo.grasso.82@gmail.com>
+-  Ruben Tonetto <https://github.com/ruben-tonetto>
+-  Giuseppe Borruso - Dinamiche Aziendali srl
+   <gborruso@dinamicheaziendali.it>
+-  Alex Comba <alex.comba@agilebg.com>
+-  `Ooops <https://www.ooops404.com>`__:
 
-  - Giovanni Serra <giovanni@gslab.it>
+   -  Giovanni Serra <giovanni@gslab.it>
+
+-  `Stesi Consulting <https://www.stesi.consulting>`__:
+
+   -  Michele Di Croce <dicroce.m@stesi.consulting>
 
 Maintainers
 -----------

--- a/l10n_it_split_payment/models/account_move.py
+++ b/l10n_it_split_payment/models/account_move.py
@@ -49,8 +49,6 @@ class AccountMove(models.Model):
         if self.env.context.get("skip_split_payment_computation"):
             return res
         self.compute_split_payment()
-        container = {"records": self}
-        self._check_balanced(container)
         return res
 
     def copy(self, default=None):
@@ -64,26 +62,30 @@ class AccountMove(models.Model):
         return res
 
     def compute_split_payment(self):
-        for move in self:
-            if move.split_payment:
-                line_sp = fields.first(
-                    move.line_ids.filtered(lambda move_line: move_line.is_split_payment)
-                )
-                for line in move.line_ids:
-                    if line.display_type == "tax" and not line.is_split_payment:
-                        write_off_line_vals = line._build_writeoff_line()
-                        if line_sp:
-                            if (
-                                float_compare(
-                                    line_sp.price_unit,
-                                    write_off_line_vals["price_unit"],
-                                    precision_rounding=move.currency_id.rounding,
-                                )
-                                != 0
-                            ):
-                                line_sp.write(write_off_line_vals)
-                        else:
-                            if move.amount_sp:
-                                move.with_context(
-                                    skip_split_payment_computation=True
-                                ).line_ids = [Command.create(write_off_line_vals)]
+        move_ids = self.filtered("split_payment")
+        for move in move_ids:
+            line_sp = fields.first(
+                move.line_ids.filtered(lambda move_line: move_line.is_split_payment)
+            )
+            lines = move.line_ids.filtered(
+                lambda line: line.display_type == "tax" and not line.is_split_payment
+            )
+            if lines:
+                write_off_line_vals = lines._build_writeoff_line()
+                if line_sp:
+                    if (
+                        float_compare(
+                            line_sp.price_unit,
+                            write_off_line_vals["price_unit"],
+                            precision_rounding=move.currency_id.rounding,
+                        )
+                        != 0
+                    ):
+                        line_sp.write(write_off_line_vals)
+                else:
+                    if move.amount_sp:
+                        move.with_context(
+                            skip_split_payment_computation=True
+                        ).line_ids = [Command.create(write_off_line_vals)]
+        container = {"records": move_ids}
+        self._check_balanced(container)

--- a/l10n_it_split_payment/models/account_move_line.py
+++ b/l10n_it_split_payment/models/account_move_line.py
@@ -21,8 +21,10 @@ class AccountMoveLine(models.Model):
                 line.is_split_payment = True
 
     def _build_writeoff_line(self):
-        self.ensure_one()
-
+        if len(self.mapped("move_id")) != 1:
+            raise UserError(
+                _("Cannot create a split payment write-off line for multiple moves.")
+            )
         if not self.move_id.company_id.sp_account_id:
             raise UserError(
                 _(
@@ -37,32 +39,27 @@ class AccountMoveLine(models.Model):
             "journal_id": self.move_id.journal_id.id,
             "date": self.move_id.invoice_date,
             "date_maturity": self.move_id.invoice_date,
-            "price_unit": -self.credit,
-            "amount_currency": self.credit,
-            "debit": self.credit,
-            "credit": self.debit,
+            "price_unit": -sum(self.mapped("credit")),
+            "amount_currency": sum(self.mapped("credit")),
+            "debit": sum(self.mapped("credit")),
+            "credit": sum(self.mapped("debit")),
             "display_type": "tax",
         }
         if self.move_id.move_type == "out_refund":
-            vals["amount_currency"] = -self.debit
-            vals["debit"] = self.credit
-            vals["credit"] = self.debit
+            vals["amount_currency"] = -sum(self.mapped("debit"))
+            vals["debit"] = sum(self.mapped("credit"))
+            vals["credit"] = sum(self.mapped("debit"))
         return vals
 
     @api.model_create_multi
     def create(self, vals_list):
         lines = super().create(vals_list)
-        for line in lines:
-            if (
-                line.display_type == "tax"
-                and line.move_id.split_payment
-                and line.move_id.is_sale_document(include_receipts=True)
-                and not line.is_split_payment
-                and not any(ml.is_split_payment for ml in line.move_id.line_ids)
-            ):
-                write_off_line_vals = line._build_writeoff_line()
-                line.move_id.line_ids = [(0, 0, write_off_line_vals)]
-                line.move_id._sync_dynamic_lines(
-                    container={"records": line.move_id, "self": line.move_id}
-                )
+        move_ids = lines.filtered(
+            lambda line: line.display_type == "tax"
+            and line.move_id.split_payment
+            and line.move_id.is_sale_document(include_receipts=True)
+            and not line.is_split_payment
+            and not any(ml.is_split_payment for ml in line.move_id.line_ids)
+        ).mapped("move_id")
+        move_ids.compute_split_payment()
         return lines

--- a/l10n_it_split_payment/readme/CONTRIBUTORS.md
+++ b/l10n_it_split_payment/readme/CONTRIBUTORS.md
@@ -8,3 +8,5 @@
 - Alex Comba \<<alex.comba@agilebg.com>\>
 - [Ooops](https://www.ooops404.com):
   - Giovanni Serra \<<giovanni@gslab.it>\>
+- [Stesi Consulting](https://www.stesi.consulting):
+  - Michele Di Croce \<<dicroce.m@stesi.consulting>\>

--- a/l10n_it_split_payment/static/description/index.html
+++ b/l10n_it_split_payment/static/description/index.html
@@ -396,17 +396,17 @@ ul.auto-toc {
 <p>Per configurare questo modulo è necessario:</p>
 <ul class="simple">
 <li>andare in Contabilità → Configurazione → Impostazioni e configura
-“Conto storno scissione pagamenti” (es. ‘IVA n/debito sospesa SP’). Il
-conto storno dovrebbe essere diverso dall’IVA a debito standard, in
-modo da aggiungerlo separatamente nella dichiarazione IVA.</li>
+“Conto storno scissione pagamenti” (es. ‘IVA n/debito sospesa SP’).
+Il conto storno dovrebbe essere diverso dall’IVA a debito standard,
+in modo da aggiungerlo separatamente nella dichiarazione IVA.</li>
 </ul>
 <p><strong>English</strong></p>
 <p>To configure this module, you need to:</p>
 <ul class="simple">
 <li>go to Accounting → Configuration → Settings and configure ‘Split
-Payment Write-off account’ (like ‘IVA n/debito sospesa SP’). Write-off
-account should be different from standard debit VAT, in order to
-separately add it in VAT statement.</li>
+Payment Write-off account’ (like ‘IVA n/debito sospesa SP’).
+Write-off account should be different from standard debit VAT, in
+order to separately add it in VAT statement.</li>
 </ul>
 <p><img alt="image1" src="https://raw.githubusercontent.com/OCA/l10n-italy/16.0/l10n_it_split_payment/static/settings.png" /></p>
 <hr class="docutils" />
@@ -427,16 +427,17 @@ al 22% SPL should be configured like the following:</li>
 <p><strong>Italiano</strong></p>
 <ul class="simple">
 <li>configurare la posizione fiscale (Contabilità → Configurazione →
-Contabilità → Posizioni fiscali) usata per la scissione dei pagamenti,
-selezionando la casella “Scissione pagamenti”. Nella posizione fiscale
-mappare l’IVA standard con l’IVA SP, come indicato di seguito:</li>
+Contabilità → Posizioni fiscali) usata per la scissione dei
+pagamenti, selezionando la casella “Scissione pagamenti”. Nella
+posizione fiscale mappare l’IVA standard con l’IVA SP, come indicato
+di seguito:</li>
 </ul>
 <p><strong>English</strong></p>
 <ul class="simple">
-<li>configure the fiscal position (Accounting → Configuration → Accounting
-→ Fiscal Positions) used for split payment, setting ‘Split Payment’
-flag. In fiscal position, map standard VAT with SP VAT, like the
-following:</li>
+<li>configure the fiscal position (Accounting → Configuration →
+Accounting → Fiscal Positions) used for split payment, setting ‘Split
+Payment’ flag. In fiscal position, map standard VAT with SP VAT, like
+the following:</li>
 </ul>
 <p><img alt="image4" src="https://raw.githubusercontent.com/OCA/l10n-italy/16.0/l10n_it_split_payment/static/fiscal_position.png" /></p>
 </div>
@@ -479,6 +480,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Alex Comba &lt;<a class="reference external" href="mailto:alex.comba&#64;agilebg.com">alex.comba&#64;agilebg.com</a>&gt;</li>
 <li><a class="reference external" href="https://www.ooops404.com">Ooops</a>:<ul>
 <li>Giovanni Serra &lt;<a class="reference external" href="mailto:giovanni&#64;gslab.it">giovanni&#64;gslab.it</a>&gt;</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.stesi.consulting">Stesi Consulting</a>:<ul>
+<li>Michele Di Croce &lt;<a class="reference external" href="mailto:dicroce.m&#64;stesi.consulting">dicroce.m&#64;stesi.consulting</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/l10n_it_split_payment/tests/test_splitpayment.py
+++ b/l10n_it_split_payment/tests/test_splitpayment.py
@@ -27,10 +27,22 @@ class TestSP(TestAccountAccount):
                 "amount": 22,
             }
         )
+        self.tax10sp = self.tax_model.create(
+            {
+                "name": "10% SP",
+                "amount": 10,
+            }
+        )
         self.tax22 = self.tax_model.create(
             {
                 "name": "22%",
                 "amount": 22,
+            }
+        )
+        self.tax10 = self.tax_model.create(
+            {
+                "name": "10%",
+                "amount": 10,
             }
         )
         self.sp_fp = self.fp_model.create(
@@ -42,7 +54,12 @@ class TestSP(TestAccountAccount):
                         0,
                         0,
                         {"tax_src_id": self.tax22.id, "tax_dest_id": self.tax22sp.id},
-                    )
+                    ),
+                    (
+                        0,
+                        0,
+                        {"tax_src_id": self.tax10.id, "tax_dest_id": self.tax10sp.id},
+                    ),
                 ],
             }
         )
@@ -272,3 +289,46 @@ class TestSP(TestAccountAccount):
         self.assertEqual(invoice.amount_total, 200)
         self.assertEqual(invoice.amount_residual, 200)
         self.assertEqual(invoice.amount_tax, 0)
+
+    def test_invoice_two_sp_taxes(self):
+        self.assertTrue(self.tax22sp.is_split_payment)
+        self.assertTrue(self.tax10sp.is_split_payment)
+        invoice = self.move_model.with_context(default_move_type="out_invoice").create(
+            {
+                "invoice_date": self.recent_date,
+                "partner_id": self.env.ref("base.res_partner_3").id,
+                "journal_id": self.sales_journal.id,
+                "fiscal_position_id": self.sp_fp.id,
+                "move_type": "out_refund",
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "service",
+                            "account_id": self.a_sale.id,
+                            "quantity": 1,
+                            "price_unit": 100,
+                            "tax_ids": [(6, 0, {self.tax22sp.id})],
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "service2",
+                            "account_id": self.a_sale.id,
+                            "quantity": 1,
+                            "price_unit": 100,
+                            "tax_ids": [(6, 0, {self.tax10sp.id})],
+                        },
+                    ),
+                ],
+            }
+        )
+        line_sp = invoice.line_ids.filtered(
+            lambda line: line.account_id.id == self.company.sp_account_id.id
+        )
+
+        self.assertTrue(len(line_sp) == 1)
+        self.assertEqual(line_sp.credit, 32)


### PR DESCRIPTION
This PR fix the case of creating two different invoice lines with two different SP Taxes. Now it does not create the write off with the correct amount

Fixes: https://github.com/OCA/l10n-italy/issues/4784