### PR TITLE
[16.0][IMP]l10n_it_fiscalcode: Improved error message for invalid fc

### DIFF
--- a/l10n_it_fiscalcode/model/res_partner.py
+++ b/l10n_it_fiscalcode/model/res_partner.py
@@ -28,11 +28,14 @@ class ResPartner(models.Model):
                     continue
                 if len(partner.fiscalcode) != 16:
                     # Check fiscalcode length of a person
-                    msg = _("The fiscal code must have 16 characters.")
+                    msg = (
+                        _("The fiscal code '%s' must have 16 characters.")
+                        % partner.fiscalcode
+                    )
                     raise ValidationError(msg)
                 if not isvalid(partner.fiscalcode):
                     # Check fiscalcode validity
-                    msg = _("The fiscal code isn't valid.")
+                    msg = _("The fiscal code '%s' isn't valid.") % partner.fiscalcode
                     raise ValidationError(msg)
         return True
 


### PR DESCRIPTION
In caso di codice fiscale errato in un partner, il valore del campo viene mostrato nel messaggio d'errore. 
Questo migliora l'identificazione della riga in errore in caso di import massivo

Per testare è sufficiente creare un partner con un codice fiscale errato

#4788 