### PR TITLE
[16.0] [FIX] l10n_it_fatturapa_in: add compute account after invoice lines import from XML

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1235,6 +1235,10 @@ class WizardImportFatturapa(models.TransientModel):
         invoice.with_context(check_move_validity=False).update(
             {"invoice_line_ids": [(6, 0, invoice_lines)]}
         )
+        # (6, 0, ids) command bypasses the ORM's compute mechanism because it
+        # directly replaces the records in the database so we need to explicitly
+        # call the compute methods
+        invoice.invoice_line_ids._compute_account_id()
 
         invoice._onchange_invoice_line_wt_ids()
 


### PR DESCRIPTION
L'importazione delle fatture da XML imposta le righe della fattura collegandole con la sintassi `[(6, 0, invoice_lines)]`, bypassando l'ORM.
Una delle conseguenze è il mancato `compute` di alcuni campi tra cui il conto.
Con questa PR si vuole risolvere questo problema nello specifico, ma forse ci sono anche altri calcoli che al momento vengono bypassati.

https://github.com/OCA/l10n-italy/issues/4797