### PR TITLE
[18.0][FIX]l10n_it_account_stamp: migration script fix

### DIFF
--- a/l10n_it_account_stamp/migrations/18.0.1.0.0/post-migration.py
+++ b/l10n_it_account_stamp/migrations/18.0.1.0.0/post-migration.py
@@ -7,8 +7,8 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(cr, version):
     openupgrade.load_data(
-        cr, "l10n_it_account_stamp", "18.0.1.0.0/noupdate_changes.xml"
+        cr, "l10n_it_account_stamp", "migrations/18.0.1.0.0/noupdate_changes.xml"
     )
     openupgrade.delete_record_translations(
-        cr, "l10n_it_account_stamp", ["l10n_it_account_stamp_2_euro"]
+        cr.cr, "l10n_it_account_stamp", ["l10n_it_account_stamp_2_euro"]
     )

--- a/l10n_it_account_stamp/migrations/18.0.1.0.0/pre-migration.py
+++ b/l10n_it_account_stamp/migrations/18.0.1.0.0/pre-migration.py
@@ -74,7 +74,6 @@ def _rename_fields(env):
     )
 
 
-@openupgrade.migrate()
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     _rename_fields(env)

--- a/l10n_it_account_stamp/migrations/18.0.1.1.0/post-migration.py
+++ b/l10n_it_account_stamp/migrations/18.0.1.1.0/post-migration.py
@@ -4,10 +4,9 @@
 from openupgradelib import openupgrade
 
 
-@openupgrade.migrate()
 def migrate(env, version):
     openupgrade.logged_query(
-        env.cr,
+        env,
         """
         UPDATE account_move_line aml
         SET


### PR DESCRIPTION
Ho testato in locale le migrazioni alla v18. 
Con queste modifiche sembra siano state applicate correttamente. Dovrei verificare il metodo `delete_record_translations`, qualcuno mi sa dire come fare?