### PR TITLE
[FIX] Errori nel modulo l10n_it_partner_statement_riba

### DIFF
--- a/l10n_it_ricevute_bancarie/tests/riba_common.py
+++ b/l10n_it_ricevute_bancarie/tests/riba_common.py
@@ -1,5 +1,6 @@
 import os
 
+from odoo import fields
 from odoo.tests import common
 from odoo.tools import config
 
@@ -131,17 +132,12 @@ class TestRibaCommon(common.TransactionCase):
         )
 
     def _create_invoice(self):
-        # ----- Set invoice date to recent date in the system
-        # ----- This solves problems with account_invoice_sequential_dates
+        invoice_date = fields.Date.today()
         self.partner.property_account_receivable_id = self.account_rec1_id.id
-        recent_date = (
-            self.env["account.move"]
-            .search([("invoice_date", "!=", False)], order="invoice_date desc", limit=1)
-            .invoice_date
-        )
         return self.env["account.move"].create(
             {
-                "invoice_date": recent_date,
+                "date": invoice_date,
+                "invoice_date": invoice_date,
                 "move_type": "out_invoice",
                 "journal_id": self.sale_journal.id,
                 "partner_id": self.partner.id,
@@ -164,15 +160,12 @@ class TestRibaCommon(common.TransactionCase):
         )
 
     def _create_sbf_invoice(self):
+        invoice_date = fields.Date.today()
         self.partner.property_account_receivable_id = self.account_rec1_id.id
-        recent_date = (
-            self.env["account.move"]
-            .search([("invoice_date", "!=", False)], order="invoice_date desc", limit=1)
-            .invoice_date
-        )
         return self.env["account.move"].create(
             {
-                "invoice_date": recent_date,
+                "date": invoice_date,
+                "invoice_date": invoice_date,
                 "move_type": "out_invoice",
                 "journal_id": self.sale_journal.id,
                 "partner_id": self.partner.id,


### PR DESCRIPTION
Corregge https://github.com/OCA/l10n-italy/issues/4821.

Al momento l'errore indicato nella issue non sta più succedendo, quindi non è possibile verificare che queste modifiche lo risolvano.
Potrebbe però essere una situazione temporanea: se dovesse tornare a succedere si può provare se queste modifiche lo risolvono.