### PR TITLE
[16.0] [FIX] l10n_it_split_payment: impedire conferma account.move sbilanciate

### DIFF
--- a/l10n_it_split_payment/models/account_move.py
+++ b/l10n_it_split_payment/models/account_move.py
@@ -43,12 +43,10 @@ class AccountMove(models.Model):
         return res
 
     def write(self, vals):
-        res = super(AccountMove, self.with_context(check_move_validity=False)).write(
-            vals
-        )
+        res = super().write(vals)
         if self.env.context.get("skip_split_payment_computation"):
             return res
-        self.compute_split_payment()
+        self.with_context(check_move_validity=False).compute_split_payment()
         container = {"records": self}
         self._check_balanced(container)
         return res

--- a/l10n_it_split_payment/models/account_move_line.py
+++ b/l10n_it_split_payment/models/account_move_line.py
@@ -42,6 +42,7 @@ class AccountMoveLine(models.Model):
             "debit": self.credit,
             "credit": self.debit,
             "display_type": "tax",
+            "tax_repartition_line_id": self.tax_repartition_line_id.id,
         }
         if self.move_id.move_type == "out_refund":
             vals["amount_currency"] = -self.debit


### PR DESCRIPTION
Come indicato in #4832 quando una move viene duplicata, attulamente il modulo interferisce nella write impostando la chiave `check_move_validity` a False durante la chiamata alla super() e questo permette di confermare le account.move con righe sbilanciate