### PR TITLE
[FIX] Usare diverse dichiarazioni d'intento per fattura con diverse righe

### DIFF
--- a/l10n_it_declaration_of_intent/models/account_move.py
+++ b/l10n_it_declaration_of_intent/models/account_move.py
@@ -227,6 +227,9 @@ class AccountMove(models.Model):
     def get_declarations_used_amounts(self, declarations):
         """Get used amount by declarations for this invoice."""
         self.ensure_one()
+        declarations_available_amounts = {
+            declaration.id: declaration.available_amount for declaration in declarations
+        }
         declarations_used_amounts = {}
         sign = 1 if self.move_type in ["out_invoice", "in_invoice"] else -1
         for tax_line in self.line_ids.filtered("tax_ids"):
@@ -245,7 +248,14 @@ class AccountMove(models.Model):
                     # assign all the remaining amount.
                     declaration_used_amount = amount
                 else:
-                    declaration_used_amount = min(amount, declaration.available_amount)
+                    declaration_available_amount = declarations_available_amounts[
+                        declaration.id
+                    ]
+                    declaration_used_amount = min(amount, declaration_available_amount)
+                declarations_available_amounts[
+                    declaration.id
+                ] -= declaration_used_amount
+
                 declarations_used_amounts[declaration.id] += declaration_used_amount
                 amount -= declaration_used_amount
         return declarations_used_amounts

--- a/l10n_it_declaration_of_intent/tests/test_declaration_of_intent.py
+++ b/l10n_it_declaration_of_intent/tests/test_declaration_of_intent.py
@@ -560,7 +560,7 @@ class TestDeclarationOfIntent(AccountTestInvoicingCommon):
         tax = self.tax1
         invoice = self.init_invoice(
             "out_invoice",
-            amounts=[1100],
+            amounts=[500, 600],
             invoice_date=self.today_date,
             partner=self.partner2,
             taxes=self.tax1,


### PR DESCRIPTION
Corregge il caso d'uso:

1. Creare diverse dichiarazioni d'intento per un cliente da importo 1000
2. Creare una fattura per il cliente con 2 righe da 600
3. Confermare la fattura

**Atteso**
La prima dichiarazione d'intento ha importo disponibile 0, la seconda 800

**Attuale**
Errore:
> Limit passed for declaration 2
> Excess value: 200.0$

<details><summary>Stack</summary>
<pre>
[...]
  File "/opt/odoo/auto/addons/l10n_it_declaration_of_intent/models/account_move.py", line 111, in _post
    invoice.update_declarations(declarations_used_amounts, grouped_lines)
  File "/opt/odoo/auto/addons/l10n_it_declaration_of_intent/models/account_move.py", line 145, in update_declarations
    declaration.line_ids = [
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1151, in __set__
    records.write({self.name: write_value})
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 322, in write
    result = super(MailThread, self).write(values)
  File "/opt/odoo/auto/addons/mail/models/mail_activity.py", line 788, in write
    return super(MailActivityMixin, self).write(vals)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3716, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1277, in _validate_fields
    check(self)
  File "/opt/odoo/auto/addons/l10n_it_declaration_of_intent/models/declaration.py", line 169, in _check_available_amount
    if declaration.available_amount < 0:
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 991, in __get__
    self.recompute(record)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1177, in recompute
    self.compute_value(recs)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1199, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
    return super()._compute_field_value(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4094, in _compute_field_value
    self.filtered('id')._validate_fields(fnames)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1277, in _validate_fields
    check(self)
  File "/opt/odoo/auto/addons/l10n_it_declaration_of_intent/models/declaration.py", line 170, in _check_available_amount
    raise UserError(
odoo.exceptions.UserError: Limit passed for declaration 2.
Excess value: 200.0$
</pre>
</details>

**Nota**: Le righe fattura possono usare diverse dichiarazioni d'intento grazie a https://github.com/OCA/l10n-italy/pull/4827, quindi aggiungerei questa PR nella issue https://github.com/OCA/l10n-italy/issues/4826.