### PR TITLE
[FIX] l10n_it_delivery_note :hide message of draft invoices checking also the default attribute display_draft_invoice_warning

### DIFF
--- a/l10n_it_delivery_note/wizard/sale_advance_payment_inv.xml
+++ b/l10n_it_delivery_note/wizard/sale_advance_payment_inv.xml
@@ -14,7 +14,7 @@
             </xpath>
             <xpath expr="//div[hasclass('alert-warning')]" position="attributes">
                 <attribute name="name">initial_message</attribute>
-                <attribute name="invisible">step != 'initial'</attribute>
+                <attribute name="invisible" add="step != 'initial'" separator="or" />
             </xpath>
             <xpath expr="//div[hasclass('alert-warning')]" position="after">
                 <div name="confirm_message" invisible="step != 'confirm'">


### PR DESCRIPTION
### Before this PR
Now clicking on "create invoices" it shows that there are draft invioces but there are not draft invoice.
Is is caused because the attribute invisible is completely replaced instead of adding "or" .

Fix: https://github.com/OCA/l10n-italy/issues/4842