### PR TITLE
[18.0][FIX] l10n_it_delivery_note: wrong quantity field in lot line in report for ddt

### DIFF
--- a/l10n_it_delivery_note/report/report_delivery_note.xml
+++ b/l10n_it_delivery_note/report/report_delivery_note.xml
@@ -304,10 +304,10 @@
                                                 </t>
                                         </t>
                                             <t
-                                            t-if="line.product_qty != lot_line.qty_done"
+                                            t-if="line.product_qty != lot_line.quantity"
                                         >
                                                 qty
-                                                <span t-field="lot_line.qty_done" />
+                                                <span t-field="lot_line.quantity" />
                                             </t>
                                             ;
                                         </t>


### PR DESCRIPTION
Correct the quantity field used in the delivery note report.

Fix: #4844