### PR TITLE
[16.0][FIX] l10n_it_fatturapa_in: removed abs from ImponibileImporto (#2959)

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -668,7 +668,7 @@ class WizardImportFatturapa(models.TransientModel):
                 "name": f"Riepilogo Aliquota {line.AliquotaIVA}",
                 "sequence": nline,
                 "account_id": credit_account_id,
-                "price_unit": float(abs(line.ImponibileImporto)),
+                "price_unit": float(line.ImponibileImporto),
             }
         )
         return retLine


### PR DESCRIPTION
Porting della patch da 14.0 a 16.0.

Commit originale: odooNextev <odoo@nextev.it>  
PR originale: https://github.com/OCA/l10n-italy/pull/3443  
Issue: https://github.com/OCA/l10n-italy/issues/2959

Modifica effettuata con cherry-pick e mantenimento autore.