### PR TITLE
[16.0][FIX] l10n_it_vat_registries: allow move lines with multiple taxes if only one is not excluded from registries

### DIFF
--- a/l10n_it_vat_registries/models/vat_registry.py
+++ b/l10n_it_vat_registries/models/vat_registry.py
@@ -76,24 +76,37 @@ class ReportRegistroIva(models.AbstractModel):
             if not (move_line.tax_line_id or move_line.tax_ids):
                 continue
 
-            if move_line.tax_ids and len(move_line.tax_ids) != 1:
-                raise UserError(
-                    _("Move line %s has too many base taxes") % move_line.name
+            # Filter out taxes that should be excluded from registries before validation
+            if move_line.tax_ids:
+                # Filter out taxes that should be excluded from registries
+                filtered_taxes = move_line.tax_ids.filtered(
+                    lambda tax: not tax.exclude_from_registries
                 )
 
-            if move_line.tax_ids:
-                tax = move_line.tax_ids[0]
+                # Now check if we have too many taxes after filtering
+                if len(filtered_taxes) > 1:
+                    raise UserError(
+                        _("Move line %s has too many base taxes") % move_line.name
+                    )
+                elif len(filtered_taxes) == 0:
+                    # All taxes are excluded, skip this move line
+                    continue
+
+                tax = filtered_taxes[0]
                 is_base = True
             else:
                 tax = move_line.tax_line_id
                 is_base = False
+                # Skip if this tax should be excluded from registries
+                if tax.exclude_from_registries:
+                    continue
 
             if tax.parent_tax_ids and len(tax.parent_tax_ids) == 1:
                 # we group by main tax
                 tax = tax.parent_tax_ids[0]
-
-            if tax.exclude_from_registries:
-                continue
+                # Skip if the parent tax should be excluded from registries
+                if tax.exclude_from_registries:
+                    continue
 
             if not res.get(tax.id):
                 res[tax.id] = {


### PR DESCRIPTION
### Description of the issue/feature this PR addresses

Currently, the VAT registry report does not allow move lines with multiple taxes, even if all but one are excluded from registries (`exclude_from_registries=True`). This prevents the registry from being printed in legitimate cases where only one tax should be included.

---

### Current behavior before PR

A `UserError` is raised if a move line has more than one tax, regardless of the `exclude_from_registries` flag.

---

### Desired behavior after PR is merged

Move lines with multiple taxes are allowed in the VAT registry report, as long as only one tax is not excluded from registries (`exclude_from_registries=False`).  
If, after filtering, more than one tax remains, the error is still raised.

---

### Steps to reproduce

1. Create an invoice line with two taxes, one of which has `exclude_from_registries=True`.
2. Try to print the VAT registry report.
3. **Before this PR:** UserError is raised.
4. **After this PR:** The line is included if only one tax remains after filtering.

---

### Related issues

N/A

---

### Other information

- This is useful when you have, for example, a "Cassa Previdenziale" (CPA) tax which is applied before the standard VAT (e.g. IVA 22%) but should be excluded from the VAT registry (`exclude_from_registries=True`). With this change, such cases are now handled correctly and the registry can be printed as expected.

---
