### PR TITLE
[FIX] l10n_it_account_stamp: use right migration function's signature

### DIFF
--- a/l10n_it_account_stamp/migrations/18.0.1.0.0/post-migration.py
+++ b/l10n_it_account_stamp/migrations/18.0.1.0.0/post-migration.py
@@ -5,10 +5,10 @@ from openupgradelib import openupgrade
 
 
 @openupgrade.migrate()
-def migrate(cr, version):
+def migrate(env, version):
     openupgrade.load_data(
-        cr, "l10n_it_account_stamp", "18.0.1.0.0/noupdate_changes.xml"
+        env.cr, "l10n_it_account_stamp", "18.0.1.0.0/noupdate_changes.xml"
     )
     openupgrade.delete_record_translations(
-        cr, "l10n_it_account_stamp", ["l10n_it_account_stamp_2_euro"]
+        env.cr, "l10n_it_account_stamp", ["l10n_it_account_stamp_2_euro"]
     )

--- a/l10n_it_account_stamp/migrations/18.0.1.0.0/post-migration.py
+++ b/l10n_it_account_stamp/migrations/18.0.1.0.0/post-migration.py
@@ -7,7 +7,7 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(
-        env.cr, "l10n_it_account_stamp", "18.0.1.0.0/noupdate_changes.xml"
+        env, "l10n_it_account_stamp", "migrations/18.0.1.0.0/noupdate_changes.xml"
     )
     openupgrade.delete_record_translations(
         env.cr, "l10n_it_account_stamp", ["l10n_it_account_stamp_2_euro"]

--- a/l10n_it_account_stamp/migrations/18.0.1.0.0/pre-migration.py
+++ b/l10n_it_account_stamp/migrations/18.0.1.0.0/pre-migration.py
@@ -3,8 +3,6 @@
 
 from openupgradelib import openupgrade
 
-from odoo import SUPERUSER_ID, api
-
 
 def _rename_fields(env):
     openupgrade.rename_fields(
@@ -75,6 +73,5 @@ def _rename_fields(env):
 
 
 @openupgrade.migrate()
-def migrate(cr, version):
-    env = api.Environment(cr, SUPERUSER_ID, {})
+def migrate(env, version):
     _rename_fields(env)


### PR DESCRIPTION
This reverts commit f70fbb930e8bc2b6f383a528c9e41ddc0c36322b.
Rif. https://github.com/OCA/openupgradelib/blob/8a86014577d567883f73e36eea436af67096078d/openupgradelib/openupgrade.py#L2348-L2351