### PR TITLE
[FIX] l10n_it_vat_settlement_communication: fix migration script

### DIFF
--- a/l10n_it_vat_settlement_communication/migrations/18.0.1.0.0/pre-migrate.py
+++ b/l10n_it_vat_settlement_communication/migrations/18.0.1.0.0/pre-migrate.py
@@ -1,10 +1,12 @@
 #  Copyright 2025 Lorenzo Battistini
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from openupgradelib import openupgrade
 
 from odoo.addons.l10n_it_account_vat_period_end_settlement import hooks
 
 
-def migrate(env, installed_version):
+@openupgrade.migrate()
+def migrate(env, version):
     # Used by OpenUpgrade when module is in `apriori`
     hooks.pre_absorb_old_module(env)


### PR DESCRIPTION
According to
https://github.com/OCA/openupgradelib/blob/8a86014577d567883f73e36eea436af67096078d/openupgradelib/openupgrade.py#L2348-L2351 in order to have env as first parameter of migrate it needs the decorator openupgrade.migrate().