### PR TITLE
[16.0] [FIX] l10n_it_declaration_of_intent: fix for multiple DI

### DIFF
--- a/l10n_it_declaration_of_intent/models/account_move.py
+++ b/l10n_it_declaration_of_intent/models/account_move.py
@@ -220,6 +220,8 @@ class AccountMove(models.Model):
                 partner_id=self.partner_id.id,
                 date=self.invoice_date,
             )
+        ids = [dec.id for dec in sorted(declarations, key=lambda d: d.date_start)]
+        declarations = declaration_model.browse(ids)
         return declarations
 
     def get_declarations_used_amounts(self, declarations):

--- a/l10n_it_declaration_of_intent/models/account_move.py
+++ b/l10n_it_declaration_of_intent/models/account_move.py
@@ -278,6 +278,12 @@ class AccountMove(models.Model):
 
     def get_declaration_residual_amounts(self, declarations):
         """Get residual amount for every `declarations`."""
+        available_plafond = 0.0
+        if self.move_type in ["in_invoice", "in_refund"]:
+            plafond = self.company_id.declaration_yearly_limit_ids.filtered(
+                lambda r: r.year == str(fields.first(declarations).date_start.year)
+            )
+            available_plafond = plafond.limit_amount - plafond.actual_used_amount
         declarations_amounts = {}
         # If the tax amount is 0, then there is no line representing the tax
         # so there will be no line having tax_line_id.
@@ -293,9 +299,18 @@ class AccountMove(models.Model):
 
             for declaration in declarations:
                 if declaration.id not in declarations_amounts:
-                    declarations_amounts[declaration.id] = declaration.available_amount
+                    if (
+                        self.move_type in ["in_invoice", "in_refund"]
+                        and declaration.available_amount > available_plafond
+                    ):
+                        declarations_amounts[declaration.id] = available_plafond
+                    else:
+                        declarations_amounts[
+                            declaration.id
+                        ] = declaration.available_amount
                 if any(tax in declaration.taxes_ids for tax in tax_line.tax_ids):
                     declarations_amounts[declaration.id] -= amount
+                    amount = 0.0
         for declaration in declarations:
             # exclude amount from lines with invoice_id equals to self
             for line in declaration.line_ids.filtered(

--- a/l10n_it_declaration_of_intent/models/account_move.py
+++ b/l10n_it_declaration_of_intent/models/account_move.py
@@ -225,16 +225,37 @@ class AccountMove(models.Model):
     def get_declarations_used_amounts(self, declarations):
         """Get used amount by declarations for this invoice."""
         self.ensure_one()
+        declarations_available_amounts = {
+            declaration.id: declaration.available_amount for declaration in declarations
+        }
         declarations_used_amounts = {}
         sign = 1 if self.move_type in ["out_invoice", "in_invoice"] else -1
         for tax_line in self.line_ids.filtered("tax_ids"):
             amount = sign * tax_line.price_subtotal
-            for declaration in declarations:
+            matching_declarations = declarations.filtered(
+                lambda declaration, line_taxes=tax_line.tax_ids: any(
+                    tax in declaration.taxes_ids for tax in line_taxes
+                )
+            )
+            for declaration in matching_declarations:
                 if declaration.id not in declarations_used_amounts:
                     declarations_used_amounts[declaration.id] = 0
-                if any(tax in declaration.taxes_ids for tax in tax_line.tax_ids):
-                    declarations_used_amounts[declaration.id] += amount
-                    amount = 0.0
+
+                if declaration == matching_declarations[-1]:
+                    # If this is the last available declaration,
+                    # assign all the remaining amount.
+                    declaration_used_amount = amount
+                else:
+                    declaration_available_amount = declarations_available_amounts[
+                        declaration.id
+                    ]
+                    declaration_used_amount = min(amount, declaration_available_amount)
+                declarations_available_amounts[
+                    declaration.id
+                ] -= declaration_used_amount
+
+                declarations_used_amounts[declaration.id] += declaration_used_amount
+                amount -= declaration_used_amount
         return declarations_used_amounts
 
     def check_declarations_amounts(self, declarations):

--- a/l10n_it_declaration_of_intent/models/declaration.py
+++ b/l10n_it_declaration_of_intent/models/declaration.py
@@ -15,8 +15,12 @@ class DeclarationOfIntentYearlyLimit(models.Model):
 
     company_id = fields.Many2one("res.company", string="Company")
     year = fields.Char(required=True)
-    limit_amount = fields.Float()
-    used_amount = fields.Float(compute="_compute_used_amount")
+    limit_amount = fields.Float(string="Plafond")
+    # TODO align terms: used_amount > issued_declarations
+    used_amount = fields.Float(
+        string="Issued Declarations", compute="_compute_used_amount"
+    )
+    actual_used_amount = fields.Float(compute="_compute_used_amount")
 
     def _compute_used_amount(self):
         for record in self:
@@ -30,6 +34,7 @@ class DeclarationOfIntentYearlyLimit(models.Model):
                 ]
             )
             record.used_amount = sum([d.limit_amount for d in declarations])
+            record.actual_used_amount = sum([d.used_amount for d in declarations])
 
 
 class DeclarationOfIntent(models.Model):

--- a/l10n_it_declaration_of_intent/views/company_view.xml
+++ b/l10n_it_declaration_of_intent/views/company_view.xml
@@ -6,12 +6,13 @@
         <field name="inherit_id" ref="base.view_company_form" />
         <field name="arch" type="xml">
             <xpath expr="//page[last()]" position="after">
-                <page string="Declarations of intent">
+                <page string="Exporter Plafond">
                     <field name="declaration_yearly_limit_ids">
                         <tree editable="top">
                             <field name="year" />
                             <field name="limit_amount" />
                             <field name="used_amount" />
+                            <field name="actual_used_amount" />
                         </tree>
                     </field>
                 </page>

--- a/l10n_it_fatturapa_out_di/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out_di/tests/test_fatturapa_xml_validation.py
@@ -32,6 +32,9 @@ class TestFatturaPAXMLValidation(FatturaPACommon):
         self.env.company.fatturapa_fiscal_position_id = self.env.ref(
             "l10n_it_fatturapa.fatturapa_RF01"
         ).id
+        self.env.company.declaration_yearly_limit_ids = [
+            (0, 0, {"year": 2016, "limit_amount": 500})
+        ]
 
         self.env.ref("product.decimal_product_uom").digits = 3
         self.env.ref("uom.product_uom_unit").name = "Unit(s)"


### PR DESCRIPTION
Vd. #3310.

Il calcolo del residuo per DI multiple è scorretto.  L'ho allineando pescando codice dalla 14.0 che a oggi funziona. Ho cercato (con approssimazione) di dividere i contributi in base agli autori (Sergio e Simone), per cui ci sono 3 commit. Il terzo è il mio e fixa una situazione particolare se le DI vengono inserite a mano a partire dalla più recente (l'ordine rimaneva quello).