### PR TITLE
[IMP] l10n_it__account_stamp: force new pip version

### DIFF
--- a/l10n_it_account_stamp/__manifest__.py
+++ b/l10n_it_account_stamp/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "ITA - Imposta di bollo",
-    "version": "18.0.1.1.1",
+    "version": "18.0.1.1.2",
     "category": "Localization/Italy",
     "summary": "Gestione automatica dell'imposta di bollo",
     "author": "Ermanno Gnan, Sergio Corato, Enrico Ganzaroli, "


### PR DESCRIPTION
See https://github.com/OCA/l10n-italy/issues/4887 for futher info.

Le modifiche relative a https://github.com/OCA/l10n-italy/pull/4866 non risultano presenti su https://wheelhouse.odoo-community.org/oca-simple/odoo-addon-l10n-it-account-stamp/