### PR TITLE
[IMP] l10n_it_edi_extension: add admin_ref to res.partner

### DIFF
--- a/l10n_it_edi_extension/data/invoice_it_template.xml
+++ b/l10n_it_edi_extension/data/invoice_it_template.xml
@@ -34,8 +34,8 @@
         </xpath>
         <xpath expr="//CedentePrestatore/IscrizioneREA" position="after">
             <RiferimentoAmministrazione
-                t-if="company.l10n_edi_it_admin_ref"
-                t-out="company.l10n_edi_it_admin_ref"
+                t-if="partner.l10n_edi_it_admin_ref or company.l10n_edi_it_admin_ref"
+                t-out="partner.l10n_edi_it_admin_ref or company.l10n_edi_it_admin_ref"
             />
         </xpath>
         <xpath expr="//DatiGeneraliDocumento/ImportoTotaleDocumento" position="after">

--- a/l10n_it_edi_extension/models/res_partner.py
+++ b/l10n_it_edi_extension/models/res_partner.py
@@ -36,6 +36,7 @@ class ResPartnerInherit(models.Model):
         "Maximum: every line contained in the electronic bill "
         "will create a line in the bill.",
     )
+    l10n_edi_it_admin_ref = fields.Char(string="Administrative Reference")
 
     @api.constrains(
         "l10n_it_codice_fiscale",

--- a/l10n_it_edi_extension/views/res_partner_view.xml
+++ b/l10n_it_edi_extension/views/res_partner_view.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@id='invoice_send_settings']" position="inside">
                 <field name="l10n_edi_it_eori_code" />
+                <field name="l10n_edi_it_admin_ref" />
                 <field name="l10n_edi_it_electronic_invoice_no_contact_update" />
                 <field name="l10n_edi_it_register" />
                 <field name="l10n_edi_it_register_province_id" />


### PR DESCRIPTION
Per la specifica delle FatturaPA, il campo 1.2.6 Riferimento Amministrativo è definito come: "Codice identificativo del cedente / prestatore ai fini amministrativo-contabili". Noi lo usiamo quando un cliente (normalmente molto grosso) ce lo chiede per identificarci nel loro gestionale, quando capita, è il cliente che ce lo da e ci chiede di inserirlo nel campo. Per come è implementato ora, admin_ref si valorizza in res.company ed è uguale per tutti i partner, dovrebbe essere un codice per il partner specifico. 