### PR TITLE
[FIX] l10n_it_edi_extension: VAT mismatch, fix StabileOrganizzazione fields

### DIFF
--- a/l10n_it_edi_extension/models/account_move.py
+++ b/l10n_it_edi_extension/models/account_move.py
@@ -750,26 +750,35 @@ class AccountMoveInherit(models.Model):
                 )
             )
 
+        partner_anagrafica_xpath = f"{partner_info_xpath}//DatiAnagrafici"
+        partner_sede_xpath = f"{partner_info_xpath}//Sede"
+        partner_vat_xpath = f"{partner_anagrafica_xpath}//IdFiscaleIVA"
+        partner_contact_xpath = f"{partner_info_xpath}//Contatti"
+
         partner_info.update(
             {
-                "city_xpath": f"{partner_info_xpath}//Comune",
-                "codice_fiscale_xpath": f"{partner_info_xpath}//CodiceFiscale",
-                "country_code_xpath": f"{partner_info_xpath}//IdPaese",
-                "email_xpath": f"{partner_info_xpath}//Email",
-                "eori_code_xpath": f"{partner_info_xpath}//CodEORI",
-                "first_name_xpath": f"{partner_info_xpath}//Nome",
-                "last_name_xpath": f"{partner_info_xpath}//Cognome",
-                "name_xpath": f"{partner_info_xpath}//Denominazione",
-                "phone_xpath": f"{partner_info_xpath}//Telefono",
-                "register_code_xpath": f"{partner_info_xpath}//NumeroIscrizioneAlbo",
-                "register_regdate_xpath": f"{partner_info_xpath}//DataIscrizioneAlbo",
-                "register_state_xpath": f"{partner_info_xpath}//ProvinciaAlbo",
-                "register_xpath": f"{partner_info_xpath}//AlboProfessionale",
-                "state_xpath": f"{partner_info_xpath}//Provincia",
-                "street_number_xpath": f"{partner_info_xpath}//NumeroCivico",
-                "street_xpath": f"{partner_info_xpath}//Indirizzo",
-                "vat_xpath": f"{partner_info_xpath}//IdCodice",
-                "zip_xpath": f"{partner_info_xpath}//CAP",
+                "city_xpath": f"{partner_sede_xpath}//Comune",
+                "codice_fiscale_xpath": f"{partner_anagrafica_xpath}//CodiceFiscale",
+                "country_code_xpath": f"{partner_sede_xpath}//Nazione",
+                "email_xpath": f"{partner_contact_xpath}//Email",
+                "eori_code_xpath": f"{partner_anagrafica_xpath}//CodEORI",
+                "first_name_xpath": f"{partner_anagrafica_xpath}//Nome",
+                "last_name_xpath": f"{partner_anagrafica_xpath}//Cognome",
+                "name_xpath": f"{partner_anagrafica_xpath}//Denominazione",
+                "phone_xpath": f"{partner_contact_xpath}//Telefono",
+                "register_code_xpath": (
+                    f"{partner_anagrafica_xpath}//NumeroIscrizioneAlbo"
+                ),
+                "register_regdate_xpath": (
+                    f"{partner_anagrafica_xpath}//DataIscrizioneAlbo"
+                ),
+                "register_state_xpath": f"{partner_anagrafica_xpath}//ProvinciaAlbo",
+                "register_xpath": f"{partner_anagrafica_xpath}//AlboProfessionale",
+                "state_xpath": f"{partner_sede_xpath}//Provincia",
+                "street_number_xpath": f"{partner_sede_xpath}//NumeroCivico",
+                "street_xpath": f"{partner_sede_xpath}//Indirizzo",
+                "vat_xpath": f"{partner_vat_xpath}//IdCodice",
+                "zip_xpath": f"{partner_sede_xpath}//CAP",
             }
         )
 

--- a/l10n_it_edi_extension/models/account_move.py
+++ b/l10n_it_edi_extension/models/account_move.py
@@ -778,6 +778,7 @@ class AccountMoveInherit(models.Model):
                 "street_number_xpath": f"{partner_sede_xpath}//NumeroCivico",
                 "street_xpath": f"{partner_sede_xpath}//Indirizzo",
                 "vat_xpath": f"{partner_vat_xpath}//IdCodice",
+                "vat_country_xpath": f"{partner_vat_xpath}//IdPaese",
                 "zip_xpath": f"{partner_sede_xpath}//CAP",
             }
         )
@@ -819,6 +820,12 @@ class AccountMoveInherit(models.Model):
                     vals[field_name] = value
 
             country_code = get_text(tree, partner_info["country_code_xpath"])
+            if (
+                vat_country := get_text(tree, partner_info.get("vat_country_xpath", ""))
+            ) != country_code:
+                vat_code = get_text(tree, partner_info["vat_xpath"])
+                vals["vat"] = f"{vat_country}{vat_code}" if vat_country else vat_code
+
             if country := self.env["res.country"].search(
                 [
                     ("code", "=", country_code),

--- a/l10n_it_edi_extension/models/account_move.py
+++ b/l10n_it_edi_extension/models/account_move.py
@@ -309,19 +309,19 @@ class AccountMoveInherit(models.Model):
                     "l10n_it_edi_stabile_organizzazione_indirizzo": get_text(
                         element_stabile_organizzazione, ".//Indirizzo"
                     ),
-                    "l10n_it_edi_stabile_organizzazione_civico": get_date(
+                    "l10n_it_edi_stabile_organizzazione_civico": get_text(
                         element_stabile_organizzazione, ".//NumeroCivico"
                     ),
-                    "l10n_it_edi_stabile_organizzazione_cap": get_date(
+                    "l10n_it_edi_stabile_organizzazione_cap": get_text(
                         element_stabile_organizzazione, ".//CAP"
                     ),
-                    "l10n_it_edi_stabile_organizzazione_comune": get_date(
+                    "l10n_it_edi_stabile_organizzazione_comune": get_text(
                         element_stabile_organizzazione, ".//Comune"
                     ),
-                    "l10n_it_edi_stabile_organizzazione_provincia": get_date(
+                    "l10n_it_edi_stabile_organizzazione_provincia": get_text(
                         element_stabile_organizzazione, ".//Provincia"
                     ),
-                    "l10n_it_edi_stabile_organizzazione_nazione": get_date(
+                    "l10n_it_edi_stabile_organizzazione_nazione": get_text(
                         element_stabile_organizzazione, ".//Nazione"
                     ),
                 }

--- a/l10n_it_edi_extension/tests/import_xmls/IT02780790107_11004.xml
+++ b/l10n_it_edi_extension/tests/import_xmls/IT02780790107_11004.xml
@@ -36,6 +36,14 @@
                 <Provincia>SS</Provincia>
                 <Nazione>IT</Nazione>
             </Sede>
+            <StabileOrganizzazione>
+                <Indirizzo>VIA PROVA 12</Indirizzo>
+                <NumeroCivico>12</NumeroCivico>
+                <CAP>00100</CAP>
+                <Comune>ROMA</Comune>
+                <Provincia>RM</Provincia>
+                <Nazione>IT</Nazione>
+            </StabileOrganizzazione>
         </CedentePrestatore>
         <RappresentanteFiscale>
             <DatiAnagrafici>

--- a/l10n_it_edi_extension/tests/import_xmls/IT99490540210_EESO5.xml
+++ b/l10n_it_edi_extension/tests/import_xmls/IT99490540210_EESO5.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ns2:FatturaElettronica
+    xmlns:ns2="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+    versione="FPR12"
+>
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>99490540210</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>00000</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>UFPQ1O</CodiceDestinatario>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>99490540210</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>Test Seller Company SA</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>10 Estero Road</Indirizzo>
+                <CAP>00000</CAP>
+                <Comune>Test City</Comune>
+                <Nazione>AD</Nazione>
+            </Sede>
+            <StabileOrganizzazione>
+                <Indirizzo>Viale Tunisia 17</Indirizzo>
+                <CAP>12010</CAP>
+                <Comune>Prova</Comune>
+                <Provincia>PR</Provincia>
+                <Nazione>IT</Nazione>
+            </StabileOrganizzazione>
+            <IscrizioneREA>
+                <Ufficio>MI</Ufficio>
+                <NumeroREA>99490540210</NumeroREA>
+                <StatoLiquidazione>LN</StatoLiquidazione>
+            </IscrizioneREA>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>AMMINISTRAZIONE BETA</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIA TORINO 38-B</Indirizzo>
+                <CAP>00145</CAP>
+                <Comune>ROMA</Comune>
+                <Provincia>RM</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2026-02-01</Data>
+                <Numero>111111</Numero>
+                <ImportoTotaleDocumento>1.22</ImportoTotaleDocumento>
+            </DatiGeneraliDocumento>
+            <FatturaPrincipale>
+                <NumeroFatturaPrincipale>111111</NumeroFatturaPrincipale>
+                <DataFatturaPrincipale>2026-02-01</DataFatturaPrincipale>
+            </FatturaPrincipale>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>Example Service</Descrizione>
+                <DataInizioPeriodo>2026-01-01</DataInizioPeriodo>
+                <DataFinePeriodo>2026-01-31</DataFinePeriodo>
+                <PrezzoUnitario>1.00</PrezzoUnitario>
+                <PrezzoTotale>1.00</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <Arrotondamento>0.00</Arrotondamento>
+                <ImponibileImporto>1.00</ImponibileImporto>
+                <Imposta>0.22</Imposta>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+    </FatturaElettronicaBody>
+</ns2:FatturaElettronica>

--- a/l10n_it_edi_extension/tests/test_import_edi_extension_xml.py
+++ b/l10n_it_edi_extension/tests/test_import_edi_extension_xml.py
@@ -113,6 +113,14 @@ class TestFatturaPAXMLValidation(Common):
                 any(tag in str(body) for body in move.mapped("message_ids.body")),
                 f"'{tag}' not found in message bodies",
             )
+        self.assertEqual(
+            move.l10n_it_edi_stabile_organizzazione_indirizzo, "VIA PROVA 12"
+        )
+        self.assertEqual(move.l10n_it_edi_stabile_organizzazione_civico, "12")
+        self.assertEqual(move.l10n_it_edi_stabile_organizzazione_cap, "00100")
+        self.assertEqual(move.l10n_it_edi_stabile_organizzazione_comune, "ROMA")
+        self.assertEqual(move.l10n_it_edi_stabile_organizzazione_provincia, "RM")
+        self.assertEqual(move.l10n_it_edi_stabile_organizzazione_nazione, "IT")
 
         # verify if attached documents are correctly imported
         attachments = self.env["ir.attachment"].search(

--- a/l10n_it_edi_extension/tests/test_import_edi_extension_xml.py
+++ b/l10n_it_edi_extension/tests/test_import_edi_extension_xml.py
@@ -134,6 +134,24 @@ class TestFatturaPAXMLValidation(Common):
             orig_attachment_data = orig_attachment.read()
             self.assertEqual(attachments[0].raw, orig_attachment_data)
 
+    def test_05_xml_import_stabile_organizzazione(self):
+        move = self._edi_import_invoice("IT99490540210_EESO5.xml")
+        move._extend_with_attachments(move.l10n_it_edi_attachment_id, new=True)
+        self.assertEqual(move.ref, "111111")
+        self.assertEqual(move.partner_id.name, "Test Seller Company SA")
+        self.assertEqual(move.partner_id.street, "10 Estero Road")
+        self.assertEqual(move.partner_id.zip, "00000")
+        self.assertEqual(move.partner_id.city, "Test City")
+        self.assertEqual(move.partner_id.country_id.code, "AD")
+        self.assertEqual(move.partner_id.vat, "IT99490540210")
+        self.assertEqual(
+            move.l10n_it_edi_stabile_organizzazione_indirizzo, "Viale Tunisia 17"
+        )
+        self.assertEqual(move.l10n_it_edi_stabile_organizzazione_cap, "12010")
+        self.assertEqual(move.l10n_it_edi_stabile_organizzazione_comune, "Prova")
+        self.assertEqual(move.l10n_it_edi_stabile_organizzazione_provincia, "PR")
+        self.assertEqual(move.l10n_it_edi_stabile_organizzazione_nazione, "IT")
+
     def test_import_zip(self):
         zip_name = "xml_import.zip"
         moves = self._import_moves_from_zip(zip_name)


### PR DESCRIPTION
- Usare partita iva con codice paese se codice paese non coincide con nazione.
- Usare campi xpath più definiti per evitare che campi vuoti vengano riempiti da altri campi con nomi uguali da xpath
- Stabile organizzazione usava get_date invece che get_text per pulire i campi.

https://github.com/OCA/l10n-italy/issues/5066