### PR TITLE
[IMP] l10n_it_edi_extension: Test per esportazione causale

### DIFF
--- a/l10n_it_edi_extension/tests/__init__.py
+++ b/l10n_it_edi_extension/tests/__init__.py
@@ -1,2 +1,5 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_export
 from . import test_import_edi_extension_xml
 from . import test_fiscalcode

--- a/l10n_it_edi_extension/tests/common.py
+++ b/l10n_it_edi_extension/tests/common.py
@@ -1,0 +1,13 @@
+#  Copyright 2024 Simone Rubino - Aion Tech
+#  Copyright 2025 Simone Rubino
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo.addons.l10n_it_edi.tests.common import TestItEdi
+
+
+class Common(TestItEdi):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.module = "l10n_it_edi_extension"

--- a/l10n_it_edi_extension/tests/export_xmls/narration.xml
+++ b/l10n_it_edi_extension/tests/export_xmls/narration.xml
@@ -1,0 +1,99 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<p:FatturaElettronica
+    xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd"
+    versione="FPR12"
+>
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>V201900001</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>0000000</CodiceDestinatario>
+            <ContattiTrasmittente>
+                <Telefono>0266766700</Telefono>
+                <Email>test@test.it</Email>
+            </ContattiTrasmittente>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>01234560157</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>company_2_data</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>1234 Test Street</Indirizzo>
+                <CAP>12345</CAP>
+                <Comune>Prova</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>00465840031</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>93026890017</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>Alessi</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Privata Alessi 6</Indirizzo>
+                <CAP>28887</CAP>
+                <Comune>Milan</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2019-01-01</Data>
+                <Numero>INV/2019/00001</Numero>
+                <ImportoTotaleDocumento>122.00</ImportoTotaleDocumento>
+                <Causale>first line</Causale>
+                <Causale>second line</Causale>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>test line</Descrizione>
+                <Quantita>1.00</Quantita>
+                <PrezzoUnitario>100.00000000</PrezzoUnitario>
+                <PrezzoTotale>100.00000000</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>100.00</ImponibileImporto>
+                <Imposta>22.00</Imposta>
+                <EsigibilitaIVA>I</EsigibilitaIVA>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2019-01-01</DataScadenzaPagamento>
+                <ImportoPagamento>122.00</ImportoPagamento>
+                <CodicePagamento>INV/2019/00001</CodicePagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_edi_extension/tests/test_export.py
+++ b/l10n_it_edi_extension/tests/test_export.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Simone Rubino
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from .common import Common
+
+
+class TestExport(Common):
+    def test_narration(self):
+        """The narration included in the invoice
+        is exported to the XML in Causale nodes."""
+        invoice = self.init_invoice(
+            "out_invoice",
+            amounts=[100],
+            company=self.company,
+            partner=self.italian_partner_a,
+            taxes=self.default_tax,
+        )
+        invoice.invoice_date_due = invoice.date
+        invoice.narration = "first line\n\nsecond line"
+        invoice.action_post()
+        self._assert_export_invoice(invoice, "narration.xml")

--- a/l10n_it_edi_extension/tests/test_import_edi_extension_xml.py
+++ b/l10n_it_edi_extension/tests/test_import_edi_extension_xml.py
@@ -7,14 +7,13 @@ from datetime import date
 
 from odoo import tools
 
-from odoo.addons.l10n_it_edi.tests.common import TestItEdi
+from .common import Common
 
 
-class TestFatturaPAXMLValidation(TestItEdi):
+class TestFatturaPAXMLValidation(Common):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.module = "l10n_it_edi_extension"
         cls.env.company.l10n_edi_it_create_partner = True
         cls.company.l10n_edi_it_create_partner = True
 


### PR DESCRIPTION
Non creo issue perché nelle altre versioni non serve.

Visto che non ci sono test per l'export, serve per testare il flusso di esportazione.