### PR TITLE
[FIX] l10n_it_edi_extension: fix add_fields argument

### DIFF
--- a/l10n_it_edi_extension/__init__.py
+++ b/l10n_it_edi_extension/__init__.py
@@ -838,7 +838,7 @@ def _l10n_it_fiscal_payment_term_post_migration(env):
                 "account.move",
                 "account_move",
                 "selection",
-                "selection",
+                "varchar",
                 "l10n_it_edi_ndd",
                 False,
             )


### PR DESCRIPTION
pass the right argument for `add_fields` https://github.com/OCA/openupgradelib/blob/master/openupgradelib/openupgrade.py#L3130

here you can see the conversion table:
https://github.com/OCA/l10n-italy/blob/18.0/l10n_it_account/migrations/18.0.1.0.0/post-migration.py#L67
