### PR TITLE
[18.0] FIX l10n_it_vat_registries: AttributeError: 'account.tax' object has no attribute '_l10n_it_get_tax_kind'

### DIFF
--- a/l10n_it_vat_registries/models/vat_registry.py
+++ b/l10n_it_vat_registries/models/vat_registry.py
@@ -65,10 +65,10 @@ class ReportRegistroIva(models.AbstractModel):
 
         for move_line in move_lines:
             taxes = move_line.tax_ids.filtered(
-                lambda tax: tax._l10n_it_get_tax_kind() in [None, "vat"]
+                lambda tax: tax._l10n_it_filter_kind("vat")
             )
             tax_line = move_line.tax_line_id.filtered(
-                lambda tax: tax._l10n_it_get_tax_kind() in [None, "vat"]
+                lambda tax: tax._l10n_it_filter_kind("vat")
             )
 
             if not (tax_line or taxes):


### PR DESCRIPTION

https://github.com/OCA/l10n-italy/issues/4923