### PR TITLE
[18.0][IMP] l10n_it_account_stamp: add sync with l10n_it_stamp_duty

### DIFF
--- a/l10n_it_account_stamp/README.rst
+++ b/l10n_it_account_stamp/README.rst
@@ -30,12 +30,19 @@ ITA - Imposta di bollo
 
 **Italiano**
 
-Questo modulo aggiunge il supporto all'imposta di bollo italiana nelle
-fatture e nelle ricevute.
+Questo modulo permette di calcolare automaticamente ed addebitare al
+cliente l'imposta di bollo italiana nelle fatture e nelle ricevute
+mantenendo la sincronizzazione con il campo "Dati Bollo"
+(``l10n_it_stamp_duty``) di ``l10n_it_edi``. In questo modo l'elemento
+XML ``<DatiBollo>`` verrà valorizzato correttamente.
 
 **English**
 
-This module adds Italian Stamp Duty support in invoices and receipts.
+This module allows to automatically compute and charge the Italian stamp
+duty to customers in invoices and receipts while maintaining
+synchronization with the "Stamp Duty Data" field
+(``l10n_it_stamp_duty``) of ``l10n_it_edi``. In this way XML tag
+``<DatiBollo>`` will be correctly set.
 
 **Table of contents**
 
@@ -57,20 +64,20 @@ necessario abilitare le funzioni complete per la contabilità:
 
 Modalità automatica:
 
-- andare sul prodotto "Imposta di bollo 2 euro" e configurare "Imposte
-  per bollo" (Imposte in esenzione).
-- per ciascuna fattura o ricevuta, l'applicabilità dell'imposta di bollo
-  verrà calcolata in modo automatico in base alla somma degli imponibili
-  relativi alle imposte selezionate.
+-  andare sul prodotto "Imposta di bollo 2 euro" e configurare "Imposte
+   per bollo" (Imposte in esenzione).
+-  per ciascuna fattura o ricevuta, l'applicabilità dell'imposta di
+   bollo verrà calcolata in modo automatico in base alla somma degli
+   imponibili relativi alle imposte selezionate.
 
 Modalità manuale:
 
-- andare sul prodotto "Imposta di bollo 2 euro" e deselezionare la
-  casella "Calcolo automatico".
-- per ciascuna fattura o ricevuta, abilitare manualmente la casella di
-  selezione "Imposta di bollo". L'applicabilità dell'imposta di bollo
-  verrà calcolata in base alla somma degli imponibili relativi alle
-  imposte selezionate.
+-  andare sul prodotto "Imposta di bollo 2 euro" e deselezionare la
+   casella "Calcolo automatico".
+-  per ciascuna fattura o ricevuta, abilitare manualmente la casella di
+   selezione "Imposta di bollo". L'applicabilità dell'imposta di bollo
+   verrà calcolata in base alla somma degli imponibili relativi alle
+   imposte selezionate.
 
 Impostare i conti di ricavo/costo nella scheda "Contabilità",
 generalmente ricavo="Debiti per bolli" e costo="Valori bollati".
@@ -86,17 +93,17 @@ accounting features:
 
 Automatic mode:
 
-- Go to 'Stamp duty 2 euro' product and configure 'Stamp taxes'
-  (exemption taxes).
-- For each invoice or receipt, the base amount for each selected tax
-  will be added up and used to determine the application of the account
-  stamp.
+-  Go to 'Stamp duty 2 euro' product and configure 'Stamp taxes'
+   (exemption taxes).
+-  For each invoice or receipt, the base amount for each selected tax
+   will be added up and used to determine the application of the account
+   stamp.
 
 Manual mode:
 
-- Go to 'Stamp duty 2 euro' product and deselect 'Auto-compute'
-  checkbox.
-- For each invoice or receipt, manually enable 'Stamp Duty' checkbox.
+-  Go to 'Stamp duty 2 euro' product and deselect 'Auto-compute'
+   checkbox.
+-  For each invoice or receipt, manually enable 'Stamp Duty' checkbox.
 
 Also set income/expense accounts, typically income = 'Debiti per bolli'
 and expense = 'Valori bollati'.
@@ -157,17 +164,19 @@ Authors
 Contributors
 ------------
 
-- Lorenzo Battistini <https://github.com/eLBati>
-- Sergio Corato
-- Ermanno Gnan
-- Enrico Ganzaroli
-- Sergio Zanchetta <https://github.com/primes2h>
-- Marco Colombo <https://github.com/TheMule71>
-- Gianmarco Conte <gconte@dinamicheaziendali.it>
-- Giovanni Serra <giovanni@gslab.it>
-- `Aion Tech <https://aiontech.company/>`__:
+-  Lorenzo Battistini <https://github.com/eLBati>
+-  Sergio Corato
+-  Ermanno Gnan
+-  Enrico Ganzaroli
+-  Sergio Zanchetta <https://github.com/primes2h>
+-  Marco Colombo <https://github.com/TheMule71>
+-  Gianmarco Conte <gconte@dinamicheaziendali.it>
+-  Giovanni Serra <giovanni@gslab.it>
+-  `Aion Tech <https://aiontech.company/>`__:
 
-  - Simone Rubino <simone.rubino@aion-tech.it>
+   -  Simone Rubino <simone.rubino@aion-tech.it>
+
+-  `Nextev Srl <https://www.nextev.it>`__
 
 Maintainers
 -----------

--- a/l10n_it_account_stamp/__manifest__.py
+++ b/l10n_it_account_stamp/__manifest__.py
@@ -17,7 +17,7 @@
     "license": "LGPL-3",
     "depends": [
         "product",
-        "account",
+        "l10n_it_edi",
     ],
     "data": [
         "data/data.xml",

--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -25,6 +25,27 @@ class AccountMove(models.Model):
     l10n_it_account_stamp_manually_apply_stamp_duty = fields.Boolean(
         string="Apply stamp duty",
     )
+    l10n_it_stamp_duty = fields.Float(
+        compute="_compute_l10n_it_stamp_duty",
+        store=True,
+    )
+
+    @api.depends(
+        "l10n_it_account_stamp_is_stamp_duty_applied",
+        "company_id.l10n_it_account_stamp_stamp_duty_product_id.list_price",
+    )
+    def _compute_l10n_it_stamp_duty(self):
+        for invoice in self:
+            if invoice.state != "draft":
+                continue
+            elif invoice.l10n_it_account_stamp_is_stamp_duty_applied:
+                stamp_product = (
+                    invoice.company_id.l10n_it_account_stamp_stamp_duty_product_id
+                )
+                stamp_duty_amount = stamp_product.list_price
+            else:
+                stamp_duty_amount = 0
+            invoice.l10n_it_stamp_duty = stamp_duty_amount
 
     def is_stamp_duty_applicable(self):
         stamp_product_id = self.company_id.with_context(

--- a/l10n_it_account_stamp/readme/CONTRIBUTORS.md
+++ b/l10n_it_account_stamp/readme/CONTRIBUTORS.md
@@ -8,3 +8,4 @@
 - Giovanni Serra \<<giovanni@gslab.it>\>
 - [Aion Tech](https://aiontech.company/):
   - Simone Rubino \<<simone.rubino@aion-tech.it>\>
+- [Nextev Srl](https://www.nextev.it)

--- a/l10n_it_account_stamp/readme/DESCRIPTION.md
+++ b/l10n_it_account_stamp/readme/DESCRIPTION.md
@@ -1,8 +1,9 @@
 **Italiano**
 
-Questo modulo aggiunge il supporto all'imposta di bollo italiana nelle
-fatture e nelle ricevute.
+Questo modulo permette di calcolare automaticamente ed addebitare al cliente l'imposta di bollo italiana nelle fatture e nelle ricevute mantenendo la sincronizzazione con il campo "Dati Bollo" (`l10n_it_stamp_duty`) di `l10n_it_edi`.
+In questo modo l'elemento XML `<DatiBollo>` verrà valorizzato correttamente.
 
 **English**
 
-This module adds Italian Stamp Duty support in invoices and receipts.
+This module allows to automatically compute and charge the Italian stamp duty to customers in invoices and receipts while maintaining synchronization with the "Stamp Duty Data" field (`l10n_it_stamp_duty`) of `l10n_it_edi`.
+In this way XML tag `<DatiBollo>` will be correctly set.

--- a/l10n_it_account_stamp/static/description/index.html
+++ b/l10n_it_account_stamp/static/description/index.html
@@ -371,10 +371,17 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/l10n-italy/tree/18.0/l10n_it_account_stamp"><img alt="OCA/l10n-italy" src="https://img.shields.io/badge/github-OCA%2Fl10n--italy-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/l10n-italy-18-0/l10n-italy-18-0-l10n_it_account_stamp"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/l10n-italy&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p><strong>Italiano</strong></p>
-<p>Questo modulo aggiunge il supporto all’imposta di bollo italiana nelle
-fatture e nelle ricevute.</p>
+<p>Questo modulo permette di calcolare automaticamente ed addebitare al
+cliente l’imposta di bollo italiana nelle fatture e nelle ricevute
+mantenendo la sincronizzazione con il campo “Dati Bollo”
+(<tt class="docutils literal">l10n_it_stamp_duty</tt>) di <tt class="docutils literal">l10n_it_edi</tt>. In questo modo l’elemento
+XML <tt class="docutils literal">&lt;DatiBollo&gt;</tt> verrà valorizzato correttamente.</p>
 <p><strong>English</strong></p>
-<p>This module adds Italian Stamp Duty support in invoices and receipts.</p>
+<p>This module allows to automatically compute and charge the Italian stamp
+duty to customers in invoices and receipts while maintaining
+synchronization with the “Stamp Duty Data” field
+(<tt class="docutils literal">l10n_it_stamp_duty</tt>) of <tt class="docutils literal">l10n_it_edi</tt>. In this way XML tag
+<tt class="docutils literal">&lt;DatiBollo&gt;</tt> will be correctly set.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -405,9 +412,9 @@ selezionarlo</li>
 <ul class="simple">
 <li>andare sul prodotto “Imposta di bollo 2 euro” e configurare “Imposte
 per bollo” (Imposte in esenzione).</li>
-<li>per ciascuna fattura o ricevuta, l’applicabilità dell’imposta di bollo
-verrà calcolata in modo automatico in base alla somma degli imponibili
-relativi alle imposte selezionate.</li>
+<li>per ciascuna fattura o ricevuta, l’applicabilità dell’imposta di
+bollo verrà calcolata in modo automatico in base alla somma degli
+imponibili relativi alle imposte selezionate.</li>
 </ul>
 <p>Modalità manuale:</p>
 <ul class="simple">
@@ -501,6 +508,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.nextev.it">Nextev Srl</a></li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
+++ b/l10n_it_account_stamp/tests/test_account_stamp_invoicing.py
@@ -130,3 +130,87 @@ class InvoicingTest(TestAccountInvoiceReport):
         self.assertEqual(
             len(invoice.line_ids.filtered(lambda line: line.is_stamp_line)), 0
         )
+
+    def test_compute_l10n_it_stamp_duty(self):
+        """Test that l10n_it_stamp_duty is correctly computed based on stamp
+        application and product price."""
+        stamp_product = self.env.company.l10n_it_account_stamp_stamp_duty_product_id
+        stamp_price = stamp_product.list_price
+
+        # Test 1: Invoice in draft with stamp duty applied
+        invoice = first(
+            self.invoices.filtered(lambda inv: inv.move_type == "out_invoice")
+        )
+        invoice.invoice_line_ids[0].write({"tax_ids": [(6, 0, [self.tax_id.id])]})
+        self.assertTrue(invoice.l10n_it_account_stamp_is_stamp_duty_applied)
+        self.assertEqual(invoice.state, "draft")
+        self.assertEqual(
+            invoice.l10n_it_stamp_duty,
+            stamp_price,
+            "Stamp duty should equal product price when applied in draft",
+        )
+
+        # Test 2: Invoice in draft without stamp duty applied
+        invoice2 = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner_a.id,
+                "invoice_date": "2024-01-01",
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Test Product Without Stamp",
+                            "price_unit": 100.0,
+                            "quantity": 1,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertFalse(invoice2.l10n_it_account_stamp_is_stamp_duty_applied)
+        self.assertEqual(invoice2.state, "draft")
+        self.assertEqual(
+            invoice2.l10n_it_stamp_duty,
+            0,
+            "Stamp duty should be 0 when not applied",
+        )
+
+        # Test 3: Posted invoice should keep value from draft
+        invoice.action_post()
+        self.assertEqual(invoice.state, "posted")
+        self.assertEqual(
+            invoice.l10n_it_stamp_duty,
+            stamp_price,
+            "Stamp duty should be preserved after posting",
+        )
+
+        # Test 4: Change stamp product price and verify recomputation
+        new_price = 5.0
+        stamp_product.list_price = new_price
+        invoice3 = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner_a.id,
+                "invoice_date": "2024-01-01",
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Test Product",
+                            "price_unit": 100.0,
+                            "quantity": 1,
+                            "tax_ids": [(6, 0, [self.tax_id.id])],
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertTrue(invoice3.l10n_it_account_stamp_is_stamp_duty_applied)
+        self.assertEqual(
+            invoice3.l10n_it_stamp_duty,
+            new_price,
+            "Stamp duty should reflect updated product price",
+        )


### PR DESCRIPTION
Attualmente il modulo `l10n_it_account_stamp` alla 18.0 non imposta i dati nella generazione dei file XML della fattura elettronica.

Ho preso spunto da questa PR che poi si è persa nel cambio di branch: https://github.com/OCA/l10n-italy/pull/4374/

Non dovrebbero essere necessarie migrazioni o altre precauzioni prima di aggiornare il modulo perchè, seppur venga aggiunto un metodo per calcolare il campo `l10n_it_stamp_duty` che prima era impostato manualmente, questa compute aggiorna il valore solo se la fattura è in bozza.