### PR TITLE
[14.0][FIX] l10n_it_delivery_note check with origin of locations instead of locations

### DIFF
--- a/l10n_it_delivery_note/mixins/picking_checker.py
+++ b/l10n_it_delivery_note/mixins/picking_checker.py
@@ -74,9 +74,15 @@ class StockPickingCheckerMixin(models.AbstractModel):
                 _("You need to select pickings with all the same recipient.")
             )
 
+    def _get_first_view_location(self, location_id):
+        if location_id.usage == "view" or not location_id.location_id:
+            return location_id
+        else:
+            return self._get_first_view_location(location_id.location_id)
+
     @api.model
     def _check_pickings_src_locations(self, pickings):
-        src_locations = pickings.mapped("location_id")
+        src_locations = {self._get_first_view_location(x.location_id) for x in pickings}
 
         if not src_locations:
             raise ValidationError(
@@ -96,7 +102,9 @@ class StockPickingCheckerMixin(models.AbstractModel):
 
     @api.model
     def _check_pickings_dest_locations(self, pickings):
-        dest_locations = pickings.mapped("location_dest_id")
+        dest_locations = {
+            self._get_first_view_location(x.location_dest_id) for x in pickings
+        }
 
         if not dest_locations:
             raise ValidationError(


### PR DESCRIPTION
Ho modificato il controllo basandomi sulla prima locazione genitore di tipo vista.

Non mi pare ci sia la possibilità di creare ubicazioni con indirizzi diversi all'interno di uno stesso genitore, fino al primo di tipo vista (poi i genitori ulteriori sono generici).