### PR TITLE
FIX 18.0 l10n_it_edi_extension - error importing invoices with detail level not MAX

### DIFF
--- a/l10n_it_edi_extension/__manifest__.py
+++ b/l10n_it_edi_extension/__manifest__.py
@@ -20,6 +20,7 @@
         "account",
         "l10n_it_edi",
         "partner_firstname",
+        "l10n_it_edi_withholding",
     ],
     "data": [
         "security/ir.model.access.csv",


### PR DESCRIPTION
Fixes #4944



Per dare un po' di contesto alla modifica: 
l10n_it_edi_extension per `import_detail_level` "tax" e "min", esegue l'[unlink()](https://github.com/OCA/l10n-italy/blob/9c91903f49b19bed412a4cf484bc4be72fdf0047/l10n_it_edi_extension/models/account_move.py#L441) delle righe non necessarie. 
  Questo però fa andare in errore altri moduli che chiamano la stessa funzione aspettandosi che quelle righe esistano (vedi [l10n_it_edi_withholding](https://github.com/odoo/odoo/blob/9a66d0676eedde5d3d9bed6518d4dde921cd9d91/addons/l10n_it_edi_withholding/models/account_move.py#L320))
  
  Con questa fix ci assicuriamo che le funzioni vengano eseguite nell'ordine corretto per poter supportare l'unlink()