### PR TITLE
[16.0][FIX] l10n_it_split_payment: multi-taxes

### DIFF
--- a/l10n_it_split_payment/models/account_move.py
+++ b/l10n_it_split_payment/models/account_move.py
@@ -4,7 +4,8 @@
 # Copyright 2023  Giuseppe Borruso <gborruso@dinamicheaziendali.it>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import Command, fields, models
+from odoo import Command, _, fields, models
+from odoo.exceptions import UserError
 from odoo.tools import float_compare
 
 
@@ -26,8 +27,6 @@ class AccountMove(models.Model):
         res = super()._compute_amount()
         for move in self:
             if move.split_payment:
-                if move.is_purchase_document():
-                    continue
                 if move.tax_totals:
                     move.amount_sp = (
                         move.tax_totals["amount_total"]
@@ -48,7 +47,11 @@ class AccountMove(models.Model):
         )
         if self.env.context.get("skip_split_payment_computation"):
             return res
-        self.compute_split_payment()
+        if "fiscal_position_id" in vals:
+            self._compute_amount()
+        self.with_context(
+            skip_split_payment_computation=True, check_move_validity=False
+        ).compute_split_payment()
         container = {"records": self}
         self._check_balanced(container)
         return res
@@ -63,15 +66,57 @@ class AccountMove(models.Model):
             res = super().copy(default=default)
         return res
 
+    def _build_writeoff_line(self):
+        self.ensure_one()
+
+        if not self.company_id.sp_account_id:
+            raise UserError(
+                _(
+                    "Please set 'Split Payment Write-off Account' field in"
+                    " accounting configuration"
+                )
+            )
+        debit = 0
+        credit = 0
+        move_tax_lines = self.line_ids.filtered(
+            lambda line: ((line.display_type == "tax") and (not line.is_split_payment))
+        )
+        for tax_line in move_tax_lines:
+            debit += tax_line.credit
+            credit += tax_line.debit
+        if debit != 0 and credit != 0:
+            if debit >= credit:
+                debit = debit - credit
+                credit = 0
+            else:
+                credit = credit - debit
+                debit = 0
+
+        vals = {
+            "name": _("Split Payment Write Off"),
+            "partner_id": self.partner_id.id,
+            "account_id": self.company_id.sp_account_id.id,
+            "journal_id": self.journal_id.id,
+            "date": self.invoice_date,
+            "date_maturity": self.invoice_date,
+            "price_unit": -debit + credit,
+            "amount_currency": debit - credit,
+            "debit": debit,
+            "credit": credit,
+            "display_type": "tax",
+            "is_split_payment": True,
+        }
+        return vals
+
     def compute_split_payment(self):
         for move in self:
-            if move.split_payment:
+            if move.is_sale_document(include_receipts=True):
                 line_sp = fields.first(
                     move.line_ids.filtered(lambda move_line: move_line.is_split_payment)
                 )
-                for line in move.line_ids:
-                    if line.display_type == "tax" and not line.is_split_payment:
-                        write_off_line_vals = line._build_writeoff_line()
+                with move._sync_dynamic_lines(container={"records": move}):
+                    if move.split_payment:
+                        write_off_line_vals = move._build_writeoff_line()
                         if line_sp:
                             if (
                                 float_compare(
@@ -81,9 +126,26 @@ class AccountMove(models.Model):
                                 )
                                 != 0
                             ):
-                                line_sp.write(write_off_line_vals)
+                                line_sp.with_context(
+                                    skip_split_payment_computation=True
+                                ).write(write_off_line_vals)
                         else:
-                            if move.amount_sp:
+                            if write_off_line_vals.get("price_unit"):
                                 move.with_context(
                                     skip_split_payment_computation=True
                                 ).line_ids = [Command.create(write_off_line_vals)]
+                    elif line_sp:
+                        neutralize_vals = {
+                            "debit": 0.0,
+                            "credit": 0.0,
+                            "amount_currency": 0.0,
+                            "price_unit": 0.0,
+                            "tax_base_amount": 0.0,
+                            "tax_tag_ids": [(6, 0, [])],
+                        }
+                        move.with_context(
+                            skip_split_payment_computation=True,
+                            check_move_validity=False,
+                        ).write(
+                            {"line_ids": [Command.update(line_sp.id, neutralize_vals)]}
+                        )

--- a/l10n_it_split_payment/models/account_move.py
+++ b/l10n_it_split_payment/models/account_move.py
@@ -42,18 +42,18 @@ class AccountMove(models.Model):
         return res
 
     def write(self, vals):
+        if self.env.context.get("skip_split_payment_computation"):
+            return super().write(vals)
         res = super(AccountMove, self.with_context(check_move_validity=False)).write(
             vals
         )
-        if self.env.context.get("skip_split_payment_computation"):
-            return res
-        if "fiscal_position_id" in vals:
-            self._compute_amount()
-        self.with_context(
-            skip_split_payment_computation=True, check_move_validity=False
-        ).compute_split_payment()
         container = {"records": self}
-        self._check_balanced(container)
+        with self._check_balanced(container):
+            if "fiscal_position_id" in vals:
+                self._compute_amount()
+            self.with_context(
+                skip_split_payment_computation=True, check_move_validity=False
+            ).compute_split_payment()
         return res
 
     def copy(self, default=None):

--- a/l10n_it_split_payment/models/account_move_line.py
+++ b/l10n_it_split_payment/models/account_move_line.py
@@ -17,7 +17,7 @@ class AccountMoveLine(models.Model):
     def _compute_is_split_payment(self):
         for line in self:
             line.is_split_payment = False
-            if line.account_id == line.company_id.sp_account_id:
+            if line.account_id and line.account_id == line.company_id.sp_account_id:
                 line.is_split_payment = True
 
     def _compute_all_tax(self):

--- a/l10n_it_split_payment/models/account_move_line.py
+++ b/l10n_it_split_payment/models/account_move_line.py
@@ -4,8 +4,8 @@
 # Copyright 2023  Giuseppe Borruso <gborruso@dinamicheaziendali.it>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo import api, fields, models
+from odoo.tools import frozendict
 
 
 class AccountMoveLine(models.Model):
@@ -20,49 +20,40 @@ class AccountMoveLine(models.Model):
             if line.account_id == line.company_id.sp_account_id:
                 line.is_split_payment = True
 
-    def _build_writeoff_line(self):
-        self.ensure_one()
-
-        if not self.move_id.company_id.sp_account_id:
-            raise UserError(
-                _(
-                    "Please set 'Split Payment Write-off Account' field in"
-                    " accounting configuration"
-                )
-            )
-        vals = {
-            "name": _("Split Payment Write Off"),
-            "partner_id": self.move_id.partner_id.id,
-            "account_id": self.move_id.company_id.sp_account_id.id,
-            "journal_id": self.move_id.journal_id.id,
-            "date": self.move_id.invoice_date,
-            "date_maturity": self.move_id.invoice_date,
-            "price_unit": -self.credit,
-            "amount_currency": self.credit,
-            "debit": self.credit,
-            "credit": self.debit,
-            "display_type": "tax",
-        }
-        if self.move_id.move_type == "out_refund":
-            vals["amount_currency"] = -self.debit
-            vals["debit"] = self.credit
-            vals["credit"] = self.debit
-        return vals
+    def _compute_all_tax(self):
+        res = None
+        for line in self:
+            res = super(AccountMoveLine, line)._compute_all_tax()
+            new_compute_all_tax = {}
+            for tax_key, tax_vals in line.compute_all_tax.items():
+                if (
+                    tax_key.get("tax_repartition_line_id")
+                    and tax_key.get("display_type")
+                    and not tax_key.get("is_split_payment")
+                ):
+                    new_tax_key = dict(tax_key)
+                    new_tax_key["is_split_payment"] = False
+                    tax_key = frozendict(new_tax_key)
+                new_compute_all_tax[tax_key] = tax_vals
+            line.compute_all_tax = new_compute_all_tax
+        return res
 
     @api.model_create_multi
     def create(self, vals_list):
         lines = super().create(vals_list)
+        move_computed = []
         for line in lines:
             if (
-                line.display_type == "tax"
+                line.move_id not in move_computed
+                and line.display_type == "tax"
                 and line.move_id.split_payment
-                and line.move_id.is_sale_document(include_receipts=True)
                 and not line.is_split_payment
                 and not any(ml.is_split_payment for ml in line.move_id.line_ids)
             ):
-                write_off_line_vals = line._build_writeoff_line()
-                line.move_id.line_ids = [(0, 0, write_off_line_vals)]
-                line.move_id._sync_dynamic_lines(
-                    container={"records": line.move_id, "self": line.move_id}
-                )
+                write_off_line_vals = line.move_id._build_writeoff_line()
+                with line.move_id._sync_dynamic_lines(
+                    container={"records": line.move_id}
+                ):
+                    line.move_id.line_ids = [(0, 0, write_off_line_vals)]
+                move_computed.append(line.move_id)
         return lines

--- a/l10n_it_split_payment/tests/test_splitpayment.py
+++ b/l10n_it_split_payment/tests/test_splitpayment.py
@@ -27,10 +27,22 @@ class TestSP(TestAccountAccount):
                 "amount": 22,
             }
         )
+        self.tax10sp = self.tax_model.create(
+            {
+                "name": "10% SP",
+                "amount": 10,
+            }
+        )
         self.tax22 = self.tax_model.create(
             {
                 "name": "22%",
                 "amount": 22,
+            }
+        )
+        self.tax10 = self.tax_model.create(
+            {
+                "name": "10%",
+                "amount": 10,
             }
         )
         self.sp_fp = self.fp_model.create(
@@ -42,7 +54,12 @@ class TestSP(TestAccountAccount):
                         0,
                         0,
                         {"tax_src_id": self.tax22.id, "tax_dest_id": self.tax22sp.id},
-                    )
+                    ),
+                    (
+                        0,
+                        0,
+                        {"tax_src_id": self.tax10.id, "tax_dest_id": self.tax10sp.id},
+                    ),
                 ],
             }
         )
@@ -272,3 +289,46 @@ class TestSP(TestAccountAccount):
         self.assertEqual(invoice.amount_total, 200)
         self.assertEqual(invoice.amount_residual, 200)
         self.assertEqual(invoice.amount_tax, 0)
+
+    def test_invoice_two_sp_taxes(self):
+        self.assertTrue(self.tax22sp.is_split_payment)
+        self.assertTrue(self.tax10sp.is_split_payment)
+        invoice = self.move_model.with_context(default_move_type="out_invoice").create(
+            {
+                "invoice_date": self.recent_date,
+                "partner_id": self.env.ref("base.res_partner_3").id,
+                "journal_id": self.sales_journal.id,
+                "fiscal_position_id": self.sp_fp.id,
+                "move_type": "out_refund",
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "service",
+                            "account_id": self.a_sale.id,
+                            "quantity": 1,
+                            "price_unit": 100,
+                            "tax_ids": [(6, 0, {self.tax22sp.id})],
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "service2",
+                            "account_id": self.a_sale.id,
+                            "quantity": 1,
+                            "price_unit": 100,
+                            "tax_ids": [(6, 0, {self.tax10sp.id})],
+                        },
+                    ),
+                ],
+            }
+        )
+        line_sp = invoice.line_ids.filtered(
+            lambda line: line.account_id.id == self.company.sp_account_id.id
+        )
+
+        self.assertTrue(len(line_sp) == 1)
+        self.assertEqual(line_sp.credit, 32)


### PR DESCRIPTION
risolve https://github.com/OCA/l10n-italy/issues/4945 
(e sostituisce https://github.com/OCA/l10n-italy/pull/4783)

La principale novità consiste nel modificare la funzione `_build_writeoff_line` in modo che non calcoli lo storno di una sola linea `tax` ma costruisca lo storno di tutte le imposte dell'`account.move`. Per questo viene spostata da `account.move.line` a `account.move` (e si modificano le traduzioni delle stringhe della funzione).
Inoltre per gestire la casistica di una fattura Split Payment di cui viene modificato il regime fiscale, sarebbe necessario eliminare la riga di "Split Payment Write Off" ma, avendo `display_type = tax`, non è possibile quindi viene azzerata in modo da sistemare i conteggi delle linee.

`and line.move_id.is_sale_document(include_receipts=True)`
è stato tolto in modo che vengano gestite anche le fatture fornitore.
