### PR TITLE
[16.0][l10n_it_vat_settlement_date] bloccare data competenza IVA

### DIFF
--- a/l10n_it_vat_settlement_date/i18n/it.po
+++ b/l10n_it_vat_settlement_date/i18n/it.po
@@ -71,3 +71,27 @@ msgstr "Comunicazione liquidazione IVA. Quadro VP"
 #: model:ir.model,name:l10n_it_vat_settlement_date.model_report_l10n_it_vat_registries_report_registro_iva_xlsx
 msgid "XLSX report for VAT registries"
 msgstr "Resoconto XLSX per registri IVA"
+
+#. module: l10n_it_vat_settlement_date
+#. odoo-python
+#: code:addons/l10n_it_vat_settlement_date/models/account_move.py:0
+#, python-format
+msgid ""
+"You cannot add/modify entries with settlement date "
+"(%(settlement)s) prior to and inclusive of the lock date "
+"%(lock)s."
+msgstr ""
+"Non è possibile aggiungere/modificare registrazioni con "
+"data competenza (%(settlement)s) precedente la data di blocco "
+"%(lock)s."
+
+#. module: l10n_it_vat_settlement_date
+#. odoo-python
+#: code:addons/l10n_it_vat_settlement_date/models/account_move.py:0
+#, python-format
+msgid ""
+"You cannot set a settlement date (%(settlement)s) "
+"prior to and inclusive of the lock date %(lock)s."
+msgstr ""
+"Non è possibile impostare una data competenza (%(settlement)s) "
+"precedente la data di blocco %(lock)s."

--- a/l10n_it_vat_settlement_date/i18n/l10n_it_vat_settlement_date.pot
+++ b/l10n_it_vat_settlement_date/i18n/l10n_it_vat_settlement_date.pot
@@ -67,3 +67,22 @@ msgstr ""
 #: model:ir.model,name:l10n_it_vat_settlement_date.model_report_l10n_it_vat_registries_report_registro_iva_xlsx
 msgid "XLSX report for VAT registries"
 msgstr ""
+
+#. module: l10n_it_vat_settlement_date
+#. odoo-python
+#: code:addons/l10n_it_vat_settlement_date/models/account_move.py:0
+#, python-format
+msgid ""
+"You cannot add/modify entries with settlement date "
+"(%(settlement)s) prior to and inclusive of the lock date "
+"%(lock)s."
+msgstr ""
+
+#. module: l10n_it_vat_settlement_date
+#. odoo-python
+#: code:addons/l10n_it_vat_settlement_date/models/account_move.py:0
+#, python-format
+msgid ""
+"You cannot set a settlement date (%(settlement)s) "
+"prior to and inclusive of the lock date %(lock)s."
+msgstr ""

--- a/l10n_it_vat_settlement_date/models/account_move.py
+++ b/l10n_it_vat_settlement_date/models/account_move.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2021 Marco Colombo (https://github/TheMule71)
 # Copyright 2024 Simone Rubino - Aion Tech
+# Copyright 2026 Andrea Martinelli - MKT SRL
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import format_date
 
 
 class AccountMove(models.Model):

--- a/l10n_it_vat_settlement_date/models/account_move.py
+++ b/l10n_it_vat_settlement_date/models/account_move.py
@@ -14,6 +14,11 @@ class AccountMove(models.Model):
         store=True,
         readonly=False,
         copy=False,
+        states={
+            "posted": [
+                ("readonly", True),
+            ],
+        },
     )
 
     @api.depends(

--- a/l10n_it_vat_settlement_date/models/account_move.py
+++ b/l10n_it_vat_settlement_date/models/account_move.py
@@ -2,9 +2,7 @@
 # Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, fields, models
-from odoo.exceptions import UserError
-from odoo.tools import format_date
+from odoo import api, fields, models
 
 
 class AccountMove(models.Model):
@@ -33,6 +31,52 @@ class AccountMove(models.Model):
                 move.date or move.invoice_date or fields.Date.context_today(move)
             )
             move.l10n_it_vat_settlement_date = settlement_date
+
+    def _get_violated_lock_dates(self, invoice_date, has_tax):
+        settlement_date = self.l10n_it_vat_settlement_date
+        if has_tax and settlement_date and invoice_date == self.date:
+            # When tax is involved,
+            # VAT Settlement Date is the date that has to be after the lock.
+            invoice_date = settlement_date
+        return super()._get_violated_lock_dates(invoice_date, has_tax)
+
+    def _get_lock_date_message(self, invoice_date, has_tax):
+        message = super()._get_lock_date_message(invoice_date, has_tax)
+        if message:
+            lock_dates = self._get_violated_lock_dates(invoice_date, has_tax)
+            settlement_date = self.l10n_it_vat_settlement_date
+            if lock_dates and has_tax and settlement_date and invoice_date == self.date:
+                # The super's message talks about a generic date.
+                # When tax is involved,
+                # VAT Settlement Date is the date that has to be after the lock,
+                # and it will be moved too.
+                lock_date, lock_type = lock_dates[-1]
+                unlocked_invoice_date = self._get_accounting_date(invoice_date, has_tax)
+                message = _(
+                    "The VAT Settlement Date is being set "
+                    "prior to the %(lock_type)s lock date %(lock_date)s.\n"
+                    "The Journal Entry will be accounted "
+                    "on %(unlocked_invoice_date)s upon posting.",
+                    lock_type=lock_type,
+                    lock_date=format_date(self.env, lock_date),
+                    unlocked_invoice_date=format_date(self.env, unlocked_invoice_date),
+                )
+            message = "\n".join(
+                [
+                    message,
+                    _(
+                        "Both VAT Settlement Date and accounting date "
+                        "will be changed upon posting.",
+                    ),
+                ]
+            )
+        return message
+
+    @api.depends(
+        "l10n_it_vat_settlement_date",
+    )
+    def _compute_tax_lock_date_message(self):
+        return super()._compute_tax_lock_date_message()
 
     def write(self, vals):
         for move in self:

--- a/l10n_it_vat_settlement_date/models/account_move.py
+++ b/l10n_it_vat_settlement_date/models/account_move.py
@@ -2,7 +2,9 @@
 # Copyright 2024 Simone Rubino - Aion Tech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import format_date
 
 
 class AccountMove(models.Model):
@@ -31,3 +33,57 @@ class AccountMove(models.Model):
                 move.date or move.invoice_date or fields.Date.context_today(move)
             )
             move.l10n_it_vat_settlement_date = settlement_date
+
+    def write(self, vals):
+        for move in self:
+            lock_date = move.company_id._get_user_fiscal_lock_date()
+            if (
+                (not self.env.context.get("bypass_journal_lock_date"))
+                and move.journal_id
+                and hasattr(move.journal_id, "fiscalyear_lock_date")
+            ):
+                date_min = fields.date.min
+                if self.user_has_groups("account.group_account_manager"):
+                    lock_date = move.journal_id.fiscalyear_lock_date or date_min
+                else:
+                    lock_date = max(
+                        move.journal_id.period_lock_date or date_min,
+                        move.journal_id.fiscalyear_lock_date or date_min,
+                    )
+
+            if (
+                move.l10n_it_vat_settlement_date
+                and move.l10n_it_vat_settlement_date <= lock_date
+            ):
+                raise UserError(
+                    _(
+                        "You cannot add/modify entries with settlement date "
+                        "(%(settlement)s) prior to and inclusive of the lock date "
+                        "%(lock)s."
+                    )
+                    % {
+                        "settlement": format_date(
+                            self.env, move.l10n_it_vat_settlement_date
+                        ),
+                        "lock": format_date(self.env, lock_date),
+                    }
+                )
+            if "l10n_it_vat_settlement_date" in vals:
+                if vals["l10n_it_vat_settlement_date"]:
+                    settlement_date = fields.Date.to_date(
+                        vals["l10n_it_vat_settlement_date"]
+                    )
+                    if settlement_date <= lock_date:
+                        raise UserError(
+                            _(
+                                "You cannot set a settlement date (%(settlement)s) "
+                                "prior to and inclusive of the lock date %(lock)s."
+                            )
+                            % {
+                                "settlement": format_date(self.env, settlement_date),
+                                "lock": format_date(self.env, lock_date),
+                            }
+                        )
+
+        res = super().write(vals)
+        return res

--- a/l10n_it_vat_settlement_date/tests/__init__.py
+++ b/l10n_it_vat_settlement_date/tests/__init__.py
@@ -1,4 +1,5 @@
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import test_account_move
 from . import test_vat_period_end_statement
 from . import test_vat_registry

--- a/l10n_it_vat_settlement_date/tests/__init__.py
+++ b/l10n_it_vat_settlement_date/tests/__init__.py
@@ -1,5 +1,6 @@
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import test_account_move
+from . import test_lock_dates
 from . import test_vat_period_end_statement
 from . import test_vat_registry

--- a/l10n_it_vat_settlement_date/tests/test_account_move.py
+++ b/l10n_it_vat_settlement_date/tests/test_account_move.py
@@ -1,0 +1,60 @@
+#  Copyright 2024 Simone Rubino - Aion Tech
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import datetime
+
+from dateutil.relativedelta import relativedelta
+
+from odoo.tests import Form, tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestAccountMove(AccountTestInvoicingCommon):
+    def test_draft_not_readonly(self):
+        """VAT settlement date is not readonly when invoice is in draft."""
+        # Arrange
+        bill = self.init_invoice(
+            "in_invoice",
+            invoice_date=datetime.date(2020, 1, 1),
+            amounts=[
+                100,
+            ],
+        )
+        settlement_date = bill.invoice_date + relativedelta(days=1)
+        # pre-condition
+        self.assertEqual(bill.state, "draft")
+
+        # Act
+        with Form(bill) as bill_form:
+            bill_form.l10n_it_vat_settlement_date = settlement_date
+
+        # Assert
+        self.assertEqual(bill.l10n_it_vat_settlement_date, settlement_date)
+
+    def test_posted_readonly(self):
+        """VAT settlement date is readonly when invoice is posted."""
+        # Arrange
+        bill = self.init_invoice(
+            "in_invoice",
+            invoice_date=datetime.date(2020, 1, 1),
+            amounts=[
+                100,
+            ],
+            post=True,
+        )
+        settlement_date = bill.invoice_date + relativedelta(days=1)
+        # pre-condition
+        self.assertEqual(bill.state, "posted")
+
+        # Act
+        with self.assertRaises(AssertionError) as ae:
+            with Form(bill) as bill_form:
+                bill_form.l10n_it_vat_settlement_date = settlement_date
+
+        # Assert
+        exc_message = ae.exception.args[0]
+        self.assertIn("readonly field", exc_message)
+        self.assertIn("l10n_it_vat_settlement_date", exc_message)
+        self.assertNotEqual(bill.l10n_it_vat_settlement_date, settlement_date)

--- a/l10n_it_vat_settlement_date/tests/test_lock_dates.py
+++ b/l10n_it_vat_settlement_date/tests/test_lock_dates.py
@@ -1,0 +1,64 @@
+#  Copyright 2024 Simone Rubino - Aion Tech
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import datetime
+
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestLockDates(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.company = cls.env.company
+
+    def test_bill_tax_lock(self):
+        """The tax lock date is checked against
+        the settlement date of a supplier bill."""
+        settlement_date = datetime.date(2020, month=1, day=1)
+        tax_lock_date = datetime.date(2020, month=1, day=2)
+        accounting_date = datetime.date(2020, month=1, day=3)
+        self.company.tax_lock_date = tax_lock_date
+        bill = self.init_invoice(
+            "in_invoice",
+            invoice_date=accounting_date,
+            amounts=[100],
+        )
+        # pre-condition
+        self.assertEqual(bill.date, accounting_date)
+        self.assertEqual(bill.invoice_date, accounting_date)
+        self.assertTrue(settlement_date < tax_lock_date < accounting_date)
+        self.assertFalse(bill.tax_lock_date_message)
+
+        # Act
+        bill.l10n_it_vat_settlement_date = settlement_date
+
+        # Assert
+        self.assertIn("VAT Settlement Date", bill.tax_lock_date_message)
+
+    def test_invoice_tax_lock(self):
+        """The tax lock date is checked against
+        the settlement date of a customer invoice."""
+        settlement_date = datetime.date(2020, month=1, day=1)
+        tax_lock_date = datetime.date(2020, month=1, day=2)
+        accounting_date = datetime.date(2020, month=1, day=3)
+        self.company.tax_lock_date = tax_lock_date
+        invoice = self.init_invoice(
+            "out_invoice",
+            invoice_date=accounting_date,
+            amounts=[100],
+        )
+        # pre-condition
+        self.assertEqual(invoice.date, accounting_date)
+        self.assertEqual(invoice.invoice_date, accounting_date)
+        self.assertTrue(settlement_date < tax_lock_date < accounting_date)
+        self.assertFalse(invoice.tax_lock_date_message)
+
+        # Act
+        invoice.l10n_it_vat_settlement_date = settlement_date
+
+        # Assert
+        self.assertIn("VAT Settlement Date", invoice.tax_lock_date_message)

--- a/l10n_it_vat_settlement_date/views/account_move_views.xml
+++ b/l10n_it_vat_settlement_date/views/account_move_views.xml
@@ -22,6 +22,7 @@
                                 ),
                             ),
                         ],
+                        'readonly': [('state', '=', 'posted')],
                     }"
                     options="{
                         'datepicker': {


### PR DESCRIPTION
risolve https://github.com/OCA/l10n-italy/issues/4958 per la 16.0