### PR TITLE
[FIX][16.0] l10n_it_withholding_tax_financial_report: xpath

### DIFF
--- a/l10n_it_financial_statements_report/wizard/wizard_financial_statements_report.py
+++ b/l10n_it_financial_statements_report/wizard/wizard_financial_statements_report.py
@@ -28,31 +28,34 @@ class ReportFinancialStatementsWizard(models.TransientModel):
                 self.receivable_accounts_only = False
         return res
 
-    def prepare_report_vals(self):
-        self.ensure_one()
-        return {
-            "financial_statements_report_type": self.financial_statements_report_type,
-            "hide_accounts_codes": self.hide_accounts_codes,
-            "wizard_id": self.id,
-            "company_id": self.company_id.id,
-            "date_from": self.date_from,
-            "date_to": self.date_to,
-            "foreign_currency": self.foreign_currency,
-            "account_ids": self.account_ids.ids or [],
-            "partner_ids": self.partner_ids.ids or [],
-            "journal_ids": self.journal_ids.ids or [],
-            "fy_start_date": self.fy_start_date,
-            "hide_account_at_0": self.hide_account_at_0,
-            "hide_parent_hierarchy_level": self.hide_parent_hierarchy_level,
-            "show_hierarchy": self.show_hierarchy,
-            "limit_hierarchy_level": self.limit_hierarchy_level,
-            "only_posted_moves": self.target_move == "posted",
-            "show_hierarchy_level": self.show_hierarchy_level,
-            "show_partner_details": self.show_partner_details,
-            "unaffected_earnings_account": self.unaffected_earnings_account.id,
-            "account_financial_report_lang": self.env.lang,
-            "grouped_by": False,
-        }
+    def _prepare_report_data(self):
+        res = super()._prepare_report_data()
+        res.update(
+            {
+                "financial_statements_report_type": self.financial_statements_report_type,  # noqa: E501
+                "hide_accounts_codes": self.hide_accounts_codes,
+                "wizard_id": self.id,
+                "company_id": self.company_id.id,
+                "date_from": self.date_from,
+                "date_to": self.date_to,
+                "foreign_currency": self.foreign_currency,
+                "account_ids": self.account_ids.ids or [],
+                "partner_ids": self.partner_ids.ids or [],
+                "journal_ids": self.journal_ids.ids or [],
+                "fy_start_date": self.fy_start_date,
+                "hide_account_at_0": self.hide_account_at_0,
+                "hide_parent_hierarchy_level": self.hide_parent_hierarchy_level,
+                "show_hierarchy": self.show_hierarchy,
+                "limit_hierarchy_level": self.limit_hierarchy_level,
+                "only_posted_moves": self.target_move == "posted",
+                "show_hierarchy_level": self.show_hierarchy_level,
+                "show_partner_details": self.show_partner_details,
+                "unaffected_earnings_account": self.unaffected_earnings_account.id,
+                "account_financial_report_lang": self.env.lang,
+                "grouped_by": False,
+            }
+        )
+        return res
 
     def _print_report(self, report_type):
         """
@@ -64,7 +67,7 @@ class ReportFinancialStatementsWizard(models.TransientModel):
         self.ensure_one()
         if self.financial_statements_report_type not in REPORT_TYPES:
             return super()._print_report(report_type)
-        report_data = self.prepare_report_vals()
+        report_data = self._prepare_report_data()
         return self.env[
             "report.l10n_it_financial_statements_report.report"
         ].print_report(self, report_data, report_type=report_type)

--- a/l10n_it_withholding_tax_financial_report/report/templates/open_items.xml
+++ b/l10n_it_withholding_tax_financial_report/report/templates/open_items.xml
@@ -10,7 +10,7 @@
         <xpath expr="//div[@style='width: 24.5%;']" position="attributes">
             <attribute name="style">width:14.5%</attribute>
         </xpath>
-        <xpath expr="//t[@t-if='foreign_currency']" position="after">
+        <xpath expr="//t[contains(@t-if,'foreign_currency')]" position="after">
             <div class="act_as_cell" style="width: 6.57%;">Net to pay</div>
             <div class="act_as_cell" style="width: 6.57%;">Residual net to pay</div>
         </xpath>
@@ -19,7 +19,7 @@
         id="report_open_items_lines_wt"
         inherit_id="account_financial_report.report_open_items_lines"
     >
-        <xpath expr="//t[@t-if='foreign_currency']" position="after">
+        <xpath expr="//t[contains(@t-if,'foreign_currency')]" position="after">
             <div class="act_as_cell amount">
                 <span
                     t-if="line.get('amount_net_pay', False)"
@@ -46,7 +46,7 @@
         <xpath expr="//div[hasclass('act_as_row')]/t[2]/div[1]" position="attributes">
             <attribute name="style">width:23.2%</attribute>
         </xpath>
-        <xpath expr="//t[@t-if='foreign_currency']" position="after">
+        <xpath expr="//t[contains(@t-if,'foreign_currency')]" position="after">
             <div class="act_as_cell amount" style="width: 6.57%;" />
             <div class="act_as_cell amount" style="width: 6.57%;">
                 <t t-if='type == "account_type"'>


### PR DESCRIPTION
Following the merge of OCA/account-financial-reporting/#1290 a few xpath exprs weren't matching any longer. Fixed to use a more forward compatible contains() match.

Solves: https://github.com/OCA/l10n-italy/issues/4969