### PR TITLE
[FIX] l10n_it_financial_statements_report: fix error KeyError: 'wizard_name'

### DIFF
--- a/l10n_it_financial_statements_report/wizard/wizard_financial_statements_report.py
+++ b/l10n_it_financial_statements_report/wizard/wizard_financial_statements_report.py
@@ -34,6 +34,7 @@ class ReportFinancialStatementsWizard(models.TransientModel):
             "financial_statements_report_type": self.financial_statements_report_type,
             "hide_accounts_codes": self.hide_accounts_codes,
             "wizard_id": self.id,
+            "wizard_name": self._name,
             "company_id": self.company_id.id,
             "date_from": self.date_from,
             "date_to": self.date_to,


### PR DESCRIPTION

After OCA/account-financial-reporting#1290 the
printing on report goes in error because of refactoring

Fixes: https://github.com/OCA/l10n-italy/issues/4972