### PR TITLE
[18.0][IMP] l10n_it_intrastat: show "Recompute Intrastat Lines" button regardless of state

### DIFF
--- a/l10n_it_intrastat/views/account.xml
+++ b/l10n_it_intrastat/views/account.xml
@@ -35,7 +35,6 @@
                         <group>
                             <button
                                 name="compute_intrastat_lines"
-                                invisible="state not in ['draft', 'sent']"
                                 string="Recompute Intrastat Lines"
                                 type="object"
                             />


### PR DESCRIPTION
Issue: [odoo-italia/task941](https://www.odoo-italia.org/web#id=941&cids=1&menu_id=206&action=328&active_id=18&model=project.task&view_type=form)