### PR TITLE
[18.0] [FIX] l10n_it_riba_oca: revert and fix related documents computation

### DIFF
--- a/l10n_it_riba_oca/__manifest__.py
+++ b/l10n_it_riba_oca/__manifest__.py
@@ -23,7 +23,7 @@
         "account_due_list",
         "base_iban",
         "l10n_it_abicab",
-        "l10n_it_edi",
+        "l10n_it_edi_related_document",
         "account_payment_term_extension",
     ],
     "data": [

--- a/l10n_it_riba_oca/models/riba.py
+++ b/l10n_it_riba_oca/models/riba.py
@@ -283,8 +283,25 @@ class RibaListLine(models.Model):
     amount = fields.Float(compute="_compute_line_values")
     invoice_date = fields.Char(compute="_compute_line_values", size=256)
     invoice_number = fields.Char(compute="_compute_line_values", size=256)
-    cig = fields.Char(string="CIG", size=256)
-    cup = fields.Char(string="CUP", size=256)
+    cig = fields.Char(compute="_compute_cig_cup_values", string="CIG", size=256)
+    cup = fields.Char(compute="_compute_cig_cup_values", string="CUP", size=256)
+
+    def _compute_cig_cup_values(self):
+        for line in self:
+            line.cig = ""
+            line.cup = ""
+            related_documents = line.mapped(
+                "move_line_ids.move_line_id.move_id.related_document_ids"
+            )
+
+            for related_document in related_documents:
+                if related_document.cup:
+                    line.cup = str(related_document.cup)
+                if related_document.cig:
+                    line.cig = str(related_document.cig)
+                # Stop if at least one value is found
+                if line.cup or line.cig:
+                    break
 
     sequence = fields.Integer("Number")
     move_line_ids = fields.One2many(

--- a/l10n_it_riba_oca/readme/USAGE.md
+++ b/l10n_it_riba_oca/readme/USAGE.md
@@ -33,3 +33,7 @@ impostata con la data di scadenza della RiBa, ma è possibile modificarla in due
 - successivamente a pagamento effettivamente avvenuto selezionando la
 registrazione dalla vista ed elenco ed eseguendo l'azione "Imposta data
 di pagamento RiBa".
+
+Non è possibile emettere Riba per fatture verso Enti che richiedono più di un CIG e un CUP differenti per fattura.
+In questo caso particolare, emettere più fatture.
+Non è possibile raggruppare Riba in fase di emissione se le fatture contengono CIG e CUP differenti. Verrà creata una riga di distinta per ogni fattura.

--- a/l10n_it_riba_oca/tests/test_riba.py
+++ b/l10n_it_riba_oca/tests/test_riba.py
@@ -455,6 +455,18 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                         },
                     )
                 ],
+                "related_document_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "type": "order",
+                            "name": "SO1232",
+                            "cig": "7987210EG5",
+                            "cup": "H71N17000690124",
+                        },
+                    )
+                ],
             }
         )
         invoice._onchange_riba_partner_bank_id()
@@ -472,8 +484,12 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         riba_list_id = action and action["res_id"] or False
         riba_list = self.slip_model.browse(riba_list_id)
         riba_list.confirm()
+        self.assertEqual(riba_list.line_ids[0].cig, "7987210EG5")
+        self.assertEqual(riba_list.line_ids[0].cup, "H71N17000690124")
         wizard_riba_export = self.env["riba.file.export"].create({})
         wizard_riba_export.with_context(active_ids=[riba_list.id]).act_getfile()
+        riba_txt = base64.decodebytes(wizard_riba_export.riba_txt)
+        self.assertTrue(b"CIG: 7987210EG5 CUP: H71N17000690124" in riba_txt)
         # Assert
         file_content = base64.decodebytes(wizard_riba_export.riba_txt).decode()
         self.assertNotIn("INV/2025/00004", file_content)
@@ -508,6 +524,18 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                         },
                     )
                 ],
+                "related_document_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "type": "order",
+                            "name": "SO1232",
+                            "cig": "7987210EG5",
+                            "cup": "H71N17000690124",
+                        },
+                    )
+                ],
             }
         )
         invoice._onchange_riba_partner_bank_id()
@@ -530,6 +558,18 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                             "price_unit": 450.00,
                             "account_id": self.sale_account.id,
                             "tax_ids": [[6, 0, self.tax_22.ids]],
+                        },
+                    )
+                ],
+                "related_document_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "type": "order",
+                            "name": "SO1232",
+                            "cig": "7987210EG5",
+                            "cup": "H71N17000690125",
                         },
                     )
                 ],
@@ -556,6 +596,9 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         self.assertTrue(len(riba_list.line_ids), 2)
         wizard_riba_export = self.env["riba.file.export"].create({})
         wizard_riba_export.with_context(active_ids=[riba_list.id]).act_getfile()
+        riba_txt = base64.decodebytes(wizard_riba_export.riba_txt)
+        self.assertTrue(b"CIG: 7987210EG5 CUP: H71N17000690124" in riba_txt)
+        self.assertTrue(b"CIG: 7987210EG5 CUP: H71N17000690125" in riba_txt)
         # Assert
         file_content = base64.decodebytes(wizard_riba_export.riba_txt).decode()
         self.assertNotIn("INV/2025/00008", file_content)

--- a/l10n_it_riba_oca/wizard/wizard_riba_file_export.py
+++ b/l10n_it_riba_oca/wizard/wizard_riba_file_export.py
@@ -392,10 +392,8 @@ class RibaFileExport(models.TransientModel):
                 unidecode(line.partner_id.ref and line.partner_id.ref[:16] or ""),
                 unidecode(line.invoice_number[:40]),
                 line.invoice_date,
-                unidecode(f"CIG: {line.cig if line.cig else ''} "),
-                "",
-                unidecode(f"CUP: {line.cup if line.cup else ''} "),
-                "",
+                unidecode(f"CIG: {line.cig} " if line.cig else ""),
+                unidecode(f"CUP: {line.cup} " if line.cup else ""),
             ]
             array_riba.append(riba)
 

--- a/l10n_it_riba_oca/wizard/wizard_riba_issue.py
+++ b/l10n_it_riba_oca/wizard/wizard_riba_issue.py
@@ -62,7 +62,15 @@ class RibaIssue(models.TransientModel):
                 self.env._("It is possible to issue C/O for posted move only!")
             )
         do_group_riba = True
-        if len({f"{x.l10n_it_cig}{x.l10n_it_cup}" for x in move_lines.move_id}) > 1:
+        if (
+            len(
+                {
+                    f"{x.cig}{x.cup}"
+                    for x in move_lines.mapped("move_id.related_document_ids")
+                }
+            )
+            > 1
+        ):
             do_group_riba = False
         if do_group_riba:
             for move_line in move_lines:
@@ -90,7 +98,7 @@ class RibaIssue(models.TransientModel):
                         invoice=move_line.move_id.name,
                     )
                 )
-            if move_line.partner_id.group_riba:  # and do_group_riba:
+            if move_line.partner_id.group_riba and do_group_riba:
                 for key in grouped_lines:
                     if (
                         key[0] == move_line.partner_id.id


### PR DESCRIPTION
Issue: [odoo-italia/task989](https://www.odoo-italia.org/web#id=989&cids=1&menu_id=211&action=328&active_id=18&model=project.task&view_type=form)

Ripristina il collegamento calcolato con i documenti correlati per impostare CIG e CUP nelle Ri.Ba.

Inoltre ho cercato di migliorare l'assegnazione controllando separatamente i dati a livello:
- Invoice-level related documents (account.move.related_document_ids)
- Invoice line-level related documents (account.move.line.related_document_ids)

Invoice line-level deve prevalere ed in caso di più occorrenze per la stessa riga di distinta viene sollevata un'eccezione.