### PR TITLE
[18.0][FIX] l10n_it_riba_oca: fix settlement amount

### DIFF
--- a/l10n_it_riba_oca/models/riba.py
+++ b/l10n_it_riba_oca/models/riba.py
@@ -481,10 +481,8 @@ class RibaListLine(models.Model):
             ]
         )
 
-        # Reduce settlement amount by amounts already matched (partial payments)
-        settlement_move_amount = settlement_move_line.debit - sum(
-            settlement_move_line.mapped("matched_credit_ids.amount")
-        )
+        # Settlement amount
+        settlement_move_amount = sum(self.mapped("amount"))
 
         # Prepare settlement move data
         move_ref = f"Settlement RiBa {self.slip_id.name}"


### PR DESCRIPTION
Quando clicco su `Mark as Settled` nella riga della distinta, 
la registrazione non risulta bilanciata perché la variabile `settlement_move_amount` non è corretta.