### PR TITLE
[18.0][FIX] l10n_it_riba_oca: removed apices from boolean domain

### DIFF
--- a/l10n_it_riba_oca/views/account_view.xml
+++ b/l10n_it_riba_oca/views/account_view.xml
@@ -120,7 +120,7 @@
         <field name="view_id" ref="view_riba_to_issue_tree" />
         <field name="search_view_id" ref="riba_filter" />
         <field name="domain">
-            ['&amp;', ('parent_state', '=', 'posted'), '&amp;',('riba','=','True'),
+            ['&amp;', ('parent_state', '=', 'posted'), '&amp;',('riba','=',True),
             '|',('past_due_invoice_ids','!=',False),('account_id.account_type','=','asset_receivable')]</field>
         <field
             name="context"


### PR DESCRIPTION
Sistemato errore nel dominio dell'azione corrispondente alla voce di menù Emissione, dentro il menù RiBa
Ticket ti riferimento https://github.com/OCA/l10n-italy/issues/4990