### PR TITLE
[18.0] [FIX] l10n_it_central_journal_reportlab, lines without account or without entry name

### DIFF
--- a/l10n_it_central_journal_reportlab/wizard/print_giornale.py
+++ b/l10n_it_central_journal_reportlab/wizard/print_giornale.py
@@ -67,7 +67,7 @@ class WizardGiornaleReportlab(models.TransientModel):
     )
     target_move = fields.Selection(
         [("all", "All"), ("posted", "Posted"), ("draft", "Draft")],
-        default="all",
+        default="posted",
     )
     fiscal_page_base = fields.Integer("Last printed page", required=True)
     start_row = fields.Integer("Start row", required=True)
@@ -163,6 +163,7 @@ class WizardGiornaleReportlab(models.TransientModel):
                 AND aml.journal_id IN %(journal_ids)s
                 AND aml.company_id = %(company_id)s
                 AND (aml.debit + aml.credit) != 0.0
+                AND aml.account_id IS NOT NULL
             GROUP BY
                 aml.account_id,
                 am.date,
@@ -214,6 +215,7 @@ class WizardGiornaleReportlab(models.TransientModel):
                  AND am.state IN %(target_type)s
                  AND aml.journal_id IN %(journal_ids)s
                  AND aml.company_id = %(company_id)s
+                 AND aml.account_id IS NOT NULL
              ORDER BY
                  am.date,
                  am.name
@@ -400,7 +402,7 @@ class WizardGiornaleReportlab(models.TransientModel):
             row = Paragraph(str(start_row), style_name)
             date = Paragraph(format_date(self.env, line["date"]), style_name)
             ref = Paragraph(str(line["ref"]), style_name)
-            move = Paragraph(line["move_name"], style_name)
+            move = Paragraph(line["move_name"] or "", style_name)
             account = Paragraph(account_name, style_name)
             name = Paragraph(line["name"], style_name)
             # dato che nel SQL ho la somma dei crediti e debiti potrei avere
@@ -476,7 +478,7 @@ class WizardGiornaleReportlab(models.TransientModel):
             row = Paragraph(str(start_row), style_name)
             date = Paragraph(format_date(self.env, line["date"]), style_name)
             ref = Paragraph(str(line["ref"]), style_name)
-            move = Paragraph(line["move_name"], style_name)
+            move = Paragraph(line["move_name"] or "", style_name)
             move_name = line["move_name"] or ""
             account = Paragraph(account_name, style_name)
 


### PR DESCRIPTION
We must exclude lines without account (like notes in invoice lines) because they are not significant for central journal; otherwise:
```
l10n_it_central_journal_reportlab/wizard/print_giornale.py", line 471, in get_final_tables_report_giornale
    else line["account_name"][user_lang]
         ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

Also, lines without name (like draft invoices) must be printed without error. But default behaviour should be printing posted entries