### PR TITLE
[16.0] [FIX] l10n_it_fatturapa_out avoiding blocking check in peyment terms

### DIFF
--- a/l10n_it_fatturapa_out/models/account.py
+++ b/l10n_it_fatturapa_out/models/account.py
@@ -88,27 +88,6 @@ class AccountInvoice(models.Model):
                     % invoice.name
                 )
 
-            if invoice.invoice_payment_term_id or invoice.invoice_date_due:
-                # The user wants to create the DatiPagamento node:
-                # they must fill these fields
-                # in order to populate the mandatory nodes
-                if not invoice.fatturapa_payment_method_id:
-                    # For node ModalitaPagamento
-                    raise UserError(
-                        _(
-                            "Invoice %(name)s: Fiscal Payment Method must be set.",
-                            name=invoice.name,
-                        )
-                    )
-                if not invoice.fatturapa_payment_term_id:
-                    # For node CondizioniPagamento
-                    raise UserError(
-                        _(
-                            "Invoice %(name)s: Fiscal Payment Term must be set.",
-                            name=invoice.name,
-                        )
-                    )
-
             if not all(
                 aml.tax_ids for aml in invoice.invoice_line_ids if aml.product_id
             ):

--- a/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
+++ b/l10n_it_fatturapa_out/tests/test_fatturapa_xml_validation.py
@@ -719,13 +719,6 @@ class TestFatturaPAXMLValidation(FatturaPACommon):
         self.assertFalse(invoice.fatturapa_payment_method_id)
         self.assertFalse(invoice.fatturapa_payment_term_id)
 
-        # Act
-        # Since payment data fields are not set, an exception is raised
-        with self.assertRaises(UserError) as ue:
-            self.run_wizard(invoice.id)
-        exc_message = ue.exception.args[0]
-        self.assertIn("Fiscal Payment Method must be set", exc_message)
-        # When fields are set, we can export the e-invoice
         with Form(invoice) as invoice_form:
             invoice_form.fatturapa_payment_method_id = self.env.ref(
                 "l10n_it_fiscal_payment_term.fatturapa_mp05"


### PR DESCRIPTION
If users do not set payment term nor due date, they are anyway blocked.

Also, recurring invoicing with modules like contract are blocked

See

[Screencast from 25-11-2025 15:09:14.webm](https://github.com/user-attachments/assets/84d6cf24-b098-4b28-b3bc-e1d3f68218ba)

Restoring checks at https://github.com/OCA/l10n-italy/pull/4869/files#diff-5b97ba45cf80ea9da22e5dd2ed8d379965d3070df26594e3d2fee5725e2f6f97L59-L86