### PR TITLE
[18.0] [FIX] l10n_it_vat_registries: allow to set rc_journal_ids

### DIFF
--- a/l10n_it_vat_registries/models/account_tax_registry.py
+++ b/l10n_it_vat_registries/models/account_tax_registry.py
@@ -37,5 +37,5 @@ class AccountTaxRegistry(models.Model):
         string="Include reverse charge moves",
     )
     rc_journal_ids = fields.One2many(
-        "account.journal", "rc_tax_registry_id", "RC Journals", readonly=True
+        "account.journal", "rc_tax_registry_id", "RC Journals"
     )

--- a/l10n_it_vat_registries/tests/test_registry.py
+++ b/l10n_it_vat_registries/tests/test_registry.py
@@ -4,6 +4,7 @@ import io
 from zipfile import ZipFile
 
 from odoo import fields
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
 
@@ -119,3 +120,36 @@ class TestRegistry(TransactionCase):
         report_ids = map(lambda report_action: report_action.get("id"), report_actions)
 
         self.assertNotIn(report_id, report_ids)
+
+
+class TestRcJournals(TransactionCase):
+    def _new_registry_form(self):
+        registry = self.env["account.tax.registry"].create(
+            {
+                "name": "Reverse charge",
+                "layout_type": "supplier",
+            }
+        )
+        return Form(registry), registry
+
+    def test_set_rc_journal_ids(self):
+        """RC journals are hidden by default and can be set once reverse
+        charge moves are included.
+
+        The ``rc_journal_ids`` field only makes sense when reverse charge
+        moves are included, so it stays invisible otherwise. Once
+        ``include_rc_moves`` is enabled the field becomes visible and the
+        user can assign journals to the registry.
+        """
+        form, registry = self._new_registry_form()
+        self.assertTrue(form._get_modifier("rc_journal_ids", "invisible"))
+        form.include_rc_moves = True
+        self.assertFalse(form._get_modifier("rc_journal_ids", "invisible"))
+        with form.rc_journal_ids.new() as journal:
+            journal.name = "RC Journal"
+            journal.code = "RCJ"
+            journal.type = "general"
+        form.save()
+
+        self.assertEqual(registry.rc_journal_ids.mapped("name"), ["RC Journal"])
+        self.assertEqual(registry.rc_journal_ids.rc_tax_registry_id, registry)

--- a/l10n_it_vat_registries/views/account_tax_registry_view.xml
+++ b/l10n_it_vat_registries/views/account_tax_registry_view.xml
@@ -21,6 +21,7 @@
                     <field
                         name="rc_journal_ids"
                         invisible="not include_rc_moves"
+                        readonly="not include_rc_moves"
                         widget="many2many_tags"
                     />
                 </group>


### PR DESCRIPTION
Altrimenti il campo "Registri IC" sul registro IVA non è impostabile

https://github.com/OCA/l10n-italy/issues/5294