### PR TITLE
[12.0] [FIX] l10n_it_reverse_charge: utilizzando il conto analitico su fattu…

### DIFF
--- a/l10n_it_reverse_charge/models/account_invoice.py
+++ b/l10n_it_reverse_charge/models/account_invoice.py
@@ -411,6 +411,7 @@ class AccountInvoice(models.Model):
         supplier_invoice.partner_id = rc_type.partner_id.id
         supplier_invoice.journal_id = rc_type.supplier_journal_id.id
         for inv_line in supplier_invoice.invoice_line_ids:
+            inv_line.account_analytic_id = False
             line_tax_ids = inv_line.invoice_line_tax_ids
             mapped_taxes = rc_type.map_tax(
                 line_tax_ids,


### PR DESCRIPTION
…ra che genera RC lo stesso viene indicato sia sulla fattura che su autofattura passiva generando un doppio movimento in analitica

https://github.com/OCA/l10n-italy/issues/4564