### PR TITLE
[18.0] [FIX] l10n_it_edi_extension: fix sequence position `DatiTrasporto`

### DIFF
--- a/l10n_it_edi_extension/data/invoice_it_template.xml
+++ b/l10n_it_edi_extension/data/invoice_it_template.xml
@@ -46,7 +46,7 @@
                 t-if="record.l10n_edi_it_art73 or company.l10n_edi_it_art73"
             >SI</Art73>
         </xpath>
-        <xpath expr="//DatiGeneraliDocumento" position="after">
+        <xpath expr="//DatiDDT" position="after">
             <DatiTrasporto t-if="record.partner_shipping_id">
                 <!-- 2.1.9.12 -->
                 <IndirizzoResa>

--- a/l10n_it_edi_extension/data/invoice_it_template.xml
+++ b/l10n_it_edi_extension/data/invoice_it_template.xml
@@ -47,7 +47,9 @@
             >SI</Art73>
         </xpath>
         <xpath expr="//DatiDDT" position="after">
-            <DatiTrasporto t-if="record.partner_shipping_id">
+            <DatiTrasporto
+                t-if="record.partner_shipping_id and record.partner_shipping_id.country_id.code == 'IT'"
+            >
                 <!-- 2.1.9.12 -->
                 <IndirizzoResa>
                     <Indirizzo

--- a/l10n_it_edi_extension/tests/common.py
+++ b/l10n_it_edi_extension/tests/common.py
@@ -23,3 +23,8 @@ class Common(TestItEdi):
                 "invoice_edi_format": "it_edi_xml",
             }
         )
+        cls.split_payment_tax = (
+            cls.env["account.tax"]
+            .with_company(cls.company)
+            .search([("name", "=", "22% SP")])
+        )

--- a/l10n_it_edi_extension/tests/common.py
+++ b/l10n_it_edi_extension/tests/common.py
@@ -23,8 +23,42 @@ class Common(TestItEdi):
                 "invoice_edi_format": "it_edi_xml",
             }
         )
+        cls.us_partner = cls.env["res.partner"].create(
+            {
+                "name": "US Partner",
+                "city": "Test city",
+                "country_id": cls.env.ref("base.us").id,
+                "zip": "12345",
+                "street": "123 Rainbow Road",
+                "company_id": False,
+                "is_company": True,
+            }
+        )
+        cls.us_shipping_partner = cls.env["res.partner"].create(
+            {
+                "name": "US Partner Shipping",
+                "city": "New Hartford",
+                "country_id": cls.env.ref("base.us").id,
+                "street": "1000 Burrstone Rd",
+                "zip": "13413",
+                "company_id": False,
+            }
+        )
         cls.split_payment_tax = (
             cls.env["account.tax"]
             .with_company(cls.company)
             .search([("name", "=", "22% SP")])
+        )
+        cls.tax_zero_percent_us = (
+            cls.env["account.tax"]
+            .with_company(cls.company)
+            .create(
+                {
+                    "name": "0 % US",
+                    "amount": 0.0,
+                    "amount_type": "percent",
+                    "l10n_it_exempt_reason": "N3.1",
+                    "l10n_it_law_reference": "Art. 8, c.1, lett.a - D.P.R. 633/1972",
+                }
+            )
         )

--- a/l10n_it_edi_extension/tests/export_xmls/partner_shipping_sequence.xml
+++ b/l10n_it_edi_extension/tests/export_xmls/partner_shipping_sequence.xml
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<p:FatturaElettronica
+    xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd"
+    versione="FPA12"
+>
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>V201900001</ProgressivoInvio>
+            <FormatoTrasmissione>FPA12</FormatoTrasmissione>
+            <CodiceDestinatario>123456</CodiceDestinatario>
+            <ContattiTrasmittente>
+                <Telefono>0266766700</Telefono>
+                <Email>test@test.it</Email>
+            </ContattiTrasmittente>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>01234560157</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>company_2_data</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>1234 Test Street</Indirizzo>
+                <CAP>12345</CAP>
+                <Comune>Prova</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>06655971007</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>06655971007</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>pa partner</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Test PA </Indirizzo>
+                <CAP>32121</CAP>
+                <Comune>PA Town</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2019-01-01</Data>
+                <Numero>INV/2019/00001</Numero>
+                <ImportoTotaleDocumento>122.00</ImportoTotaleDocumento>
+            </DatiGeneraliDocumento>
+            <DatiOrdineAcquisto>
+                <IdDocumento>PO0123</IdDocumento>
+                <Data>2019-01-01</Data>
+                <CodiceCUP>0123456789</CodiceCUP>
+                <CodiceCIG>0987654321</CodiceCIG>
+            </DatiOrdineAcquisto>
+            <DatiTrasporto>
+                <IndirizzoResa>
+                    <Indirizzo>Largo S. Martino 1</Indirizzo>
+                    <CAP>80129</CAP>
+                    <Comune>Napoli</Comune>
+                    <Nazione>IT</Nazione>
+                </IndirizzoResa>
+            </DatiTrasporto>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>test line</Descrizione>
+                <Quantita>1.00</Quantita>
+                <PrezzoUnitario>100.00000000</PrezzoUnitario>
+                <PrezzoTotale>100.00000000</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>100.00</ImponibileImporto>
+                <Imposta>22.00</Imposta>
+                <EsigibilitaIVA>S</EsigibilitaIVA>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2019-01-01</DataScadenzaPagamento>
+                <ImportoPagamento>100.00</ImportoPagamento>
+                <CodicePagamento>INV/2019/00001</CodicePagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_edi_extension/tests/export_xmls/us_partner_shipping.xml
+++ b/l10n_it_edi_extension/tests/export_xmls/us_partner_shipping.xml
@@ -1,0 +1,111 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<p:FatturaElettronica
+    xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd"
+    versione="FPR12"
+>
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>V202400001</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>XXXXXXX</CodiceDestinatario>
+            <ContattiTrasmittente>
+                <Telefono>0266766700</Telefono>
+                <Email>test@test.it</Email>
+            </ContattiTrasmittente>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>01234560157</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>company_2_data</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>1234 Test Street</Indirizzo>
+                <CAP>12345</CAP>
+                <Comune>Prova</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>US</IdPaese>
+                    <IdCodice>OO99999999999</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>US Partner</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>123 Rainbow Road</Indirizzo>
+                <CAP>00000</CAP>
+                <Comune>Test city</Comune>
+                <Nazione>US</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2024-08-07</Data>
+                <Numero>INV/2024/00001</Numero>
+                <ImportoTotaleDocumento>1068.11</ImportoTotaleDocumento>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>A productive product</Descrizione>
+                <Quantita>1.00</Quantita>
+                <PrezzoUnitario>989.99907313</PrezzoUnitario>
+                <PrezzoTotale>989.99907313</PrezzoTotale>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N3.1</Natura>
+                <AltriDatiGestionali>
+                    <TipoDato>DIVISA</TipoDato>
+                    <RiferimentoTesto>USD</RiferimentoTesto>
+                    <RiferimentoNumero>1068.11000000</RiferimentoNumero>
+                </AltriDatiGestionali>
+                <AltriDatiGestionali>
+                    <TipoDato>CAMBIO</TipoDato>
+                    <RiferimentoNumero>1.07890000</RiferimentoNumero>
+                    <RiferimentoData>2024-08-07</RiferimentoData>
+                </AltriDatiGestionali>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>0.00</AliquotaIVA>
+                <Natura>N3.1</Natura>
+                <Arrotondamento>0.00092687</Arrotondamento>
+                <ImponibileImporto>990.00</ImponibileImporto>
+                <Imposta>0.00</Imposta>
+                <EsigibilitaIVA>I</EsigibilitaIVA>
+                <RiferimentoNormativo
+                >Art. 8, c.1, lett.a - D.P.R. 633/1972</RiferimentoNormativo>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2024-08-07</DataScadenzaPagamento>
+                <ImportoPagamento>1068.11</ImportoPagamento>
+                <CodicePagamento>INV/2024/00001</CodicePagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_edi_extension/tests/test_export.py
+++ b/l10n_it_edi_extension/tests/test_export.py
@@ -34,3 +34,22 @@ class TestExport(Common):
         invoice.partner_shipping_id = self.italian_shipping_partner_a
         invoice.action_post()
         self._assert_export_invoice(invoice, "partner_shipping.xml")
+
+    def test_partner_shipping_with_related_documents(self):
+        """Sequence tag in IndirizzoResa node."""
+        invoice = self.init_invoice(
+            "out_invoice",
+            amounts=[100],
+            company=self.company,
+            partner=self.italian_partner_b,
+            taxes=self.split_payment_tax,
+        )
+        invoice.invoice_date_due = invoice.date
+        invoice.l10n_it_origin_document_type = "purchase_order"
+        invoice.l10n_it_origin_document_date = invoice.date
+        invoice.l10n_it_origin_document_name = "PO0123"
+        invoice.l10n_it_cup = "0123456789"
+        invoice.l10n_it_cig = "0987654321"
+        invoice.partner_shipping_id = self.italian_shipping_partner_a
+        invoice.action_post()
+        self._assert_export_invoice(invoice, "partner_shipping_sequence.xml")

--- a/l10n_it_edi_extension/tests/test_export.py
+++ b/l10n_it_edi_extension/tests/test_export.py
@@ -1,6 +1,8 @@
 # Copyright 2025 Simone Rubino
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo import Command
+
 from .common import Common
 
 
@@ -53,3 +55,43 @@ class TestExport(Common):
         invoice.partner_shipping_id = self.italian_shipping_partner_a
         invoice.action_post()
         self._assert_export_invoice(invoice, "partner_shipping_sequence.xml")
+
+    def test_us_partner_shipping(self):
+        """The US partner shipping included in the invoice
+        is exported to the XML in IndirizzoResa node."""
+        usd = self.env.ref("base.USD")
+
+        self.env["res.currency.rate"].with_company(self.company).create(
+            {
+                "name": "2024-08-06",
+                "rate": 1.0789,
+                "currency_id": usd.id,
+            }
+        )
+
+        invoice = (
+            self.env["account.move"]
+            .with_company(self.company)
+            .create(
+                {
+                    "move_type": "out_invoice",
+                    "invoice_date": "2024-08-07",
+                    "invoice_date_due": "2024-08-07",
+                    "partner_id": self.us_partner.id,
+                    "partner_shipping_id": self.us_shipping_partner.id,
+                    "currency_id": usd.id,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": "A productive product",
+                                "price_unit": 1068.11,
+                                "quantity": 1,
+                                "tax_ids": [Command.set(self.tax_zero_percent_us.ids)],
+                            }
+                        ),
+                    ],
+                }
+            )
+        )
+        invoice.action_post()
+        self._assert_export_invoice(invoice, "us_partner_shipping.xml")


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/5034
Dipende da https://github.com/OCA/l10n-italy/pull/5046 (utile a correggere i test automatici).
Invalid content was found starting with element 'DatiOrdineAcquisto'. One of '{FatturaPrincipale}' is expected.