### PR TITLE
[FIX] l10n_it_edi_extension: clean, normalise, and make IndirizzoResa values safe.

### DIFF
--- a/l10n_it_edi_extension/data/invoice_it_template.xml
+++ b/l10n_it_edi_extension/data/invoice_it_template.xml
@@ -47,20 +47,25 @@
             >SI</Art73>
         </xpath>
         <xpath expr="//DatiGeneraliDocumento" position="after">
-            <DatiTrasporto t-if="record.partner_shipping_id">
+            <DatiTrasporto>
                 <!-- 2.1.9.12 -->
-                <IndirizzoResa>
+                <t t-set="shipper" t-value="record.partner_shipping_id" />
+                <IndirizzoResa t-if="shipper and shipper.country_id.code == 'IT'">
                     <Indirizzo
-                        t-out="format_address(record.partner_shipping_id.street, record.partner_shipping_id.street2, 60)"
+                        t-out="format_address(shipper.street, shipper.street2, 60)"
                     />
-                    <CAP t-out="record.partner_shipping_id.zip" />
+                    <CAP>
+                        <t t-if="shipper.zip" t-out="shipper.zip" />
+                    </CAP>
                     <Comune
-                        t-out="format_alphanumeric(record.partner_shipping_id.city, 60)"
+                        t-if="shipper.city"
+                        t-out="format_alphanumeric(shipper.city, 60)"
                     />
                     <Provincia
-                        t-out="format_alphanumeric(record.partner_shipping_id.state_id.code, 2)"
+                        t-if="shipper.state_id"
+                        t-out="format_alphanumeric(shipper.state_id.code, 2)"
                     />
-                    <Nazione t-out="record.partner_shipping_id.country_id.code" />
+                    <Nazione t-out="shipper.country_id.code" />
                 </IndirizzoResa>
             </DatiTrasporto>
         </xpath>


### PR DESCRIPTION
Currently there is no normalisation of CAP (as there is in Odoo SA l10n_it_edi) so this can happen:

```
<DatiTrasporto>
    <IndirizzoResa>
      <Indirizzo>Kunming city</Indirizzo>
      <CAP>0009</CAP>
      <Comune>Shanghai</Comune>
      <Nazione>CN</Nazione>
    </IndirizzoResa>
  </DatiTrasporto>
```
Where SDI rejects:
`File non conforme al formato : The value '0009' of element 'CAP' is not valid. riga: 75 - colonna: 26
`
Other than this, the PR tries to render other values (provincia) safe, other than city, if missing.
