### PR TITLE
[16.0] [FIX] l10n_it_fatturapa_out allowing invoicing users to view "Export Electronic Invoice" wizard

### DIFF
--- a/l10n_it_fatturapa_out/security/ir.model.access.csv
+++ b/l10n_it_fatturapa_out/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_fatturapa_attachment_out,access_fatturapa_attachment_out,model_fatturapa_attachment_out,account.group_account_invoice,1,1,1,1
 access_wizard_export_fatturapa,access_wizard_export_fatturapa,model_wizard_export_fatturapa,account.group_account_invoice,1,1,1,1
+access_ir_model,access_ir_model,base.model_ir_model,account.group_account_invoice,1,0,0,0


### PR DESCRIPTION
Without this, users without access to ir.model get access error

<img width="1100" height="343" alt="image" src="https://github.com/user-attachments/assets/b643cc0a-959a-4b5b-94d5-d61d130ff915" />

Rif https://github.com/OCA/l10n-italy/pull/4156