### PR TITLE
[FIX] l10n_it_edi_related_document: fix singleton error in inverse method

### DIFF
--- a/l10n_it_edi_related_document/models/account_move.py
+++ b/l10n_it_edi_related_document/models/account_move.py
@@ -174,20 +174,20 @@ class AccountMove(models.Model):
 
             vals = {
                 "type": document_type,
-                "name": self.l10n_it_origin_document_name,
-                "date": self.l10n_it_origin_document_date,
-                "cig": self.l10n_it_cig,
-                "cup": self.l10n_it_cup,
+                "name": record.l10n_it_origin_document_name,
+                "date": record.l10n_it_origin_document_date,
+                "cig": record.l10n_it_cig,
+                "cup": record.l10n_it_cup,
             }
             if not record.standard_related_document_id:
-                self.standard_related_document_id = self.env[
+                record.standard_related_document_id = self.env[
                     "account.move.related_document"
                 ].create(vals)
-                self.related_document_ids = [
-                    fields.Command.link(self.standard_related_document_id.id)
+                record.related_document_ids = [
+                    fields.Command.link(record.standard_related_document_id.id)
                 ]
             else:
-                self.standard_related_document_id.with_context(
+                record.standard_related_document_id.with_context(
                     l10n_it_edi_related_loop_avoid=True
                 ).update(vals)
 


### PR DESCRIPTION
## Riepilogo

Corregge un errore singleton in `_inverse_original_related_document_fields` quando vengono create più fatture contemporaneamente.

Il metodo itera con `for record in self:` ma poi usa `self` invece di `record` per accedere ai campi, causando:
```
ValueError: Expected singleton: account.move(...)
```

Introdotto nella PR #5046.

## Modifiche

Sostituzione di `self` con `record` in 8 punti all'interno del loop (righe 177-192).