### PR TITLE
[FIX] l10n_it_delivery_note: Found unexpected attributes on stock.picking: _delivery_note_fields

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -114,8 +114,6 @@ class StockPicking(models.Model):
             }
         )
 
-        type(self)._delivery_note_fields = fields
-
         return fields
 
     def _compute_boolean_flags(self):


### PR DESCRIPTION
Senza questa modifica i test automatici di `l10n_it_delivery_note` falliscono:
<details><summary>Found unexpected attributes on stock.picking: _delivery_note_fields</summary>
<pre>
2026-02-18 18:30:51,132 338 ERROR odoo odoo.addons.l10n_it_delivery_note.tests.test_stock_delivery_note: FAIL: StockDeliveryNote.test_partial_delivering_single_so
Traceback (most recent call last):
  File "/opt/odoo-venv/bin/coverage", line 6, in <module>
    sys.exit(main())
  File "/opt/odoo-venv/lib/python3.10/site-packages/coverage/cmdline.py", line 1163, in main
    status = CoverageScript().command_line(argv)
  File "/opt/odoo-venv/lib/python3.10/site-packages/coverage/cmdline.py", line 853, in command_line
    return self.do_run(options, args)
  File "/opt/odoo-venv/lib/python3.10/site-packages/coverage/cmdline.py", line 1042, in do_run
    runner.run()
  File "/opt/odoo-venv/lib/python3.10/site-packages/coverage/execfile.py", line 213, in run
    exec(code, main_mod.__dict__)
  File "/opt/odoo-venv/bin/odoo", line 8, in <module>
    odoo.cli.main()
  File "/opt/odoo/odoo/cli/command.py", line 76, in main
    o.run(args)
  File "/opt/odoo/odoo/cli/server.py", line 182, in run
    main(args)
  File "/opt/odoo/odoo/cli/server.py", line 175, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/opt/odoo/odoo/service/server.py", line 1462, in start
    rc = server.run(preload, stop)
  File "/opt/odoo/odoo/service/server.py", line 627, in run
    rc = preload_registries(preload)
  File "/opt/odoo/odoo/service/server.py", line 1366, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-13>", line 2, in new
  File "/opt/odoo/odoo/tools/func.py", line 97, in locked
    return func(inst, *args, **kwargs)
  File "/opt/odoo/odoo/modules/registry.py", line 129, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/odoo/modules/loading.py", line 489, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "/opt/odoo/odoo/modules/loading.py", line 365, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/odoo/modules/loading.py", line 284, in load_module_graph
    test_results = loader.run_suite(suite, global_report=report)
  File "/opt/odoo/odoo/tests/loader.py", line 118, in run_suite
    suite(results)
AssertionError: Found unexpected attributes on stock.picking: _delivery_note_fields
</pre>
</details>

Ad esempio: https://github.com/OCA/l10n-italy/actions/runs/22152389208/job/64047030086#step:8:1324.