### PR TITLE
[FIX] l10n_it_account_vat_period_end_settlement: do not update undef field

### DIFF
--- a/l10n_it_account_vat_period_end_settlement/__init__.py
+++ b/l10n_it_account_vat_period_end_settlement/__init__.py
@@ -3,4 +3,4 @@
 from . import report
 from . import wizard
 from . import models
-from .hooks import pre_absorb_old_module
+from .hooks import pre_absorb_old_module, post_absorb_old_module

--- a/l10n_it_account_vat_period_end_settlement/__manifest__.py
+++ b/l10n_it_account_vat_period_end_settlement/__manifest__.py
@@ -43,5 +43,6 @@
         ],
     },
     "pre_init_hook": "pre_absorb_old_module",
+    "post_init_hook": "post_absorb_old_module",
     "installable": True,
 }

--- a/l10n_it_account_vat_period_end_settlement/hooks.py
+++ b/l10n_it_account_vat_period_end_settlement/hooks.py
@@ -3,14 +3,13 @@
 from openupgradelib import openupgrade
 
 
-def set_exclude_from_vat_settlements(env):
-    openupgrade.logged_query(
-        env.cr,
+def post_absorb_old_module(env):
+    if openupgrade.column_exists(env.cr, "account_tax", "vat_statement_account_id"):
+        query = """
+            UPDATE account_tax SET exclude_from_vat_settlements = True
+            WHERE vat_statement_account_id IS NULL;
         """
-        UPDATE account_tax SET exclude_from_vat_settlements = True
-        WHERE vat_statement_account_id IS NULL;
-        """,
-    )
+        openupgrade.logged_query(env.cr, query)
 
 
 def pre_absorb_old_module(env):
@@ -25,4 +24,3 @@ def pre_absorb_old_module(env):
             ],
             merge_modules=True,
         )
-        set_exclude_from_vat_settlements(env)


### PR DESCRIPTION
Durante l'esecuzione del pre-hook il modulo tenta di eseguire l'update della colonna [exclude_from_vat_settlements](https://github.com/OCA/l10n-italy/blob/77e3b9532753e105345e09d221c9e71f45d8750f/l10n_it_account_vat_period_end_settlement/models/account.py#L810) della tabella account_tax che ancora non esiste, in quanto definita dal modulo stesso.

Errore specifico:
`sycopg2.errors.UndefinedColumn: column "exclude_from_vat_settlements" of relation "account_tax" does not exist`

Spostando la query in un post-hook il comportamento risulta corretto.

L'errore nei test della CI non mi risulta sia da imputare alla modifica introdotta da questo modulo in quanto avviene anche eseguendo i test di l10n_it_edi_extension in isolamento, eseguendo:

```sh
./odoo-bin -c <config> -i l10n_it_edi_extension --stop-after-init
./odoo-bin -c <config> -u l10n_it_edi_extension --test-enable --stop-after-init
```