### PR TITLE
[18.0] FIX l10n_it_edi_extension: Element text are different for node /FatturaElettronica/FatturaElettronicaBody/DatiGenerali/DatiGeneraliDocumento/ImportoTotaleDocumento

### DIFF
--- a/l10n_it_edi_extension/tests/export_xmls/us_partner_shipping.xml
+++ b/l10n_it_edi_extension/tests/export_xmls/us_partner_shipping.xml
@@ -64,7 +64,7 @@
                 <Divisa>EUR</Divisa>
                 <Data>2024-08-07</Data>
                 <Numero>INV/2024/00001</Numero>
-                <ImportoTotaleDocumento>1068.11</ImportoTotaleDocumento>
+                <ImportoTotaleDocumento>990.00</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>
         <DatiBeniServizi>


### PR DESCRIPTION

Odoo core commit https://github.com/odoo/odoo/commit/0b54f84 changed ImportoTotaleDocumento from using invoice currency amounts (base_amount_currency/tax_amount_currency) to company currency amounts (base_amount/tax_amount).

This is correct per Italian tax law (art. 21, c. 2, lett. l, D.P.R. 633/72): since Divisa must be EUR for Italian-resident issuers, ImportoTotaleDocumento can also be expressed in EUR.

For l10n_it_edi_extension, the USD invoice (1068.11 USD at rate 1.0789) now correctly reports 990.00 EUR as the total.