### PR TITLE
[18.0] [FIX] l10n_it_riba_oca: fix scripts for OpenUpgrade migration

### DIFF
--- a/l10n_it_riba_oca/hooks.py
+++ b/l10n_it_riba_oca/hooks.py
@@ -13,5 +13,4 @@ def pre_absorb_old_module(env):
             [
                 ("l10n_it_riba", "l10n_it_riba_oca"),
             ],
-            merge_modules=True,
         )

--- a/l10n_it_riba_oca/migrations/18.0.1.0.0/pre-migrate.py
+++ b/l10n_it_riba_oca/migrations/18.0.1.0.0/pre-migrate.py
@@ -2,15 +2,12 @@
 #  Copyright 2024 Nextev Srl
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from openupgradelib import openupgrade
 
-# pylint: disable=odoo-addons-relative-import
-# because
-#   from ... import hooks
-# raises
-#   ImportError: attempted relative import with no known parent package
 from odoo.addons.l10n_it_riba_oca import hooks
 
 
-def migrate(cr, installed_version):
+@openupgrade.migrate()
+def migrate(env, version):
     # Used by OpenUpgrade when module is in `apriori`
-    hooks.migrate_old_module(cr)
+    hooks.pre_absorb_old_module(env)


### PR DESCRIPTION
Gli script di pre-migrazione di OpenUpgrade ricevono solo il cursore del database (`cr`) e una stringa di versione come argomenti, mentre il normale flusso di aggiornamento di Odoo (tramite frontend o `odoo -u`) fornisce un oggetto `env` completo.

Questo commit introduce una funzione wrapper `migrate_old_module(cr)` in `hooks.py` che costruisce un `api.Environment` a partire dal solo cursore, permettendo di riutilizzare correttamente la logica esistente di `pre_absorb_old_module(env)` anche durante una migrazione con OpenUpgrade.

Inoltre, `migrate(cr, installed_version)` nello script di pre-migrazione è stata corretto in `migrate(cr, version)`, che è esattamente quella attesa da OpenUpgrade.

Senza queste modifiche, la migrazione funzionava solo aggiornando il modulo dal frontend di Odoo (dove `env` è già disponibile), ma falliva silenziosamente con OpenUpgrade, che chiama la funzione passando solo il cursore senza costruire un `env` automaticamente.