### PR TITLE
[14.0][l10n_it_delivery_note] FIX backorder

### DIFF
--- a/l10n_it_delivery_note/models/stock_picking.py
+++ b/l10n_it_delivery_note/models/stock_picking.py
@@ -492,6 +492,7 @@ class StockPicking(models.Model):
         """When we make a backorder of a picking the delivery note lines needed
         to be updated otherwise stock_delivery_note_line_move_uniq constraint is raised"""
         backorders = super()._create_backorder()
-        for backorder in backorders:
-            backorder.backorder_id.delivery_note_id.update_detail_lines()
+        if backorders:
+            for backorder in backorders:
+                backorder.backorder_id.delivery_note_id.update_detail_lines()
         return backorders


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/5133

In `_create_backorder` è necessario controllare il risultato di
`backorders = super()._create_backorder()`
perchè altrimenti c'è la possibilità che si generi l'errore:
>TypeError: 'NoneType' object is not iterable