### PR TITLE
[16.0][FIX] l10n_it_account_stamp: Bollo non applicato in prima riga fattura

### DIFF
--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -32,7 +32,7 @@ class AccountMove(models.Model):
         total_tax_base = sum(
             (
                 inv_tax.price_subtotal
-                for inv_tax in self.line_ids.filtered(
+                for inv_tax in self.invoice_line_ids.filtered(
                     lambda line: set(line.tax_ids.ids)
                     & set(stamp_product_id.stamp_apply_tax_ids.ids)
                 )


### PR DESCRIPTION
Risolve #4753 