### PR TITLE
[FIX] l10n_it_riba_oca script di migrazione

### DIFF
--- a/l10n_it_riba_oca/migrations/18.0.1.0.0/pre-migrate.py
+++ b/l10n_it_riba_oca/migrations/18.0.1.0.0/pre-migrate.py
@@ -8,9 +8,11 @@
 #   from ... import hooks
 # raises
 #   ImportError: attempted relative import with no known parent package
+from openupgradelib import openupgrade
 from odoo.addons.l10n_it_riba_oca import hooks
 
 
-def migrate(cr, installed_version):
+@openupgrade.migrate()
+def migrate(env, version):
     # Used by OpenUpgrade when module is in `apriori`
-    hooks.migrate_old_module(cr)
+    hooks.pre_absorb_old_module(env)


### PR DESCRIPTION
Lo script di migrazione non era aggiornato: la signature di migrate non era corretta e la funzione chiamata da hooks era stata rinominata. Necessario per proseguire https://github.com/OCA/l10n-italy/issues/4519