### PR TITLE
[18.0][FIX] l10n_it_edi_related_document: set standard_related_docume…

### DIFF
--- a/l10n_it_edi_related_document/models/account_move.py
+++ b/l10n_it_edi_related_document/models/account_move.py
@@ -63,7 +63,7 @@ class AccountMoveRelatedDocumentType(models.Model):
         # after creating documents, check if one should is eligible
         # to become the standard_related_document_id
         for record in ret.filtered(
-            lambda r: r.type == "order"
+            lambda r: r.type in ("order", "contract", "agreement")
             and r.invoice_id
             and not r.invoice_id.standard_related_document_id
         ):
@@ -71,11 +71,13 @@ class AccountMoveRelatedDocumentType(models.Model):
                 l10n_it_edi_related_loop_avoid=True
             )
             invoice.standard_related_document_id = record
-            invoice.l10n_it_origin_document_type = "purchase_order"
+            invoice.l10n_it_origin_document_type = (
+                "purchase_order" if record.type == "order" else record.type
+            )
             invoice.l10n_it_origin_document_name = record.name
             invoice.l10n_it_origin_document_date = record.date
             invoice.l10n_it_cig = record.cig
-            record.invoice_id.l10n_it_cup = record.cup
+            invoice.l10n_it_cup = record.cup
 
         return ret
 


### PR DESCRIPTION
…nt_id for contract and agreement types

## Problema

Quando si crea un documento collegato con tipo `contratto` o `convenzione` 
su una fattura PA, il campo `standard_related_document_id` non veniva mai 
impostato perché il metodo `create` gestiva solo `type == "order"`.

Questo causava `l10n_it_origin_document_type` a rimanere `False`, bloccando 
l'invio della fattura PA con l'errore:
"Compilare il campo Tipo Documento Origine nella scheda Fatturazione elettronica"

## Soluzione

Esteso il filtro nel metodo `create` per includere i tipi `contract` e 
`agreement`, con la corretta mappatura su `l10n_it_origin_document_type`.
