### PR TITLE
[FIX] l10n_it_edi_extension: when importing an XML with DatiRitenuta or DatiCassaPrevidenziale

### DIFF
--- a/l10n_it_edi_extension/models/account_move.py
+++ b/l10n_it_edi_extension/models/account_move.py
@@ -420,7 +420,12 @@ class AccountMoveInherit(models.Model):
         return partner
 
     def _l10n_it_edi_search_tax_for_import(
-        self, company, percentage, extra_domain=None, l10n_it_exempt_reason=None
+        self,
+        company,
+        percentage,
+        extra_domain=None,
+        l10n_it_exempt_reason=None,
+        **kwargs,
     ):
         # Check if a tax of the default product fits what is requested
         partner_default_product = self.partner_id.l10n_it_edi_ext_default_product_id
@@ -438,6 +443,7 @@ class AccountMoveInherit(models.Model):
                 percentage,
                 product_extra_domain,
                 l10n_it_exempt_reason=l10n_it_exempt_reason,
+                **kwargs,
             )
             if not tax:
                 tax = super()._l10n_it_edi_search_tax_for_import(
@@ -445,6 +451,7 @@ class AccountMoveInherit(models.Model):
                     percentage,
                     extra_domain,
                     l10n_it_exempt_reason=l10n_it_exempt_reason,
+                    **kwargs,
                 )
         else:
             tax = super()._l10n_it_edi_search_tax_for_import(
@@ -452,6 +459,7 @@ class AccountMoveInherit(models.Model):
                 percentage,
                 extra_domain,
                 l10n_it_exempt_reason=l10n_it_exempt_reason,
+                **kwargs,
             )
         return tax
 


### PR DESCRIPTION

get
TypeError: AccountMoveInherit._l10n_it_edi_search_tax_for_import() got an unexpected keyword argument 'vat_only'

The vat_only parameter has been in l10n_it_edi_withholding since the beginning of Odoo 18. Importing invoices that have withholding/pension fund taxes has never worked with l10n_it_edi_extension installed.

The error only triggers when the imported XML contains DatiRitenuta or DatiCassaPrevidenziale sections (withholding or pension fund data), because that's when l10n_it_edi_withholding calls the method with vat_only=False. Regular invoices without those sections work fine since the base module never passes vat_only.

When l10n_it_edi_withholding._l10n_it_edi_get_extra_info() calls self._l10n_it_edi_search_tax_for_import(..., vat_only=False), Python dispatches to the most derived override — which is l10n_it_edi_extension's version. But that version doesn't accept vat_only, hence the TypeError.