### PR TITLE
18.0 fix related document copy false

### DIFF
--- a/l10n_it_edi_related_document/models/account_move.py
+++ b/l10n_it_edi_related_document/models/account_move.py
@@ -63,7 +63,7 @@ class AccountMoveRelatedDocumentType(models.Model):
         # after creating documents, check if one should is eligible
         # to become the standard_related_document_id
         for record in ret.filtered(
-            lambda r: r.type == "order"
+            lambda r: r.type in ("order", "contract", "agreement")
             and r.invoice_id
             and not r.invoice_id.standard_related_document_id
         ):
@@ -71,11 +71,13 @@ class AccountMoveRelatedDocumentType(models.Model):
                 l10n_it_edi_related_loop_avoid=True
             )
             invoice.standard_related_document_id = record
-            invoice.l10n_it_origin_document_type = "purchase_order"
+            invoice.l10n_it_origin_document_type = (
+                "purchase_order" if record.type == "order" else record.type
+            )
             invoice.l10n_it_origin_document_name = record.name
             invoice.l10n_it_origin_document_date = record.date
             invoice.l10n_it_cig = record.cig
-            record.invoice_id.l10n_it_cup = record.cup
+            invoice.l10n_it_cup = record.cup
 
         return ret
 

--- a/l10n_it_edi_related_document/models/account_move.py
+++ b/l10n_it_edi_related_document/models/account_move.py
@@ -123,6 +123,7 @@ class AccountMove(models.Model):
         comodel_name="account.move.related_document",
         string="Standard Related Document",
         help="Technical field to store the document corresponding to standard fields",
+        copy=False,
     )
 
     # override

--- a/l10n_it_edi_related_document/tests/test_import_xml.py
+++ b/l10n_it_edi_related_document/tests/test_import_xml.py
@@ -92,3 +92,40 @@ class TestItEdiImport(TestItEdi):
         )
         self.assertEqual(invoice.l10n_it_cig, "CIG2")
         self.assertEqual(invoice.l10n_it_cup, "CUP2")
+
+    def test_standard_related_document_not_copied_to_refund(self):
+        """Test that standard_related_document_id error when creating a credit note"""
+        euro = self.setup_other_currency("EUR")
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner_a.id,
+                "invoice_date": fields.Date.from_string("2016-01-01"),
+                "currency_id": euro.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        None,
+                        {
+                            "product_id": self.product_a.id,
+                            "quantity": 1,
+                            "price_unit": 100,
+                        },
+                    ),
+                ],
+            }
+        )
+        self.env["account.move.related_document"].create(
+            {
+                "invoice_id": invoice.id,
+                "type": "contract",
+                "name": "C00001",
+                "cig": "CIG123",
+            }
+        )
+        self.assertTrue(invoice.standard_related_document_id)
+        # Create refund from invoice
+        refund = invoice.copy({"move_type": "out_refund"})
+        # standard_related_document_id must not be copied to the refund
+        self.assertFalse(refund.standard_related_document_id)
+        self.assertFalse(refund.l10n_it_origin_document_type)


### PR DESCRIPTION
### Problema

Quando Odoo crea una nota di credito da una fattura PA, copia il campo tecnico `standard_related_document_id` dalla fattura originale.

Questo causa un problema: quando si aggiunge un nuovo documento collegato alla nota di credito, il metodo `create` trova `standard_related_document_id` già popolato (con il documento della fattura originale) e salta l'impostazione del nuovo documento. 
Di conseguenza `l10n_it_origin_document_type` rimane `False`, bloccando l'invio con l'errore:
"Compilare il campo Tipo Documento Origine nella scheda Fatturazione elettronica"

### Soluzione

Aggiunto `copy=False` al campo `standard_related_document_id` per evitare che venga copiato durante la creazione di note di credito o duplicati.
Aggiunto test che verifica il comportamento corretto.