### PR TITLE
[FIX] l10n_it_edi_extension: sanitizza il campo Causale per conformità Latin-1 SDI

### DIFF
--- a/l10n_it_edi_extension/models/account_move.py
+++ b/l10n_it_edi_extension/models/account_move.py
@@ -10,6 +10,29 @@ from odoo.addons.base.models.ir_qweb_fields import Markup
 from odoo.addons.l10n_it_edi.models.account_move import get_date, get_float, get_text
 
 
+def _sanitize_fatturapa_string(value):
+    """Replace characters outside BasicLatin+Latin-1 Supplement range
+    with ASCII equivalents, to comply with SDI String200LatinType pattern."""
+    if not value:
+        return value
+    replacements = {
+        "\u201c": '"',  # " left double quotation mark
+        "\u201d": '"',  # " right double quotation mark
+        "\u2018": "'",  # ' left single quotation mark
+        "\u2019": "'",  # ' right single quotation mark / apostrophe
+        "\u2013": "-",  # – en dash
+        "\u2014": "-",  # — em dash
+        "\u2026": "...",  # … horizontal ellipsis
+        "\u00ab": '"',  # « left-pointing double angle quotation mark
+        "\u00bb": '"',  # » right-pointing double angle quotation mark
+    }
+    for char, replacement in replacements.items():
+        value = value.replace(char, replacement)
+    # Remove any remaining characters outside U+0000-U+00FF
+    value = "".join(c if ord(c) <= 0x00FF else "" for c in value)
+    return value
+
+
 class AccountMoveInherit(models.Model):
     _inherit = "account.move"
 
@@ -286,7 +309,7 @@ class AccountMoveInherit(models.Model):
                 for causale200 in causale_list_200:
                     causale_list.append(causale200)
 
-        res["causale"] = causale_list
+        res["causale"] = [_sanitize_fatturapa_string(c) for c in causale_list]
 
         return res
 

--- a/l10n_it_edi_extension/tests/export_xmls/narration_sanitize.xml
+++ b/l10n_it_edi_extension/tests/export_xmls/narration_sanitize.xml
@@ -1,0 +1,106 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<p:FatturaElettronica
+    xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd"
+    versione="FPR12"
+>
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>V201900001</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>0000000</CodiceDestinatario>
+            <ContattiTrasmittente>
+                <Telefono>0266766700</Telefono>
+                <Email>test@test.it</Email>
+            </ContattiTrasmittente>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>01234560157</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>company_2_data</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>1234 Test Street</Indirizzo>
+                <CAP>12345</CAP>
+                <Comune>Prova</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>00465840031</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>93026890017</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>Alessi</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Privata Alessi 6</Indirizzo>
+                <CAP>28887</CAP>
+                <Comune>Milan</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2019-01-01</Data>
+                <Numero>INV/2019/00001</Numero>
+                <ImportoTotaleDocumento>122.00</ImportoTotaleDocumento>
+                <Causale>"Virgolette" e trattino lungo - e apostrofo'</Causale>
+            </DatiGeneraliDocumento>
+            <DatiTrasporto>
+                <IndirizzoResa>
+                    <Indirizzo>Via Privata Alessi 6</Indirizzo>
+                    <CAP>28887</CAP>
+                    <Comune>Milan</Comune>
+                    <Nazione>IT</Nazione>
+                </IndirizzoResa>
+            </DatiTrasporto>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>test line</Descrizione>
+                <Quantita>1.00</Quantita>
+                <PrezzoUnitario>100.00000000</PrezzoUnitario>
+                <PrezzoTotale>100.00000000</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>100.00</ImponibileImporto>
+                <Imposta>22.00</Imposta>
+                <EsigibilitaIVA>I</EsigibilitaIVA>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2019-01-01</DataScadenzaPagamento>
+                <ImportoPagamento>122.00</ImportoPagamento>
+                <CodicePagamento>INV/2019/00001</CodicePagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_edi_extension/tests/export_xmls/narration_sanitize.xml
+++ b/l10n_it_edi_extension/tests/export_xmls/narration_sanitize.xml
@@ -66,7 +66,7 @@
                 <Data>2019-01-01</Data>
                 <Numero>INV/2019/00001</Numero>
                 <ImportoTotaleDocumento>122.00</ImportoTotaleDocumento>
-                <Causale>"Virgolette" e trattino lungo - e apostrofo'</Causale>
+                <Causale>"Virgolette" e trattino - apostrofo'</Causale>
             </DatiGeneraliDocumento>
             <DatiTrasporto>
                 <IndirizzoResa>

--- a/l10n_it_edi_extension/tests/test_export.py
+++ b/l10n_it_edi_extension/tests/test_export.py
@@ -107,8 +107,6 @@ class TestExport(Common):
             taxes=self.default_tax,
         )
         invoice.invoice_date_due = invoice.date
-        invoice.narration = (
-            "\u201cVirgolette\u201d" "e trattino lungo \u2013" "e apostrofo\u2019"
-        )
+        invoice.narration = "\u201cVirgolette\u201d e trattino \u2013 apostrofo\u2019"
         invoice.action_post()
         self._assert_export_invoice(invoice, "narration_sanitize.xml")

--- a/l10n_it_edi_extension/tests/test_export.py
+++ b/l10n_it_edi_extension/tests/test_export.py
@@ -95,3 +95,20 @@ class TestExport(Common):
         )
         invoice.action_post()
         self._assert_export_invoice(invoice, "us_partner_shipping.xml")
+
+    def test_narration_sanitize(self):
+        """Special typographic characters in narration (curly quotes, en dash)
+        are replaced with ASCII equivalents to comply with SDI Latin-1 pattern."""
+        invoice = self.init_invoice(
+            "out_invoice",
+            amounts=[100],
+            company=self.company,
+            partner=self.italian_partner_a,
+            taxes=self.default_tax,
+        )
+        invoice.invoice_date_due = invoice.date
+        invoice.narration = (
+            "\u201cVirgolette\u201d" "e trattino lungo \u2013" "e apostrofo\u2019"
+        )
+        invoice.action_post()
+        self._assert_export_invoice(invoice, "narration_sanitize.xml")


### PR DESCRIPTION
## Fixes #5176

## Descrizione

Lo SDI scarta le fatture elettroniche quando il campo `<Causale>` contiene caratteri tipografici fuori dal range ammesso dallo schema XSD della FatturaPA (`String200LatinType`).

Questo fix aggiunge la funzione `_sanitize_fatturapa_string()` che sostituisce automaticamente i caratteri problematici con equivalenti ASCII prima della generazione dell'XML:

| Carattere | Unicode | Sostituzione |
|-----------|---------|--------------|
| `"` `"` | U+201C/201D | `"` |
| `'` `'` | U+2018/2019 | `'` |
| `–` `—` | U+2013/2014 | `-` |
| `…` | U+2026 | `...` |
| `«` `»` | U+00AB/00BB | `"` |

I caratteri fuori da U+0000–U+00FF non mappati esplicitamente vengono rimossi come fallback.

La funzione viene applicata in `_l10n_it_edi_get_values()` sulla lista `causale` prima che venga restituita al template.