### PR TITLE
[FIX] l10n_it_vat_registries: Rimozione Link riferimento normativo nelle informazioni del modulo

### DIFF
--- a/l10n_it_vat_registries/readme/DESCRIPTION.md
+++ b/l10n_it_vat_registries/readme/DESCRIPTION.md
@@ -1,2 +1,1 @@
 Law: Decreto del Presidente della Repubblica del 26 ottobre 1972 n. 633
-<https://goo.gl/31yTVj>


### PR DESCRIPTION
Fixes #5181

### Context
Il link nella Gazzetta ufficiale presente nell'informazione del modulo non è più valido, per cui è stato tolto come suggerito da [francesco-ooops](https://github.com/francesco-ooops).