### PR TITLE
[FIX] Un pagamento per più fatture con ritenuta genera importi sbagliati

### DIFF
--- a/l10n_it_withholding_tax/README.rst
+++ b/l10n_it_withholding_tax/README.rst
@@ -131,6 +131,9 @@ Contributors
 * `Aion Tech <https://aiontech.company/>`_:
 
   * Simone Rubino <simone.rubino@aion-tech.it>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_it_withholding_tax/models/withholding_tax.py
+++ b/l10n_it_withholding_tax/models/withholding_tax.py
@@ -279,20 +279,29 @@ class WithholdingTaxStatement(models.Model):
                 if wt_inv:
                     # Compute how much has been already paid
                     # but has no corresponding Withholding Tax move
-                    payment_moves = self.env["account.move"].browse()
+                    payment_moves_to_amount = {}
                     for (
                         _partial,
-                        _amount,
+                        amount,
                         counterpart_line,
                     ) in st.invoice_id._get_reconciled_invoices_partials():
-                        payment_moves |= counterpart_line.move_id
+                        payment_move = counterpart_line.move_id
+                        payment_moves_to_amount.setdefault(
+                            payment_move,
+                            payment_moves_to_amount.get(payment_move, 0) + amount,
+                        )
+                    payment_moves = self.env["account.move"].browse(
+                        [move.id for move in payment_moves_to_amount.keys()]
+                    )
                     # Exclude payments created for Withholding Taxes
                     wt_moves = self.env["withholding.tax.move"].search(
                         [("account_move_id", "in", payment_moves.ids)]
                     )
                     wt_payment_moves = wt_moves.wt_account_move_id
                     no_wt_payment_moves = payment_moves - wt_payment_moves
-                    no_wt_paid_amount = sum(no_wt_payment_moves.mapped("amount_total"))
+                    no_wt_paid_amount = sum(
+                        [payment_moves_to_amount[move] for move in no_wt_payment_moves]
+                    )
 
                     amount_base = st.invoice_id.amount_untaxed * (
                         no_wt_paid_amount / st.invoice_id.amount_net_pay

--- a/l10n_it_withholding_tax/readme/CONTRIBUTORS.rst
+++ b/l10n_it_withholding_tax/readme/CONTRIBUTORS.rst
@@ -8,3 +8,6 @@
 * `Aion Tech <https://aiontech.company/>`_:
 
   * Simone Rubino <simone.rubino@aion-tech.it>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/l10n_it_withholding_tax/static/description/index.html
+++ b/l10n_it_withholding_tax/static/description/index.html
@@ -461,6 +461,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;aion-tech.it">simone.rubino&#64;aion-tech.it</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_it_withholding_tax/tests/test_withholding_tax.py
+++ b/l10n_it_withholding_tax/tests/test_withholding_tax.py
@@ -626,8 +626,15 @@ class TestWithholdingTax(TransactionCase):
             ],
         )
         self.assertEqual(len(statements), len(invoices))
-        self.assertAlmostEqual(
-            sum(x.tax for x in statements), 95.44 + 2.62 + 20 + 9.68 + 9.68
+        self.assertRecordValues(
+            statements.sorted("tax"),
+            [
+                {
+                    "amount": amount,
+                    "tax": amount,
+                }
+                for amount in (2.62, 9.68, 9.68, 20, 95.44)
+            ],
         )
         wh_move_ids = statements.mapped("move_ids.wt_account_move_id")
         self.assertEqual(len(wh_move_ids), len(statements))
@@ -734,8 +741,9 @@ class TestWithholdingTax(TransactionCase):
         """
         # Arrange
         amount = 2000
-        wt_amount = 500
         bill = self._create_bill(price_unit=amount)
+        w_tax = bill.line_ids.invoice_line_tax_wt_ids
+        wt_amount = amount * w_tax.rate_ids.tax / 100
         bill.withholding_tax_no_generate_move = True
         wt_statement = self.env["withholding.tax.statement"].search(
             [
@@ -743,6 +751,7 @@ class TestWithholdingTax(TransactionCase):
             ]
         )
         # pre-condition
+        self.assertEqual(wt_amount, 400)
         self.assertTrue(bill.withholding_tax_no_generate_move)
 
         # Act 1: Partial payment generating no move


### PR DESCRIPTION
Corregge https://github.com/OCA/l10n-italy/issues/5190.