### PR TITLE
[IMP] l10n_it_edi_extension: adapt FatturaPA import to core

### DIFF
--- a/l10n_it_edi_extension/models/account_move.py
+++ b/l10n_it_edi_extension/models/account_move.py
@@ -413,10 +413,41 @@ class AccountMoveInherit(models.Model):
 
         return extra_info, message_to_log
 
+    @api.model
+    def _l10n_it_edi_extension_core_partner_fields(self):
+        """Return partner fields core writes during FatturaPA import.
+
+        Override this hook when another module starts (or stops) writing
+        a partner field through core's ``_l10n_it_edi_import_partner``,
+        so that ``_l10n_it_edi_update_partner`` keeps respecting core.
+        """
+        return {
+            "name",
+            "vat",
+            "email",
+            "phone",
+            "street",
+            "street2",
+            "zip",
+            "city",
+            "country_id",
+            "is_company",
+            "l10n_it_codice_fiscale",
+        }
+
     def _l10n_it_edi_update_partner(self, xml_tree, role, partner):
+        """Fill on ``partner`` the FatturaPA fields core does not handle.
+
+        Core writes the basic identity and address block. Drop those
+        keys from the prepared values so they stay as core wrote them,
+        and write the FatturaPA extras (state_id, EORI, professional
+        register data, firstname/lastname split).
+        """
         vals = self._l10n_it_edi_extension_prepare_partner_values(xml_tree, role)
-        del vals["vat"]  # Because VAT is used to identify the partner
-        partner.update(vals)
+        for field_name in self._l10n_it_edi_extension_core_partner_fields():
+            vals.pop(field_name, None)
+        if vals:
+            partner.update(vals)
         return partner
 
     def _l10n_it_edi_search_tax_for_import(
@@ -845,15 +876,136 @@ class AccountMoveInherit(models.Model):
         return vals
 
     def _l10n_it_edi_extension_create_partner(self, invoice_data, role):
+        """Return a partner for ``role``, looking up an existing one first.
+
+        Used for roles core does not handle (e.g. ``RappresentanteFiscale``).
+        Follows the path core uses for buyer/seller: match by Italian
+        Codice Fiscale, then delegate to ``_l10n_it_edi_import_partner``
+        which calls ``_retrieve_partner`` and creates a new partner when
+        nothing matches. ``_l10n_it_edi_update_partner`` fills the
+        FatturaPA extras (state_id, EORI, Albo*, firstname/lastname)
+        on top.
+        """
+        Partner = self.env["res.partner"]
         partner_values = self._l10n_it_edi_extension_prepare_partner_values(
             invoice_data,
             role,
         )
-        if partner_values:
-            partner = self.env["res.partner"].create(partner_values)
-        else:
-            partner = self.env["res.partner"].browse()
+        if not partner_values:
+            return Partner
+        company = self.env.company
+        codice_fiscale = partner_values.get("l10n_it_codice_fiscale")
+        partner = Partner
+        if codice_fiscale:
+            partner = Partner.with_company(company).search(
+                [
+                    *Partner._check_company_domain(company),
+                    ("l10n_it_codice_fiscale", "=like", codice_fiscale),
+                ],
+                limit=1,
+            )
+        if not partner:
+            partner, _logs = self._l10n_it_edi_import_partner(
+                company_id=company,
+                name=partner_values.get("name"),
+                phone=partner_values.get("phone"),
+                email=partner_values.get("email"),
+                vat=partner_values.get("vat"),
+                street=partner_values.get("street"),
+                city=partner_values.get("city"),
+                zip_code=partner_values.get("zip"),
+            )
+            if partner and codice_fiscale and not partner.l10n_it_codice_fiscale:
+                partner.l10n_it_codice_fiscale = codice_fiscale
+            if partner and not partner.country_id and partner_values.get("country_id"):
+                partner.country_id = partner_values["country_id"]
+        if partner:
+            self._l10n_it_edi_update_partner(invoice_data, role, partner)
         return partner
+
+    def _l10n_it_edi_extension_get_bank_partner(self, invoice):
+        """Return the partner that owns the bank accounts in this FatturaPA.
+
+        Mirrors core's ``_l10n_it_edi_import_partner_bank`` selection
+        via ``is_outbound``/``is_inbound``: the invoice partner on
+        outbound documents (in_invoice, out_refund), the company
+        partner on inbound documents (out_invoice, in_refund). Empty
+        recordset on any other move type skips the bank update.
+        """
+        if invoice.is_outbound(include_receipts=False):
+            return invoice.partner_id
+        if invoice.is_inbound(include_receipts=False):
+            return invoice.company_id.partner_id
+        return self.env["res.partner"]
+
+    def _l10n_it_edi_extension_get_or_create_bank(self, bic, bank_name):
+        """Return a ``res.bank`` matching ``bic`` or ``bank_name``.
+
+        Search by BIC, then by name; create one when nothing matches.
+        Returns empty when both inputs are empty.
+        """
+        ResBank = self.env["res.bank"]
+        if not (bic or bank_name):
+            return ResBank
+        bank = ResBank
+        if bic:
+            bank = ResBank.search([("bic", "=", bic)], limit=1)
+        if not bank and bank_name:
+            bank = ResBank.search([("name", "=", bank_name)], limit=1)
+        if not bank:
+            bank = ResBank.create({"name": bank_name or bic, "bic": bic or False})
+        return bank
+
+    def _l10n_it_edi_extension_update_partner_bank(self, tree, invoice):
+        """Fill bank_id and acc_holder_name on partner banks created on import.
+
+        Core sets ``acc_number`` on ``res.partner.bank`` and stops there.
+        FatturaPA carries ``BIC`` and ``IstitutoFinanziario`` inside each
+        ``DatiPagamento/DettaglioPagamento`` plus ``Beneficiario`` at the
+        ``DatiPagamento`` level. Map them to ``res.bank`` (creating it
+        when missing) and link the record via ``bank_id``. Values already
+        set on the partner bank stay untouched.
+
+        ``_l10n_it_edi_extension_get_bank_partner`` picks the partner
+        the same way core does. The search filters by company so banks
+        from other companies cannot match.
+        """
+        if tree is None:
+            return
+        bank_partner = self._l10n_it_edi_extension_get_bank_partner(invoice)
+        if not bank_partner:
+            return
+        PartnerBank = self.env["res.partner.bank"]
+        bank_domain = [
+            *PartnerBank._check_company_domain(invoice.company_id),
+            ("partner_id", "child_of", bank_partner.commercial_partner_id.id),
+        ]
+        for payment_node in tree.xpath("//DatiPagamento"):
+            holder = get_text(payment_node, "./Beneficiario") or False
+            for detail_node in payment_node.xpath("./DettaglioPagamento"):
+                iban = get_text(detail_node, "./IBAN")
+                if not iban:
+                    continue
+                bic = get_text(detail_node, "./BIC") or False
+                bank_name = get_text(detail_node, "./IstitutoFinanziario") or False
+                if not (bic or bank_name or holder):
+                    continue
+                partner_bank = PartnerBank.search(
+                    [*bank_domain, ("acc_number", "=", iban)],
+                    limit=1,
+                )
+                if not partner_bank:
+                    continue
+                vals = {}
+                if holder and not partner_bank.acc_holder_name:
+                    vals["acc_holder_name"] = holder
+                if (bic or bank_name) and not partner_bank.bank_id:
+                    if bank := self._l10n_it_edi_extension_get_or_create_bank(
+                        bic, bank_name
+                    ):
+                        vals["bank_id"] = bank.id
+                if vals:
+                    partner_bank.write(vals)
 
     def _l10n_it_edi_import_invoice(self, invoice, data, is_new):
         invoice = super()._l10n_it_edi_import_invoice(invoice, data, is_new)
@@ -893,23 +1045,15 @@ class AccountMoveInherit(models.Model):
                             invoice.sudo().message_post(body=message)
 
         partner_role = "seller" if is_incoming else "buyer"
-        if (
-            invoice
-            and invoice.partner_id
-            and not invoice.partner_id.l10n_edi_it_electronic_invoice_no_contact_update
-        ):
-            self._l10n_it_edi_update_partner(
-                body_tree, partner_role, invoice.partner_id
-            )
-        elif (
-            invoice
-            and not invoice.partner_id
-            and self.env.company.l10n_edi_it_create_partner
-        ):
-            invoice.partner_id = self._l10n_it_edi_extension_create_partner(
-                body_tree,
-                partner_role,
-            )
+        if invoice and invoice.partner_id:
+            if not invoice.partner_id.l10n_edi_it_electronic_invoice_no_contact_update:
+                # Core creates the partner; fill the FatturaPA extras core
+                # leaves out (Provincia, EORI, Albo*, firstname/lastname) on
+                # both pre-existing partners and partners core created.
+                self._l10n_it_edi_update_partner(
+                    body_tree, partner_role, invoice.partner_id
+                )
+            self._l10n_it_edi_extension_update_partner_bank(body_tree, invoice)
 
         if tax_representative := self._l10n_it_edi_extension_create_partner(
             body_tree,

--- a/l10n_it_edi_extension/models/res_company.py
+++ b/l10n_it_edi_extension/models/res_company.py
@@ -22,11 +22,6 @@ class ResCompanyInherit(models.Model):
         help="The fields must be entered only when the seller/provider is "
         "non-resident, with a stable organization in Italy",
     )
-    l10n_edi_it_create_partner = fields.Boolean(
-        string="Create Partner on Eletronic Invoice import",
-        help="Automatically create the partner if it does not "
-        "exist during the import of Electronic Invoices.",
-    )
     l10n_it_edi_import_detail_level = fields.Selection(
         selection=[
             ("min", "Minimum"),
@@ -49,13 +44,6 @@ class ResCompanyInherit(models.Model):
 class AccountConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    l10n_edi_it_create_partner = fields.Boolean(
-        related="company_id.l10n_edi_it_create_partner",
-        string="Create Partner on Eletronic Invoice import",
-        help="Automatically create the partner if it does not "
-        "exist during the import of Electronic Invoices.",
-        readonly=False,
-    )
     l10n_it_edi_import_detail_level = fields.Selection(
         related="company_id.l10n_it_edi_import_detail_level",
         readonly=False,

--- a/l10n_it_edi_extension/tests/test_import_edi_extension_xml.py
+++ b/l10n_it_edi_extension/tests/test_import_edi_extension_xml.py
@@ -12,12 +12,6 @@ from .common import Common
 
 
 class TestFatturaPAXMLValidation(Common):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env.company.l10n_edi_it_create_partner = True
-        cls.company.l10n_edi_it_create_partner = True
-
     def _edi_import_invoice(self, filename):
         moves = self.env["account.move"]
         path = f"l10n_it_edi_extension/tests/import_xmls/{filename}"
@@ -100,10 +94,10 @@ class TestFatturaPAXMLValidation(Common):
         self.assertEqual(move.l10n_it_edi_summary_ids[0].amount_tax, 7.48)
         self.assertEqual(move.l10n_it_edi_summary_ids[0].payability, "D")
         self.assertEqual(move.partner_id.name, "SOCIETA' ALPHA SRL")
-        self.assertEqual(move.partner_id.street, "VIALE ROMA 543")
+        self.assertEqual(move.partner_id.street, "Viale Roma 543")
         self.assertEqual(move.partner_id.state_id.code, "SS")
         self.assertEqual(move.partner_id.country_id.code, "IT")
-        self.assertEqual(move.partner_id.vat, "02780790107")
+        self.assertEqual(move.partner_id.vat, "IT02780790107")
         self.assertEqual(
             move.l10n_it_edi_tax_representative_id.name, "Rappresentante fiscale"
         )
@@ -221,26 +215,6 @@ class TestFatturaPAXMLValidation(Common):
         # Assert
         partner = invoice.partner_id
         self.assertEqual(partner.name, partner_name)
-
-    def test_avoid_create_partner(self):
-        """Partner is not created during import if the setting is disabled."""
-        self.env.company.l10n_edi_it_create_partner = False
-        partner_name = "SOCIETA' BETA SRL"
-        # pre-condition
-        partner = self.env["res.partner"].search(
-            [
-                ("name", "=", partner_name),
-            ],
-            limit=1,
-        )
-        self.assertFalse(partner)
-
-        # Act
-        invoice = self._assert_import_invoice("IT02780790107_11004.xml", [{}])
-
-        # Assert
-        partner = invoice.partner_id
-        self.assertFalse(partner)
 
     def test_min_import_detail_level(self):
         """If import detail level is Minimum,

--- a/l10n_it_edi_extension/views/company_view.xml
+++ b/l10n_it_edi_extension/views/company_view.xml
@@ -6,13 +6,6 @@
         <field name="inherit_id" ref="l10n_it_edi.res_config_settings_view_form" />
         <field name="arch" type="xml">
             <setting id="italian_edi" position="after">
-                <setting
-                    id="l10n_edi_it_create_partner"
-                    help="Automatically create the partner if it does not exist during the import of Electronic Invoices."
-                    company_dependent="1"
-                >
-                    <field name="l10n_edi_it_create_partner" />
-                </setting>
                 <setting id="l10n_it_edi_import_detail_level">
                     <div class="group-content">
                         <span


### PR DESCRIPTION
Core 18.0 added the partner creation and moved the code to import the payments.

### After this PR

  - Partner update on each import. Core fills name, VAT, address. This module fills the Italian extras (Provincia, EORI, Albo*, firstname/lastname) through the existing _l10n_it_edi_update_partner, on both pre-existing partners and partners core created.
  - l10n_edi_it_create_partner flag removed because core creates the partner
  - Bank update. New _l10n_it_edi_extension_update_partner_bank fills bank_id and acc_holder_name, reading BIC, IstitutoFinanziario and Beneficiario from DatiPagamento. Values already set stay untouched.
  - I changed also the tests to fit new core