### PR TITLE
[14.0][IMP] l10n_it_fatturapa_in: port #3100 to v. 14.0 and add check for multicompany partner

### DIFF
--- a/l10n_it_fatturapa_in/models/account.py
+++ b/l10n_it_fatturapa_in/models/account.py
@@ -55,7 +55,7 @@ class AccountInvoice(models.Model):
         "line_ids.full_reconcile_id",
     )
     def _compute_amount(self):
-        super(AccountInvoice, self)._compute_amount()
+        super()._compute_amount()
         for inv in self:
             if inv.efatt_rounding != 0:
                 inv.amount_total += inv.efatt_rounding
@@ -252,7 +252,7 @@ class AccountInvoice(models.Model):
             bill.e_invoice_validation_message = ",\n".join(error_messages) + "."
 
     def name_get(self):
-        result = super(AccountInvoice, self).name_get()
+        result = super().name_get()
         res = []
         for tup in result:
             invoice = self.browse(tup[0])

--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -238,7 +238,7 @@ class FatturaPAAttachmentIn(models.Model):
             # That is why we set it as the last field.
             cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore
             wiz_obj = self.env["wizard.import.fatturapa"].with_context(
-                from_attachment=att
+                from_attachment=att, att_company=att.company_id
             )
             partner_id = wiz_obj.get_partner_from_einvoice_node(cedentePrestatore)
             att.xml_supplier_id = partner_id

--- a/l10n_it_fatturapa_in/models/attachment.py
+++ b/l10n_it_fatturapa_in/models/attachment.py
@@ -238,7 +238,8 @@ class FatturaPAAttachmentIn(models.Model):
             # That is why we set it as the last field.
             cedentePrestatore = fatt.FatturaElettronicaHeader.CedentePrestatore
             wiz_obj = self.env["wizard.import.fatturapa"].with_context(
-                from_attachment=att, att_company=att.company_id
+                from_attachment=att,
+                att_company=att.company_id
             )
             partner_id = wiz_obj.get_partner_from_einvoice_node(cedentePrestatore)
             att.xml_supplier_id = partner_id

--- a/l10n_it_fatturapa_in/tests/data/IT03309970733_VATG1.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT03309970733_VATG1.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:FatturaElettronica versione="FPA12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>05979361218</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>VATG1</ProgressivoInvio>
+            <FormatoTrasmissione>FPA12</FormatoTrasmissione>
+            <CodiceDestinatario>UFPQ1O</CodiceDestinatario>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>03309970733</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>MRORSS90E25B111T</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>SOCIETA' ALPHA BETA SRL</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF02</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIALE ROMA 543B</Indirizzo>
+                <CAP>07100</CAP>
+                <Comune>SASSARI</Comune>
+                <Provincia>SS</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <CodiceFiscale>80213330584</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>AMMINISTRAZIONE BETA</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIA TORINO 38-B</Indirizzo>
+                <CAP>00145</CAP>
+                <Comune>ROMA</Comune>
+                <Provincia>RM</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2015-02-16</Data>
+                <Numero>FT/2015/0009</Numero>
+                <Causale>Rif ordine MAPA: --- Nr. Identificativo Ordine 1234567</Causale>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <CodiceArticolo>
+                    <CodiceTipo>SA</CodiceTipo>
+                    <CodiceValore>123456-01</CodiceValore>
+                </CodiceArticolo>
+                <Descrizione>USB</Descrizione>
+                <Quantita>4.00</Quantita>
+                <UnitaMisura>PZ</UnitaMisura>
+                <PrezzoUnitario>177.00</PrezzoUnitario>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Percentuale>10.00</Percentuale>
+                </ScontoMaggiorazione>
+                <PrezzoTotale>637.20</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <RiferimentoAmministrazione>D122353</RiferimentoAmministrazione>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>2</NumeroLinea>
+                <CodiceArticolo>
+                    <CodiceTipo>SA</CodiceTipo>
+                    <CodiceValore>123456-04</CodiceValore>
+                </CodiceArticolo>
+                <Descrizione>USB</Descrizione>
+                <Quantita>1.00</Quantita>
+                <UnitaMisura>PZ</UnitaMisura>
+                <PrezzoUnitario>596.00</PrezzoUnitario>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Percentuale>10.00</Percentuale>
+                </ScontoMaggiorazione>
+                <PrezzoTotale>536.40</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <RiferimentoAmministrazione>D122354</RiferimentoAmministrazione>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>1173.60</ImponibileImporto>
+                <Imposta>258.19</Imposta>
+                <EsigibilitaIVA>S</EsigibilitaIVA>
+                <RiferimentoNormativo>SCISSIONE PAGAMENTI Split Payment art.17-ter del DPR 633/1972</RiferimentoNormativo>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/data/IT03309970733_VATG2.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT03309970733_VATG2.xml
@@ -33,6 +33,17 @@ xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.
                 <Nazione>IT</Nazione>
             </Sede>
         </CedentePrestatore>
+        <RappresentanteFiscale>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>03309970733</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>Rappresentante fiscale</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+        </RappresentanteFiscale>
         <CessionarioCommittente>
             <DatiAnagrafici>
                 <CodiceFiscale>80213330584</CodiceFiscale>
@@ -48,6 +59,17 @@ xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.
                 <Nazione>IT</Nazione>
             </Sede>
         </CessionarioCommittente>
+        <TerzoIntermediarioOSoggettoEmittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>03309970733</IdCodice>
+                </IdFiscaleIVA>
+                <Anagrafica>
+                    <Denominazione>Terzo Intermediario</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+        </TerzoIntermediarioOSoggettoEmittente>
     </FatturaElettronicaHeader>
     <FatturaElettronicaBody>
         <DatiGenerali>
@@ -58,6 +80,17 @@ xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.
                 <Numero>FT/2015/0009</Numero>
                 <Causale>Rif ordine MAPA: --- Nr. Identificativo Ordine 1234567</Causale>
             </DatiGeneraliDocumento>
+                <DatiTrasporto>
+                    <DatiAnagraficiVettore>
+                        <IdFiscaleIVA>
+                            <IdPaese>IT</IdPaese>
+                            <IdCodice>03309970733</IdCodice>
+                        </IdFiscaleIVA>
+                        <Anagrafica>
+                            <Denominazione>Trasporto spa</Denominazione>
+                        </Anagrafica>
+                    </DatiAnagraficiVettore>
+                </DatiTrasporto>
         </DatiGenerali>
         <DatiBeniServizi>
             <DettaglioLinee>

--- a/l10n_it_fatturapa_in/tests/data/IT03309970733_VATG2.xml
+++ b/l10n_it_fatturapa_in/tests/data/IT03309970733_VATG2.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:FatturaElettronica versione="FPA12" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>05979361218</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>VATG2</ProgressivoInvio>
+            <FormatoTrasmissione>FPA12</FormatoTrasmissione>
+            <CodiceDestinatario>UFPQ1O</CodiceDestinatario>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>03309970733</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>03533590174</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>SOCIETA' ALPHA BETA SRL</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF02</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIALE ROMA 543B</Indirizzo>
+                <CAP>07100</CAP>
+                <Comune>SASSARI</Comune>
+                <Provincia>SS</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <CodiceFiscale>80213330584</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>AMMINISTRAZIONE BETA</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>VIA TORINO 38-B</Indirizzo>
+                <CAP>00145</CAP>
+                <Comune>ROMA</Comune>
+                <Provincia>RM</Provincia>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2015-02-16</Data>
+                <Numero>FT/2015/0009</Numero>
+                <Causale>Rif ordine MAPA: --- Nr. Identificativo Ordine 1234567</Causale>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <CodiceArticolo>
+                    <CodiceTipo>SA</CodiceTipo>
+                    <CodiceValore>123456-01</CodiceValore>
+                </CodiceArticolo>
+                <Descrizione>USB</Descrizione>
+                <Quantita>4.00</Quantita>
+                <UnitaMisura>PZ</UnitaMisura>
+                <PrezzoUnitario>177.00</PrezzoUnitario>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Percentuale>10.00</Percentuale>
+                </ScontoMaggiorazione>
+                <PrezzoTotale>637.20</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <RiferimentoAmministrazione>D122353</RiferimentoAmministrazione>
+            </DettaglioLinee>
+            <DettaglioLinee>
+                <NumeroLinea>2</NumeroLinea>
+                <CodiceArticolo>
+                    <CodiceTipo>SA</CodiceTipo>
+                    <CodiceValore>123456-04</CodiceValore>
+                </CodiceArticolo>
+                <Descrizione>USB</Descrizione>
+                <Quantita>1.00</Quantita>
+                <UnitaMisura>PZ</UnitaMisura>
+                <PrezzoUnitario>596.00</PrezzoUnitario>
+                <ScontoMaggiorazione>
+                    <Tipo>SC</Tipo>
+                    <Percentuale>10.00</Percentuale>
+                </ScontoMaggiorazione>
+                <PrezzoTotale>536.40</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <RiferimentoAmministrazione>D122354</RiferimentoAmministrazione>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>1173.60</ImponibileImporto>
+                <Imposta>258.19</Imposta>
+                <EsigibilitaIVA>S</EsigibilitaIVA>
+                <RiferimentoNormativo>SCISSIONE PAGAMENTI Split Payment art.17-ter del DPR 633/1972</RiferimentoNormativo>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_fatturapa_in/tests/fatturapa_common.py
+++ b/l10n_it_fatturapa_in/tests/fatturapa_common.py
@@ -339,7 +339,7 @@ class FatturapaCommon(SingleTransactionCase):
         cls.misc_journal = cls.create_misc_journal()
 
     def setUp(self):
-        super(FatturapaCommon, self).setUp()
+        super().setUp()
         self.wizard_model = self.env["wizard.import.fatturapa"]
         self.wizard_link_model = self.env["wizard.link.to.invoice"]
         self.data_model = self.env["ir.model.data"]

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -1044,6 +1044,55 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         for partner in partners:
             self.assertIn(partner.name, exc_message)
 
+    def test_56_xml_import_vat_group(self):
+        """Importing bills from VAT groups creates different suppliers."""
+        # Arrange: The involved XMLs contain suppliers from a VAT group:
+        # the suppliers have the same VAT `common_vat`,
+        # but each supplier has a different fiscal code
+        common_vat = 'IT03309970733'
+        vat_group_1_fiscalcode = 'MRORSS90E25B111T'
+        vat_group_2_fiscalcode = '03533590174'
+
+        # Update any conflicting partner from other tests
+        existing_partners = self.env['res.partner'].search(
+            [
+                '|',
+                ('sanitized_vat', '=', common_vat),
+                ('fiscalcode', 'in', (
+                    vat_group_1_fiscalcode,
+                    vat_group_2_fiscalcode,
+                )),
+            ],
+        )
+        existing_partners.update({
+            'vat': 'IT12345670017',
+            'fiscalcode': '1234567890123456',
+        })
+
+        # Act: Import the XMLs,
+        # checking that the suppliers match the data in the XML
+        res = self.run_wizard('VATG1', 'IT03309970733_VATG1.xml')
+        invoice_model = res.get('res_model')
+        invoice_domain = res.get('domain')
+        invoice_vat_group_1 = self.env[invoice_model].search(invoice_domain)
+        vat_group_1_partner = invoice_vat_group_1.partner_id
+        self.assertEqual(vat_group_1_partner.sanitized_vat, common_vat)
+        self.assertEqual(vat_group_1_partner.fiscalcode, vat_group_1_fiscalcode)
+
+        res = self.run_wizard('VATG2', 'IT03309970733_VATG2.xml')
+        invoice_model = res.get('res_model')
+        invoice_domain = res.get('domain')
+        invoice_vat_group_2 = self.env[invoice_model].search(invoice_domain)
+        vat_group_2_partner = invoice_vat_group_2.partner_id
+        self.assertEqual(vat_group_2_partner.sanitized_vat, common_vat)
+        self.assertEqual(vat_group_2_partner.fiscalcode, vat_group_2_fiscalcode)
+
+        # Assert: Two different partners have been created
+        self.assertNotEqual(
+            vat_group_1_partner,
+            vat_group_2_partner,
+        )
+
     def test_01_xml_link(self):
         """
         E-invoice lines are created.

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -31,7 +31,7 @@ class TestDuplicatedAttachment(FatturapaCommon):
 
 class TestFatturaPAXMLValidation(FatturapaCommon):
     def setUp(self):
-        super(TestFatturaPAXMLValidation, self).setUp()
+        super().setUp()
         self.wt = self.create_wt_4q()
         self.wtq = self.create_wt_27_20q()
         self.wt4q = self.create_wt_26_40q()
@@ -1012,32 +1012,36 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         and we try to import an Electronic Invoice for that VAT,
         an exception is raised."""
         # Arrange: There are two partners with the same VAT
-        common_vat = 'IT03309970733'
-        partners = self.env['res.partner'].create([
-            {
-                'name': "Test partner1",
-                'vat': common_vat,
-            },
-            {
-                'name': "Test partner2",
-                'vat': common_vat,
-            },
-        ])
+        common_vat = "IT03309970733"
+        partners = self.env["res.partner"].create(
+            [
+                {
+                    "name": "Test partner1",
+                    "vat": common_vat,
+                },
+                {
+                    "name": "Test partner2",
+                    "vat": common_vat,
+                },
+            ]
+        )
 
         # Update any conflicting partner from other tests
-        existing_partners = self.env['res.partner'].search(
+        existing_partners = self.env["res.partner"].search(
             [
-                ('sanitized_vat', '=', common_vat),
-                ('id', 'not in', partners.ids),
+                ("vat", "=", common_vat),
+                ("id", "not in", partners.ids),
             ],
         )
-        existing_partners.update({
-            'vat': 'IT12345670017',
-        })
+        existing_partners.update(
+            {
+                "vat": "IT12345670017",
+            }
+        )
 
         # Assert: The import wizard can't choose between the two created partners
         with self.assertRaises(UserError) as ue:
-            self.run_wizard('VATG1', 'IT03309970733_VATG1.xml')
+            self.run_wizard("VATG1", "IT03309970733_VATG1.xml")
         exc_message = ue.exception.args[0]
         self.assertIn("Two distinct partners", exc_message)
         self.assertIn("VAT number", exc_message)
@@ -1049,42 +1053,48 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         # Arrange: The involved XMLs contain suppliers from a VAT group:
         # the suppliers have the same VAT `common_vat`,
         # but each supplier has a different fiscal code
-        common_vat = 'IT03309970733'
-        vat_group_1_fiscalcode = 'MRORSS90E25B111T'
-        vat_group_2_fiscalcode = '03533590174'
+        common_vat = "IT03309970733"
+        vat_group_1_fiscalcode = "MRORSS90E25B111T"
+        vat_group_2_fiscalcode = "03533590174"
 
         # Update any conflicting partner from other tests
-        existing_partners = self.env['res.partner'].search(
+        existing_partners = self.env["res.partner"].search(
             [
-                '|',
-                ('sanitized_vat', '=', common_vat),
-                ('fiscalcode', 'in', (
-                    vat_group_1_fiscalcode,
-                    vat_group_2_fiscalcode,
-                )),
+                "|",
+                ("vat", "=", common_vat),
+                (
+                    "fiscalcode",
+                    "in",
+                    (
+                        vat_group_1_fiscalcode,
+                        vat_group_2_fiscalcode,
+                    ),
+                ),
             ],
         )
-        existing_partners.update({
-            'vat': 'IT12345670017',
-            'fiscalcode': '1234567890123456',
-        })
+        existing_partners.update(
+            {
+                "vat": "IT12345670017",
+                "fiscalcode": "1234567890123456",
+            }
+        )
 
         # Act: Import the XMLs,
         # checking that the suppliers match the data in the XML
-        res = self.run_wizard('VATG1', 'IT03309970733_VATG1.xml')
-        invoice_model = res.get('res_model')
-        invoice_domain = res.get('domain')
+        res = self.run_wizard("VATG1", "IT03309970733_VATG1.xml")
+        invoice_model = res.get("res_model")
+        invoice_domain = res.get("domain")
         invoice_vat_group_1 = self.env[invoice_model].search(invoice_domain)
         vat_group_1_partner = invoice_vat_group_1.partner_id
-        self.assertEqual(vat_group_1_partner.sanitized_vat, common_vat)
+        self.assertEqual(vat_group_1_partner.vat, common_vat)
         self.assertEqual(vat_group_1_partner.fiscalcode, vat_group_1_fiscalcode)
 
-        res = self.run_wizard('VATG2', 'IT03309970733_VATG2.xml')
-        invoice_model = res.get('res_model')
-        invoice_domain = res.get('domain')
+        res = self.run_wizard("VATG2", "IT03309970733_VATG2.xml")
+        invoice_model = res.get("res_model")
+        invoice_domain = res.get("domain")
         invoice_vat_group_2 = self.env[invoice_model].search(invoice_domain)
         vat_group_2_partner = invoice_vat_group_2.partner_id
-        self.assertEqual(vat_group_2_partner.sanitized_vat, common_vat)
+        self.assertEqual(vat_group_2_partner.vat, common_vat)
         self.assertEqual(vat_group_2_partner.fiscalcode, vat_group_2_fiscalcode)
 
         # Assert: Two different partners have been created
@@ -1344,7 +1354,7 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
 
 class TestFatturaPAEnasarco(FatturapaCommon):
     def setUp(self):
-        super(TestFatturaPAEnasarco, self).setUp()
+        super().setUp()
 
         self.invoice_model = self.env["account.move"]
 

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -1007,6 +1007,41 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         for model in to_unlink:
             model.unlink()
 
+    def test_55_duplicated_partner(self):
+        """If there are multiple partners with the same VAT
+        and we try to import an Electronic Invoice for that VAT,
+        an exception is raised."""
+        # Arrange: There are two partners with the same VAT
+        common_vat = 'IT03309970733'
+        partners = self.env['res.partner'].create([
+            {
+                'name': "Test partner1",
+                'vat': common_vat,
+            },
+            {
+                'name': "Test partner2",
+                'vat': common_vat,
+            },
+        ])
+
+        # Update any conflicting partner from other tests
+        existing_partners = self.env['res.partner'].search(
+            [
+                ('sanitized_vat', '=', common_vat),
+                ('id', 'not in', partners.ids),
+            ],
+        )
+        existing_partners.update({
+            'vat': 'IT12345670017',
+        })
+
+        # Assert: The import wizard can't choose between the two created partners
+        with self.assertRaises(UserError) as ue:
+            self.run_wizard('VATG1', 'IT03309970733_VATG1.xml')
+        exc_message = ue.exception.args[0]
+        self.assertIn("Two distinct partners", exc_message)
+        self.assertIn("VAT number", exc_message)
+
     def test_01_xml_link(self):
         """
         E-invoice lines are created.

--- a/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
+++ b/l10n_it_fatturapa_in/tests/test_import_fatturapa_xml.py
@@ -1041,6 +1041,8 @@ class TestFatturaPAXMLValidation(FatturapaCommon):
         exc_message = ue.exception.args[0]
         self.assertIn("Two distinct partners", exc_message)
         self.assertIn("VAT number", exc_message)
+        for partner in partners:
+            self.assertIn(partner.name, exc_message)
 
     def test_01_xml_link(self):
         """

--- a/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.py
+++ b/l10n_it_fatturapa_in/wizard/link_to_existing_invoice.py
@@ -138,7 +138,7 @@ class WizardLinkToInvoice(models.TransientModel):
 
     @api.model
     def default_get(self, fields_list):
-        res = super(WizardLinkToInvoice, self).default_get(fields_list)
+        res = super().default_get(fields_list)
         attachment = self._get_default_attachment()
         lines_vals = self._get_default_lines_vals(attachment)
         res.update(

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -2,6 +2,7 @@
 #  Copyright 2024 Simone Rubino - Aion Tech
 #  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import datetime
 import logging
 import re
 import warnings
@@ -29,7 +30,7 @@ WT_CODES_MAPPING = {
 }
 
 
-class PartnerDuplicatedException (UserError):
+class PartnerDuplicatedException(UserError):
     pass
 
 
@@ -202,17 +203,16 @@ class WizardImportFatturapa(models.TransientModel):
             )
 
     def _get_partner_domains_by_vat_fc(self, vat, fc):
-        """Return domains for searching partner using VAT and FC.
-        """
-        vat_domain = [('sanitized_vat', '=', vat)]
-        fc_domain = [('fiscalcode', '=', fc)]
+        """Return domains for searching partner using VAT and FC."""
+        vat_domain = [("vat", "=", vat)]
+        fc_domain = [("fiscalcode", "=", fc)]
         domains = list()
         if vat and fc:
             # The partner must match exactly (both VAT and FC)
             domains.append(expression.AND([vat_domain, fc_domain]))
             # Or it is missing either FC or VAT
-            no_vat_domain = [('sanitized_vat', '=', False)]
-            no_fc_domain = [('fiscalcode', '=', False)]
+            no_vat_domain = [("vat", "=", False)]
+            no_fc_domain = [("fiscalcode", "=", False)]
             vat_domain = expression.AND([vat_domain, no_fc_domain])
             fc_domain = expression.AND([no_vat_domain, fc_domain])
 
@@ -222,59 +222,76 @@ class WizardImportFatturapa(models.TransientModel):
             domains.append(fc_domain)
 
         # Inject the multi-company partners sharing rule, if enabled
-        res_partner_rule = self.env['ir.model.data'].sudo().xmlid_to_object(
-            "base.res_partner_rule", raise_if_not_found=False)
-        att = self.env.context.get('from_attachment')
+        res_partner_rule = (
+            self.env["ir.model.data"]
+            .sudo()
+            .xmlid_to_object("base.res_partner_rule", raise_if_not_found=False)
+        )
+        att = self.env.context.get("from_attachment")
         if att and res_partner_rule and res_partner_rule.active:
             partner_rule_domain = res_partner_rule.domain_force
             partner_rule_domain = partner_rule_domain.replace(
-                'user.company_id', 'company_id',
+                "user.company_id",
+                "company_id",
             )
             partner_rule_domain = safe_eval(
                 partner_rule_domain,
                 locals_dict={
-                    'company_id': att.company_id,
+                    "company_id": att.company_id,
                 },
             )
             for domain_index in range(len(domains)):
                 domain = domains[domain_index]
-                domains[domain_index] = expression.AND([
-                    domain, partner_rule_domain,
-                ])
+                domains[domain_index] = expression.AND(
+                    [
+                        domain,
+                        partner_rule_domain,
+                    ]
+                )
         return domains
 
     def _search_partner_by_vat_fc(self, vat, fc):
         """Search partner using VAT and FC."""
         domains = self._get_partner_domains_by_vat_fc(vat, fc)
-        partner_model = self.env['res.partner']
+        partner_model = self.env["res.partner"]
         for domain in domains:
             partners = partner_model.search(domain)
             if partners:
                 break
         else:
             partners = partner_model.browse()
+        company = self._get_company_from_attachment()
+        if partners and company:
+            # in case of multi company instance, can happen that a
+            # partner with same VAT and FC is present in one or more of
+            # other company, leading to a duplicated partner excpetion
+            partners = partners.filtered(
+                lambda partner: not partner.company_id or partner.company_id == company
+            )
         return partners
 
     def _get_commercial_partner(self, partners):
         """Get the common commercial partner from `partners`."""
         if len(partners) > 1:
             # Ensure that all found partners have the same commercial partner
-            commercial_partner = self.env['res.partner'].browse()
+            commercial_partner = self.env["res.partner"].browse()
             for partner in partners:
                 partner_commercial_partner = partner.commercial_partner_id
                 if (
-                    commercial_partner and
-                    partner_commercial_partner != commercial_partner
+                    commercial_partner
+                    and partner_commercial_partner != commercial_partner
                 ):
-                    same_vat_cf_partners = partner_commercial_partner \
-                        | commercial_partner
+                    same_vat_cf_partners = (
+                        partner_commercial_partner | commercial_partner
+                    )
                     raise PartnerDuplicatedException(
-                        _("Two distinct partners {partners} with "
-                          "VAT number {vat} or Fiscal Code {cf} already "
-                          "present in db.")
-                        .format(
-                            partners=', '.join(
-                                same_vat_cf_partners.mapped('display_name')
+                        _(
+                            "Two distinct partners {partners} with "
+                            "VAT number {vat} or Fiscal Code {cf} already "
+                            "present in db."
+                        ).format(
+                            partners=", ".join(
+                                same_vat_cf_partners.mapped("display_name")
                             ),
                             vat=partner.vat,
                             cf=partner.fiscalcode,
@@ -284,8 +301,21 @@ class WizardImportFatturapa(models.TransientModel):
         elif len(partners) == 1:
             commercial_partner = first(partners).commercial_partner_id
         else:
-            commercial_partner = self.env['res.partner'].browse()
+            commercial_partner = self.env["res.partner"]
         return commercial_partner
+
+    @api.model
+    def _get_company_from_attachment(self):
+        # Try to retrieve company from context key
+        company = self.env.context.get("att_company", self.env["res.company"])
+        if not company:
+            # If no company record passed in context, try to get from
+            # the attachment in context or if it is not present get as
+            # False
+            company = self.env.context.get(
+                "from_attachment", self.env["ir.attachment"]
+            ).company_id
+        return company
 
     def _extract_vat(self, DatiAnagrafici):
         """Extract VAT from node DatiAnagrafici."""
@@ -301,11 +331,11 @@ class WizardImportFatturapa(models.TransientModel):
             else:
                 vat = "%s%s" % (
                     DatiAnagrafici.IdFiscaleIVA.IdPaese.upper(),
-                    re.sub(r'\W+', '', DatiAnagrafici.IdFiscaleIVA.IdCodice).upper()
+                    re.sub(r"\W+", "", DatiAnagrafici.IdFiscaleIVA.IdCodice).upper(),
                 )
         return vat
 
-    def _prepare_partner_values(self, DatiAnagrafici, cf, vat, supplier):
+    def _prepare_partner_values(self, DatiAnagrafici, cf, vat):
         country_id = False
         if DatiAnagrafici.IdFiscaleIVA:
             CountryCode = DatiAnagrafici.IdFiscaleIVA.IdPaese
@@ -313,28 +343,25 @@ class WizardImportFatturapa(models.TransientModel):
             if countries:
                 country_id = countries[0].id
             else:
-                raise UserError(
-                    _("Country Code %s not found in system.") % CountryCode
-                )
+                raise UserError(_("Country Code %s not found in system.") % CountryCode)
         vals = {
-            'vat': vat,
-            'fiscalcode': cf,
-            'customer': False,
-            'supplier': supplier,
-            'is_company': (
-                DatiAnagrafici.Anagrafica.Denominazione and True or False),
-            'eori_code': DatiAnagrafici.Anagrafica.CodEORI or '',
-            'country_id': country_id,
+            "vat": vat,
+            "fiscalcode": cf,
+            "is_company": (DatiAnagrafici.Anagrafica.Denominazione and True or False),
+            "eori_code": DatiAnagrafici.Anagrafica.CodEORI or "",
+            "country_id": country_id,
         }
         if DatiAnagrafici.Anagrafica.Nome:
-            vals['firstname'] = DatiAnagrafici.Anagrafica.Nome
+            vals["firstname"] = DatiAnagrafici.Anagrafica.Nome
         if DatiAnagrafici.Anagrafica.Cognome:
-            vals['lastname'] = DatiAnagrafici.Anagrafica.Cognome
+            vals["lastname"] = DatiAnagrafici.Anagrafica.Cognome
         if DatiAnagrafici.Anagrafica.Denominazione:
-            vals['name'] = DatiAnagrafici.Anagrafica.Denominazione
+            vals["name"] = DatiAnagrafici.Anagrafica.Denominazione
+        company = self._get_company_from_attachment()
+        vals["company_id"] = company.id
         return vals
 
-    def getPartnerBase(self, DatiAnagrafici, supplier=True, raise_if_duplicated=True):
+    def getPartnerBase(self, DatiAnagrafici, raise_if_duplicated=True):
         if not DatiAnagrafici:
             return False
         cf = DatiAnagrafici.CodiceFiscale or False
@@ -347,7 +374,7 @@ class WizardImportFatturapa(models.TransientModel):
                 raise duplicated_exception
             else:
                 self.log_inconsistency(duplicated_exception.args[0])
-                found_partner = self.env['res.partner'].browse()
+                found_partner = self.env["res.partner"].browse()
         else:
             if commercial_partner:
                 commercial_partner_id = commercial_partner.id
@@ -355,8 +382,8 @@ class WizardImportFatturapa(models.TransientModel):
                 found_partner = commercial_partner
             else:
                 # partner to be created
-                vals = self._prepare_partner_values(DatiAnagrafici, cf, vat, supplier)
-                found_partner = self.env['res.partner'].create(vals)
+                vals = self._prepare_partner_values(DatiAnagrafici, cf, vat)
+                found_partner = self.env["res.partner"].create(vals)
         return found_partner.id
 
     def get_partner_from_einvoice_node(self, partner_node):
@@ -492,7 +519,7 @@ class WizardImportFatturapa(models.TransientModel):
         self.get_partner_from_einvoice_node(cedPrest)
 
     def getCarrirerPartner(self, Carrier):
-        partner_model = self.env['res.partner']
+        partner_model = self.env["res.partner"]
         partner_id = self.getPartnerBase(
             Carrier.DatiAnagraficiVettore,
             raise_if_duplicated=False,
@@ -1211,9 +1238,11 @@ class WizardImportFatturapa(models.TransientModel):
 
         invoice_data = {
             "e_invoice_received_date": e_invoice_received_date,
-            "date": e_invoice_received_date
-            if company.in_invoice_registration_date == "rec_date"
-            else e_invoice_date,
+            "date": (
+                e_invoice_received_date
+                if company.in_invoice_registration_date == "rec_date"
+                else e_invoice_date
+            ),
             "fiscal_document_type_id": fiscal_document_type.id,
             "sender": fatt.FatturaElettronicaHeader.SoggettoEmittente or False,
             "move_type": invoice_type,
@@ -1577,9 +1606,9 @@ class WizardImportFatturapa(models.TransientModel):
         if not partner.property_supplier_payment_term_id:
             due_dates = self._get_last_due_date(FatturaBody.DatiPagamento)
             if due_dates:
-                self.env["account.move"].browse(
-                    invoice_id
-                ).invoice_date_due = due_dates[0]
+                self.env["account.move"].browse(invoice_id).invoice_date_due = (
+                    due_dates[0]
+                )
         if PaymentsData:
             PaymentDataModel = self.env["fatturapa.payment.data"]
             PaymentTermsModel = self.env["fatturapa.payment_term"]
@@ -1948,11 +1977,7 @@ class WizardImportFatturapa(models.TransientModel):
                         supplier=False,
                         raise_if_duplicated=False,
                     )
-                    invoice.write(
-                        {
-                            'tax_representative_id': tax_partner_id
-                        }
-                    )
+                    invoice.write({"tax_representative_id": tax_partner_id})
                     invoice.write({"tax_representative_id": tax_partner_id})
                 if Intermediary:
                     Intermediary_id = self.getPartnerBase(
@@ -1960,11 +1985,7 @@ class WizardImportFatturapa(models.TransientModel):
                         supplier=False,
                         raise_if_duplicated=False,
                     )
-                    invoice.write(
-                        {
-                            'intermediary': Intermediary_id
-                        }
-                    )
+                    invoice.write({"intermediary": Intermediary_id})
                 new_invoices.append(invoice_id)
                 self.check_invoice_amount(invoice, fattura)
 

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -264,7 +264,7 @@ class WizardImportFatturapa(models.TransientModel):
         if partners and company:
             # in case of multi company instance, can happen that a
             # partner with same VAT and FC is present in one or more of
-            # other company, leading to a duplicated partner excpetion
+            # other company, leading to a duplicated partner exception
             partners = partners.filtered(
                 lambda partner: not partner.company_id or partner.company_id == company
             )

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -12,6 +12,7 @@ from odoo.exceptions import UserError
 from odoo.fields import first
 from odoo.osv import expression
 from odoo.tools import float_is_zero, frozendict
+from odoo.tools.safe_eval import safe_eval
 from odoo.tools.translate import _
 
 from odoo.addons.base_iban.models.res_partner_bank import pretty_iban
@@ -196,12 +197,88 @@ class WizardImportFatturapa(models.TransientModel):
                 % (DatiAnagrafici.Anagrafica.Cognome, partner.lastname)
             )
 
-    def getPartnerBase(self, DatiAnagrafici):  # noqa: C901
+    def _get_partner_domains_by_vat_fc(self, vat, fc):
+        """Return domains for searching partner using VAT and FC.
+        """
+        vat_domain = [('sanitized_vat', '=', vat)]
+        fc_domain = [('fiscalcode', '=', fc)]
+        domains = list()
+        if vat:
+            domains.append(vat_domain)
+        if fc:
+            domains.append(fc_domain)
+
+        # Inject the multi-company partners sharing rule, if enabled
+        res_partner_rule = self.env['ir.model.data'].sudo().xmlid_to_object(
+            "base.res_partner_rule", raise_if_not_found=False)
+        att = self.env.context.get('from_attachment')
+        if att and res_partner_rule and res_partner_rule.active:
+            partner_rule_domain = res_partner_rule.domain_force
+            partner_rule_domain = partner_rule_domain.replace(
+                'user.company_id', 'company_id',
+            )
+            partner_rule_domain = safe_eval(
+                partner_rule_domain,
+                locals_dict={
+                    'company_id': att.company_id,
+                },
+            )
+            for domain_index in range(len(domains)):
+                domain = domains[domain_index]
+                domains[domain_index] = expression.AND([
+                    domain, partner_rule_domain,
+                ])
+        return domains
+
+    def _search_partner_by_vat_fc(self, vat, fc):
+        """Search partner using VAT and FC."""
+        domains = self._get_partner_domains_by_vat_fc(vat, fc)
+        partner_model = self.env['res.partner']
+        for domain in domains:
+            partners = partner_model.search(domain)
+            if partners:
+                break
+        else:
+            partners = partner_model.browse()
+        return partners
+
+    def _get_commercial_partner(self, partners):
+        """Get the common commercial partner from `partners`."""
+        if len(partners) > 1:
+            # Ensure that all found partners have the same commercial partner
+            commercial_partner = self.env['res.partner'].browse()
+            for partner in partners:
+                partner_commercial_partner = partner.commercial_partner_id
+                if (
+                    commercial_partner and
+                    partner_commercial_partner != commercial_partner
+                ):
+                    same_vat_cf_partners = partner_commercial_partner \
+                        | commercial_partner
+                    raise UserError(
+                        _("Two distinct partners {partners} with "
+                          "VAT number {vat} or Fiscal Code {cf} already "
+                          "present in db.")
+                        .format(
+                            partners=', '.join(
+                                same_vat_cf_partners.mapped('display_name')
+                            ),
+                            vat=partner.vat,
+                            cf=partner.fiscalcode,
+                        )
+                    )
+                commercial_partner = partner_commercial_partner
+        elif len(partners) == 1:
+            commercial_partner = first(partners).commercial_partner_id
+        else:
+            commercial_partner = self.env['res.partner'].browse()
+        return commercial_partner
+
+    def getPartnerBase(self, DatiAnagrafici, supplier=True):
         if not DatiAnagrafici:
             return False
         partner_model = self.env["res.partner"]
         cf = DatiAnagrafici.CodiceFiscale or False
-        vat = False
         if DatiAnagrafici.IdFiscaleIVA:
             id_paese = DatiAnagrafici.IdFiscaleIVA.IdPaese.upper()
             id_codice = re.sub(r"\W+", "", DatiAnagrafici.IdFiscaleIVA.IdCodice).upper()
@@ -211,64 +288,14 @@ class WizardImportFatturapa(models.TransientModel):
                 vat = "IT{}".format(id_codice.rjust(11, "0")[:11])
             # XXX maybe San Marino needs special formatting too?
             else:
-                vat = id_codice
-        partners = partner_model
-        res_partner_rule = (
-            self.env["ir.model.data"]
-            .sudo()
-            .xmlid_to_object("base.res_partner_rule", raise_if_not_found=False)
-        )
-        if vat:
-            domain = [("vat", "=", vat)]
-            if (
-                self.env.context.get("from_attachment")
-                and res_partner_rule
-                and res_partner_rule.active
-            ):
-                att = self.env.context.get("from_attachment")
-                domain.extend(
-                    [
-                        "|",
-                        ("company_id", "child_of", att.company_id.id),
-                        ("company_id", "=", False),
-                    ]
+                vat = "%s%s" % (
+                    DatiAnagrafici.IdFiscaleIVA.IdPaese.upper(),
+                    re.sub(r'\W+', '', DatiAnagrafici.IdFiscaleIVA.IdCodice).upper()
                 )
-            partners = partner_model.search(domain)
-        if not partners and cf:
-            domain = [("fiscalcode", "=", cf)]
-            if (
-                self.env.context.get("from_attachment")
-                and res_partner_rule
-                and res_partner_rule.active
-            ):
-                att = self.env.context.get("from_attachment")
-                domain.extend(
-                    [
-                        "|",
-                        ("company_id", "child_of", att.company_id.id),
-                        ("company_id", "=", False),
-                    ]
-                )
-            partners = partner_model.search(domain)
-        commercial_partner_id = False
-        if len(partners) > 1:
-            for partner in partners:
-                if (
-                    commercial_partner_id
-                    and partner.commercial_partner_id.id != commercial_partner_id
-                ):
-                    self.log_inconsistency(
-                        _(
-                            "Two distinct partners with "
-                            "VAT number %s or Fiscal Code %s already "
-                            "present in db." % (vat, cf)
-                        )
-                    )
-                    return False
-                commercial_partner_id = partner.commercial_partner_id.id
-        if partners:
-            if not commercial_partner_id:
-                commercial_partner_id = partners[0].commercial_partner_id.id
+        partners = self._search_partner_by_vat_fc(vat, cf)
+        commercial_partner = self._get_commercial_partner(partners)
+        if commercial_partner:
+            commercial_partner_id = commercial_partner.id
             self.check_partner_base_data(commercial_partner_id, DatiAnagrafici)
             return commercial_partner_id
         else:

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1987,7 +1987,7 @@ class WizardImportFatturapa(models.TransientModel):
                         raise_if_duplicated=False,
                     )
                     invoice.write({"intermediary": Intermediary_id})
-                new_invoices.append(invoice_id)
+                new_invoices.append(invoice.id)
                 self.check_invoice_amount(invoice, fattura)
 
                 invoice.set_einvoice_data(fattura)

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -29,6 +29,10 @@ WT_CODES_MAPPING = {
 }
 
 
+class PartnerDuplicatedException (UserError):
+    pass
+
+
 class WizardImportFatturapa(models.TransientModel):
     _name = "wizard.import.fatturapa"
     _description = "Import E-bill"
@@ -264,7 +268,7 @@ class WizardImportFatturapa(models.TransientModel):
                 ):
                     same_vat_cf_partners = partner_commercial_partner \
                         | commercial_partner
-                    raise UserError(
+                    raise PartnerDuplicatedException(
                         _("Two distinct partners {partners} with "
                           "VAT number {vat} or Fiscal Code {cf} already "
                           "present in db.")
@@ -283,11 +287,9 @@ class WizardImportFatturapa(models.TransientModel):
             commercial_partner = self.env['res.partner'].browse()
         return commercial_partner
 
-    def getPartnerBase(self, DatiAnagrafici, supplier=True):
-        if not DatiAnagrafici:
-            return False
-        partner_model = self.env["res.partner"]
-        cf = DatiAnagrafici.CodiceFiscale or False
+    def _extract_vat(self, DatiAnagrafici):
+        """Extract VAT from node DatiAnagrafici."""
+        vat = False
         if DatiAnagrafici.IdFiscaleIVA:
             id_paese = DatiAnagrafici.IdFiscaleIVA.IdPaese.upper()
             id_codice = re.sub(r"\W+", "", DatiAnagrafici.IdFiscaleIVA.IdCodice).upper()
@@ -301,42 +303,61 @@ class WizardImportFatturapa(models.TransientModel):
                     DatiAnagrafici.IdFiscaleIVA.IdPaese.upper(),
                     re.sub(r'\W+', '', DatiAnagrafici.IdFiscaleIVA.IdCodice).upper()
                 )
-        partners = self._search_partner_by_vat_fc(vat, cf)
-        commercial_partner = self._get_commercial_partner(partners)
-        if commercial_partner:
-            commercial_partner_id = commercial_partner.id
-            self.check_partner_base_data(commercial_partner_id, DatiAnagrafici)
-            return commercial_partner_id
-        else:
-            # partner to be created
-            country_id = False
-            if DatiAnagrafici.IdFiscaleIVA:
-                CountryCode = DatiAnagrafici.IdFiscaleIVA.IdPaese
-                countries = self.CountryByCode(CountryCode)
-                if countries:
-                    country_id = countries[0].id
-                else:
-                    raise UserError(
-                        _("Country Code %s not found in system.") % CountryCode
-                    )
-            vals = {
-                "vat": vat,
-                "fiscalcode": cf,
-                "is_company": (
-                    DatiAnagrafici.Anagrafica.Denominazione and True or False
-                ),
-                "eori_code": DatiAnagrafici.Anagrafica.CodEORI or "",
-                "country_id": country_id,
-                "company_id": self.env.company.id,
-            }
-            if DatiAnagrafici.Anagrafica.Nome:
-                vals["firstname"] = DatiAnagrafici.Anagrafica.Nome
-            if DatiAnagrafici.Anagrafica.Cognome:
-                vals["lastname"] = DatiAnagrafici.Anagrafica.Cognome
-            if DatiAnagrafici.Anagrafica.Denominazione:
-                vals["name"] = DatiAnagrafici.Anagrafica.Denominazione
+        return vat
 
-            return partner_model.create(vals).id
+    def _prepare_partner_values(self, DatiAnagrafici, cf, vat, supplier):
+        country_id = False
+        if DatiAnagrafici.IdFiscaleIVA:
+            CountryCode = DatiAnagrafici.IdFiscaleIVA.IdPaese
+            countries = self.CountryByCode(CountryCode)
+            if countries:
+                country_id = countries[0].id
+            else:
+                raise UserError(
+                    _("Country Code %s not found in system.") % CountryCode
+                )
+        vals = {
+            'vat': vat,
+            'fiscalcode': cf,
+            'customer': False,
+            'supplier': supplier,
+            'is_company': (
+                DatiAnagrafici.Anagrafica.Denominazione and True or False),
+            'eori_code': DatiAnagrafici.Anagrafica.CodEORI or '',
+            'country_id': country_id,
+        }
+        if DatiAnagrafici.Anagrafica.Nome:
+            vals['firstname'] = DatiAnagrafici.Anagrafica.Nome
+        if DatiAnagrafici.Anagrafica.Cognome:
+            vals['lastname'] = DatiAnagrafici.Anagrafica.Cognome
+        if DatiAnagrafici.Anagrafica.Denominazione:
+            vals['name'] = DatiAnagrafici.Anagrafica.Denominazione
+        return vals
+
+    def getPartnerBase(self, DatiAnagrafici, supplier=True, raise_if_duplicated=True):
+        if not DatiAnagrafici:
+            return False
+        cf = DatiAnagrafici.CodiceFiscale or False
+        vat = self._extract_vat(DatiAnagrafici)
+        try:
+            partners = self._search_partner_by_vat_fc(vat, cf)
+            commercial_partner = self._get_commercial_partner(partners)
+        except PartnerDuplicatedException as duplicated_exception:
+            if raise_if_duplicated:
+                raise duplicated_exception
+            else:
+                self.log_inconsistency(duplicated_exception.args[0])
+                found_partner = self.env['res.partner'].browse()
+        else:
+            if commercial_partner:
+                commercial_partner_id = commercial_partner.id
+                self.check_partner_base_data(commercial_partner_id, DatiAnagrafici)
+                found_partner = commercial_partner
+            else:
+                # partner to be created
+                vals = self._prepare_partner_values(DatiAnagrafici, cf, vat, supplier)
+                found_partner = self.env['res.partner'].create(vals)
+        return found_partner.id
 
     def get_partner_from_einvoice_node(self, partner_node):
         """
@@ -471,8 +492,11 @@ class WizardImportFatturapa(models.TransientModel):
         self.get_partner_from_einvoice_node(cedPrest)
 
     def getCarrirerPartner(self, Carrier):
-        partner_model = self.env["res.partner"]
-        partner_id = self.getPartnerBase(Carrier.DatiAnagraficiVettore)
+        partner_model = self.env['res.partner']
+        partner_id = self.getPartnerBase(
+            Carrier.DatiAnagraficiVettore,
+            raise_if_duplicated=False,
+        )
         no_contact_update = False
         if partner_id:
             no_contact_update = partner_model.browse(
@@ -1920,13 +1944,28 @@ class WizardImportFatturapa(models.TransientModel):
                 self.set_StabileOrganizzazione(cedentePrestatore, invoice)
                 if TaxRappresentative:
                     tax_partner_id = self.getPartnerBase(
-                        TaxRappresentative.DatiAnagrafici
+                        TaxRappresentative.DatiAnagrafici,
+                        supplier=False,
+                        raise_if_duplicated=False,
+                    )
+                    invoice.write(
+                        {
+                            'tax_representative_id': tax_partner_id
+                        }
                     )
                     invoice.write({"tax_representative_id": tax_partner_id})
                 if Intermediary:
-                    Intermediary_id = self.getPartnerBase(Intermediary.DatiAnagrafici)
-                    invoice.write({"intermediary": Intermediary_id})
-                new_invoices.append(invoice.id)
+                    Intermediary_id = self.getPartnerBase(
+                        Intermediary.DatiAnagrafici,
+                        supplier=False,
+                        raise_if_duplicated=False,
+                    )
+                    invoice.write(
+                        {
+                            'intermediary': Intermediary_id
+                        }
+                    )
+                new_invoices.append(invoice_id)
                 self.check_invoice_amount(invoice, fattura)
 
                 invoice.set_einvoice_data(fattura)

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -347,6 +347,8 @@ class WizardImportFatturapa(models.TransientModel):
         vals = {
             "vat": vat,
             "fiscalcode": cf,
+            "customer_rank": 0,
+            "supplier_rank": supplier,
             "is_company": (DatiAnagrafici.Anagrafica.Denominazione and True or False),
             "eori_code": DatiAnagrafici.Anagrafica.CodEORI or "",
             "country_id": country_id,

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -203,6 +203,15 @@ class WizardImportFatturapa(models.TransientModel):
         vat_domain = [('sanitized_vat', '=', vat)]
         fc_domain = [('fiscalcode', '=', fc)]
         domains = list()
+        if vat and fc:
+            # The partner must match exactly (both VAT and FC)
+            domains.append(expression.AND([vat_domain, fc_domain]))
+            # Or it is missing either FC or VAT
+            no_vat_domain = [('sanitized_vat', '=', False)]
+            no_fc_domain = [('fiscalcode', '=', False)]
+            vat_domain = expression.AND([vat_domain, no_fc_domain])
+            fc_domain = expression.AND([no_vat_domain, fc_domain])
+
         if vat:
             domains.append(vat_domain)
         if fc:

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1980,7 +1980,6 @@ class WizardImportFatturapa(models.TransientModel):
                         raise_if_duplicated=False,
                     )
                     invoice.write({"tax_representative_id": tax_partner_id})
-                    invoice.write({"tax_representative_id": tax_partner_id})
                 if Intermediary:
                     Intermediary_id = self.getPartnerBase(
                         Intermediary.DatiAnagrafici,

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -335,7 +335,7 @@ class WizardImportFatturapa(models.TransientModel):
                 )
         return vat
 
-    def _prepare_partner_values(self, DatiAnagrafici, cf, vat):
+    def _prepare_partner_values(self, DatiAnagrafici, cf, vat, supplier):
         country_id = False
         if DatiAnagrafici.IdFiscaleIVA:
             CountryCode = DatiAnagrafici.IdFiscaleIVA.IdPaese
@@ -361,7 +361,7 @@ class WizardImportFatturapa(models.TransientModel):
         vals["company_id"] = company.id
         return vals
 
-    def getPartnerBase(self, DatiAnagrafici, raise_if_duplicated=True):
+    def getPartnerBase(self, DatiAnagrafici, supplier=True, raise_if_duplicated=True):
         if not DatiAnagrafici:
             return False
         cf = DatiAnagrafici.CodiceFiscale or False

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -384,7 +384,7 @@ class WizardImportFatturapa(models.TransientModel):
                 found_partner = commercial_partner
             else:
                 # partner to be created
-                vals = self._prepare_partner_values(DatiAnagrafici, cf, vat)
+                vals = self._prepare_partner_values(DatiAnagrafici, cf, vat, supplier)
                 found_partner = self.env["res.partner"].create(vals)
         return found_partner.id
 

--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -238,6 +238,7 @@ class WizardImportFatturapa(models.TransientModel):
                 partner_rule_domain,
                 locals_dict={
                     "company_id": att.company_id,
+                    "company_ids": att.company_id.ids,
                 },
             )
             for domain_index in range(len(domains)):


### PR DESCRIPTION
Superseed #3513 

This PR porting the commit of #3100 for v. 12.0 to v. 14.0 and add a check by company for partner.

In multicompany instance, can happen a partner with same VAT and/or FC is present in more than one company, blocking invoice import because there is more than on partner; here add a check to get only partner of the same in attachment or no company set in partner