### PR TITLE
[FIX] l10n_it_edi_extension: omit explicit ID in einvoice_line migration

### DIFF
--- a/l10n_it_edi_extension/__init__.py
+++ b/l10n_it_edi_extension/__init__.py
@@ -714,12 +714,12 @@ def _l10n_it_fatturapa_in_post_migration(env):
                 """
                 INSERT INTO
                     l10n_it_edi_line (
-                        id, invoice_id, line_number, service_type, name, qty, uom,
+                        invoice_id, line_number, service_type, name, qty, uom,
                         period_start_date, period_end_date, unit_price,
                         total_price, tax_amount, wt_amount, tax_kind
                     )
                 SELECT
-                    id, invoice_id, line_number, service_type, name, qty, uom,
+                    invoice_id, line_number, service_type, name, qty, uom,
                     period_start_date, period_end_date, unit_price,
                     total_price, tax_amount, wt_amount, tax_kind
                 FROM


### PR DESCRIPTION
Explicitly passing the `id` column during the data migration from
`einvoice_line` to '`10n_it_edi_line` prevents the underlying PostgreSQL
sequence from advancing. As a result, the sequence lags behind the maximum
inserted ID, causing Odoo to crash with a "Duplicate key value violates
unique constraint" error on subsequent native record creations.

Fix this by omitting the `id` column from the INSERT and SELECT statements.
This allows PostgreSQL to handle ID generation natively via `nextval()`,
keeping the sequence and data naturally synchronized and avoiding the crash.