### PR TITLE
[FIX] l10n_it_edi_extension: reset PostgreSQL sequence after migration from einvoice_line

### DIFF
--- a/l10n_it_edi_extension/__init__.py
+++ b/l10n_it_edi_extension/__init__.py
@@ -714,12 +714,12 @@ def _l10n_it_fatturapa_in_post_migration(env):
                 """
                 INSERT INTO
                     l10n_it_edi_line (
-                        id, invoice_id, line_number, service_type, name, qty, uom,
+                        invoice_id, line_number, service_type, name, qty, uom,
                         period_start_date, period_end_date, unit_price,
                         total_price, tax_amount, wt_amount, tax_kind
                     )
                 SELECT
-                    id, invoice_id, line_number, service_type, name, qty, uom,
+                    invoice_id, line_number, service_type, name, qty, uom,
                     period_start_date, period_end_date, unit_price,
                     total_price, tax_amount, wt_amount, tax_kind
                 FROM

--- a/l10n_it_edi_extension/migrations/18.0.1.9.1/post-migration.py
+++ b/l10n_it_edi_extension/migrations/18.0.1.9.1/post-migration.py
@@ -1,0 +1,18 @@
+#  Copyright 2026 Nextev Srl
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Reset the sequence after data migrated from einvoice_line with explicit IDs
+    openupgrade.logged_query(
+        env.cr,
+        """
+        SELECT setval(
+            'l10n_it_edi_line_id_seq',
+            (SELECT MAX(id) FROM l10n_it_edi_line)
+        )
+        """,
+    )


### PR DESCRIPTION
### Bug
Durante la migrazione da `l10n_it_fatturapa_in `(v16) a `l10n_it_edi_extension` (v18), i record di `einvoice_line` vengono inseriti in `l10n_it_edi_line` con i loro `id` originali espliciti. La sequenza PostgreSQL `l10n_it_edi_line_id_seq` non veniva però aggiornata per riflettere l'ID massimo migrato.

Di conseguenza, il primo tentativo di creare un nuovo record l10n_it_edi.line dopo la migrazione fallisce con:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "l10n_it_edi_line_pkey"
DETAIL:  Key (id)=(1) already exists.
```

Questo blocca completamente l'importazione delle fatture elettroniche sui database migrati dalla v16.

### Fix

- Dopo la `INSERT INTO l10n_it_edi_line ... SELECT ... FROM einvoice_line`, viene eseguita `setval('l10n_it_edi_line_id_seq', MAX(id))` per allineare la sequenza ai dati migrati. 

- `migrations/18.0.1.8.1/post-migration.py`: applica lo stesso `setval` come step post-migrazione one-shot per i database che hanno già eseguito la migrazione incompleta.