### PR TITLE
[18.0][FIX] l10n_it_riba_oca: fix multi-company RiBa collection fees setting

### DIFF
--- a/l10n_it_riba_oca/models/account_config.py
+++ b/l10n_it_riba_oca/models/account_config.py
@@ -25,7 +25,7 @@ class ResConfigSettings(models.TransientModel):
     def default_get(self, fields_list):
         res = super().default_get(fields_list)
         if res:
-            res["due_cost_service_id"] = self.env.user.company_id.due_cost_service_id.id
+            res["due_cost_service_id"] = self.env.company.due_cost_service_id.id
         return res
 
 


### PR DESCRIPTION
## Description

Fixes #5211

The `default_get` override in `ResConfigSettings` reads `due_cost_service_id` from `self.env.user.company_id` (the user's main company), ignoring the company currently selected in the settings form. In multi-company environments, when the active company differs from the user's main company, the RiBa collection fees service shown/defaulted in the settings is the wrong one.

## Changes

- In `models/account_config.py`, `default_get` now reads from `self.env.company` instead of `self.env.user.company_id`, so the default is taken from the **active** company, consistent with the `company_id` field default of `res.config.settings`.

The `related="company_id.due_cost_service_id"` field with `readonly=False` already reads from and writes to the correct company; this change aligns the `default_get` default with the same active company.

## Checklist

- [x] User-visible strings are translated
- [x] Tests pass (no test changes needed — existing single-company behavior is preserved)
- [x] Migration script: not needed (no data migration required)
