### PR TITLE
[16.0] [IMP] l10n_it_account_stamp: avoid use distinct write to create account move line(s) for account stamp

### DIFF
--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -3,6 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Command
 
 
 class AccountMove(models.Model):
@@ -176,17 +177,18 @@ class AccountMove(models.Model):
                 if inv.state == "posted":
                     posted = True
                     inv.state = "draft"
-                line_model = self.env["account.move.line"]
                 stamp_product_id = inv.company_id.with_context(
                     lang=inv.partner_id.lang
                 ).tax_stamp_product_id
                 if not stamp_product_id:
                     raise UserError(_("Missing tax stamp product in company settings!"))
                 income_vals, expense_vals = inv._build_tax_stamp_lines(stamp_product_id)
-                income_vals["move_id"] = inv.id
-                expense_vals["move_id"] = inv.id
-                line_model.with_context(check_move_validity=False).create(income_vals)
-                line_model.with_context(check_move_validity=False).create(expense_vals)
+
+                inv.line_ids = [
+                    Command.create(income_vals),
+                    Command.create(expense_vals),
+                ]
+
                 if posted:
                     inv.state = "posted"
         return res


### PR DESCRIPTION
Sometimes can happen when reset to draft an invoice or confirm it, that operation raise an exception for unbalanced move. Due to creation of account stamp move line(s) is executed in two different step even if context key `check_move_validity` is present with value `False`.

This PR, execute the create command in a single step, avoid calling multiple times methods to recompute dynamic lines