### PR TITLE
[16.0] [IMP] l10n_it_withholding_tax: pass default name to account move for withholding tax

### DIFF
--- a/l10n_it_withholding_tax/models/withholding_tax.py
+++ b/l10n_it_withholding_tax/models/withholding_tax.py
@@ -370,7 +370,12 @@ class WithholdingTaxMove(models.Model):
                 % (self.wt_account_move_id.name)
             )
         # Move - head
+        # Add name key in move vals, avoid to short circuit sequence date
+        # computation in
+        # https://github.com/odoo/odoo/blob/16.0/addons/account/models/sequence_mixin.py#l76
+        # that short circuit lead to duplicate account move exception
         move_vals = {
+            "name": "/",
             "ref": _(
                 "WT %(code)s - %(move)s",
                 code=self.withholding_tax_id.code,


### PR DESCRIPTION
Sometime can happen that not passing name value in Withholding Tax payment account move, lead to a duplicate sequence error. 
This because, the account.move name field is used here: https://github.com/odoo/odoo/blob/16.0/addons/account/models/sequence_mixin.py#L76
and during the confirmation of Withholding tax payment account.move, the sequence is set to restart from 0 and this sequence restart raising a duplicate account move name