### PR TITLE
[18.0] [IMP] l10n_it_account_stamp: use single write to create account stamp move lines

### DIFF
--- a/l10n_it_account_stamp/models/account_move.py
+++ b/l10n_it_account_stamp/models/account_move.py
@@ -3,6 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Command
 
 
 class AccountMove(models.Model):
@@ -207,7 +208,6 @@ class AccountMove(models.Model):
                 if inv.state == "posted":
                     posted = True
                     inv.state = "draft"
-                line_model = self.env["account.move.line"]
                 stamp_product_id = inv.company_id.with_context(
                     lang=inv.partner_id.lang
                 ).l10n_it_account_stamp_stamp_duty_product_id
@@ -218,10 +218,12 @@ class AccountMove(models.Model):
                 income_vals, expense_vals = inv._build_stamp_duty_lines(
                     stamp_product_id
                 )
-                income_vals["move_id"] = inv.id
-                expense_vals["move_id"] = inv.id
-                line_model.with_context(check_move_validity=False).create(income_vals)
-                line_model.with_context(check_move_validity=False).create(expense_vals)
+
+                inv.line_ids = [
+                    Command.create(income_vals),
+                    Command.create(expense_vals),
+                ]
+
                 if posted:
                     inv.state = "posted"
         return res


### PR DESCRIPTION
Porting to v. 18.0 of #5219 

Use a single write to create account stamp move lines to avoid unbalanced move exception