### PR TITLE
[16.0][IMP] l10n_it_riba_oca: more Ri.Ba. expense policies

### DIFF
--- a/l10n_it_riba_oca/README.rst
+++ b/l10n_it_riba_oca/README.rst
@@ -53,10 +53,10 @@ https://github.com/odoo/enterprise/commit/03c2e68ad88e3430e7fe604804d2bcc6332dc9
 
 I moduli esistenti che dipendevano da ``l10n_it_riba`` dovranno quindi:
 
-- adattare il nome della dipendenza da ``l10n_it_riba`` a
-  ``l10n_it_riba_oca``
-- adattare eventuali riferimenti esterni (XMLID) da
-  ``l10n_it_riba.[...]`` a ``l10n_it_riba_oca.[...]``
+-  adattare il nome della dipendenza da ``l10n_it_riba`` a
+   ``l10n_it_riba_oca``
+-  adattare eventuali riferimenti esterni (XMLID) da
+   ``l10n_it_riba.[...]`` a ``l10n_it_riba_oca.[...]``
 
 Configuration
 =============
@@ -67,12 +67,12 @@ Nella configurazione delle RiBa è possibile specificare se si tratti di
 'Salvo buon fine' o 'Al dopo incasso', che hanno un flusso completamente
 diverso.
 
-- Al dopo incasso: le fatture risulteranno pagate all'accettazione;
-  l'incasso potrà essere registrato con una normale riconciliazione
-  bancaria, che andrà a chiudere gli "effetti attivi" aperti
-  all'accettazione.
-- Salvo buon fine: le registrazioni generate seguiranno la struttura
-  descritta nel documento http://goo.gl/jpRhJp
+-  Al dopo incasso: le fatture risulteranno pagate all'accettazione;
+   l'incasso potrà essere registrato con una normale riconciliazione
+   bancaria, che andrà a chiudere gli "effetti attivi" aperti
+   all'accettazione.
+-  Salvo buon fine: le registrazioni generate seguiranno la struttura
+   descritta nel documento http://goo.gl/jpRhJp
 
 È possibile specificare diverse configurazioni (dal menù *Configurazione
 → Pagamenti → Configurazione RiBa*). Per ognuna, in caso di 'Salvo buon
@@ -99,6 +99,61 @@ Nel caso si vogliano gestire anche le spese per ogni scadenza con
 ricevuta bancaria, si deve configurare un prodotto di tipo servizio e
 collegarlo in *Configurazione → Impostazioni → Contabilità → Imposte →
 Spese di incasso RiBa*.
+
+**Spese di incasso per cliente**
+
+Sulla scheda del cliente (*Contatti*), nella sezione **RiBa**, sono
+disponibili due campi che governano l'addebito delle spese di incasso al
+momento della conferma della fattura:
+
+-  **Escludi spese Ri.Ba.** (``riba_exclude_expenses``): se attivo, al
+   cliente non viene mai addebitata alcuna spesa di incasso, qualunque
+   sia la politica impostata.
+-  **Politica spese Ri.Ba.** (``riba_policy_expenses``): determina
+   quante righe spesa vengono aggiunte alla fattura. Le opzioni
+   disponibili sono:
+
++----------------------+----------------------+----------------------+
+| Politica (etichetta  | Quante spese per     | Comportamento tra    |
+| / chiave)            | fattura              | fatture diverse      |
++======================+======================+======================+
+| One expense per      | una per ogni         | nessuna              |
+| maturity —           | scadenza             | deduplicazione:      |
+| ``unlimited``        |                      | tutte le scadenze di |
+|                      |                      | tutte le fatture     |
+|                      |                      | vengono sempre       |
+|                      |                      | addebitate           |
++----------------------+----------------------+----------------------+
+| One expense per      | una sola, a          | nessuna              |
+| invoice —            | prescindere dal      | deduplicazione: ogni |
+| ``one_per_invoice``  | numero di scadenze   | fattura riceve la    |
+|                      |                      | propria spesa        |
++----------------------+----------------------+----------------------+
+| One expense per      | una per ciascun mese | salta la spesa se    |
+| maturity month —     | in cui cade una      | quel mese è già      |
+| ``one_a_month``      | scadenza             | coperto da una       |
+| (default)            |                      | scadenza di un'altra |
+|                      |                      | fattura del cliente  |
++----------------------+----------------------+----------------------+
+| One expense per      | una sola, a          | salta la spesa se    |
+| invoice month —      | prescindere dal      | nello stesso mese    |
+| ``one_a_matu         | numero di scadenze   | della data fattura   |
+| rity_invoice_month`` |                      | esiste già un'altra  |
+|                      |                      | fattura del cliente  |
+|                      |                      | con spesa            |
++----------------------+----------------------+----------------------+
+| One expense per      | una per ogni mese di | salta la spesa se    |
+| maturity month,      | scadenza             | nello stesso mese    |
+| dedup within invoice |                      | della data fattura   |
+| month —              |                      | esiste già un'altra  |
+| ``maturity           |                      | fattura con una      |
+| _per_invoice_month`` |                      | scadenza nello       |
+|                      |                      | **stesso mese**      |
++----------------------+----------------------+----------------------+
+
+La deduplicazione considera solo le fatture del cliente **già
+confermate** che riportano una riga spesa: l'ordine di conferma delle
+fatture quindi è rilevante.
 
 Usage
 =====
@@ -133,12 +188,13 @@ In maniera predefinita la data delle registrazioni dei pagamenti viene
 impostata con la data di scadenza della RiBa, ma è possibile modificarla
 in due momenti:
 
-- durante la creazione del pagamento, cliccando su "Segna righe come
-  pagate" o su "Segna coma pagata" o usando l'azione "Registrazione Riba
-  a data di scadenza" e indicando una data nel campo ``Data pagamento``,
-- successivamente a pagamento effettivamente avvenuto selezionando la
-  registrazione dalla vista ed elenco ed eseguendo l'azione "Imposta
-  data di pagamento RiBa".
+-  durante la creazione del pagamento, cliccando su "Segna righe come
+   pagate" o su "Segna coma pagata" o usando l'azione "Registrazione
+   Riba a data di scadenza" e indicando una data nel campo
+   ``Data pagamento``,
+-  successivamente a pagamento effettivamente avvenuto selezionando la
+   registrazione dalla vista ed elenco ed eseguendo l'azione "Imposta
+   data di pagamento RiBa".
 
 Bug Tracker
 ===========
@@ -156,27 +212,27 @@ Credits
 Contributors
 ------------
 
-- Lorenzo Battistini <lorenzo.battistini@agilebg.com>
-- Andrea Cometa <a.cometa@apuliasoftware.it>
-- Andrea Gallina <a.gallina@apuliasoftware.it>
-- Davide Corio <info@davidecorio.com>
-- Giacomo Grasso <giacomo.grasso@agilebg.com>
-- Gabriele Baldessari <gabriele.baldessari@gmail.com>
-- Alex Comba <alex.comba@agilebg.com>
-- Marco Calcagni <mcalcagni@dinamicheaziendali.it>
-- Sergio Zanchetta <https://github.com/primes2h>
-- Simone Vanin <simone.vanin@agilebg.com>
-- Sergio Corato <https://github.com/sergiocorato>
-- Giovanni Serra <giovanni@gslab.it>
-- `Aion Tech <https://aiontech.company/>`__:
+-  Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+-  Andrea Cometa <a.cometa@apuliasoftware.it>
+-  Andrea Gallina <a.gallina@apuliasoftware.it>
+-  Davide Corio <info@davidecorio.com>
+-  Giacomo Grasso <giacomo.grasso@agilebg.com>
+-  Gabriele Baldessari <gabriele.baldessari@gmail.com>
+-  Alex Comba <alex.comba@agilebg.com>
+-  Marco Calcagni <mcalcagni@dinamicheaziendali.it>
+-  Sergio Zanchetta <https://github.com/primes2h>
+-  Simone Vanin <simone.vanin@agilebg.com>
+-  Sergio Corato <https://github.com/sergiocorato>
+-  Giovanni Serra <giovanni@gslab.it>
+-  `Aion Tech <https://aiontech.company/>`__:
 
-  - Simone Rubino <simone.rubino@aion-tech.it>
+   -  Simone Rubino <simone.rubino@aion-tech.it>
 
-- `TAKOBI <https://takobi.online>`__:
+-  `TAKOBI <https://takobi.online>`__:
 
-  - Simone Rubino <sir@takobi.online>
+   -  Simone Rubino <sir@takobi.online>
 
-- Nextev Srl <odoo@nextev.it>
+-  Nextev Srl <odoo@nextev.it>
 
 Maintainers
 -----------

--- a/l10n_it_riba_oca/models/account.py
+++ b/l10n_it_riba_oca/models/account.py
@@ -196,6 +196,65 @@ class AccountMove(models.Model):
                     return True
         return False
 
+    def invoice_month_check(self, move_lines):
+        """
+        Check whether the invoice month (based on the invoice date) is already
+        charged. Used for the 'one_a_maturity_invoice_month' policy, which adds
+        a single expense per invoice month regardless of the maturities.
+
+        :param move_lines: existing move lines (already charged with expenses)
+            for the partner
+        :return: True if another invoice issued in the same month/year as the
+            current invoice date already carries a collection fee, so the
+            current invoice must be skipped.
+        """
+        self.ensure_one()
+        if not self.invoice_date:
+            return False
+        for line in move_lines:
+            other_invoice_date = line.move_id.invoice_date
+            if (
+                other_invoice_date
+                and other_invoice_date.month == self.invoice_date.month
+                and other_invoice_date.year == self.invoice_date.year
+            ):
+                return True
+        return False
+
+    def maturity_per_invoice_month_check(self, invoice_date_due, move_lines):
+        """
+        Check whether a given maturity month is already charged within the
+        invoice month. Used for the 'maturity_per_invoice_month' policy, which
+        adds an expense for every maturity month unless another invoice issued
+        in the same month (of the invoice date) already carries an expense for
+        a maturity falling in the same month.
+
+        Maturities are compared by month/year, not by exact date: two invoices
+        of the same invoice month with maturities on different days of the same
+        month are charged only once.
+
+        :param invoice_date_due: due date of current invoice
+        :param move_lines: existing move lines (already charged with expenses)
+            for the partner
+        :return: True if another invoice of the same invoice month/year already
+            has a maturity in the same month/year (so the expense is skipped)
+        """
+        self.ensure_one()
+        if not self.invoice_date:
+            return False
+        for line in move_lines:
+            other_invoice_date = line.move_id.invoice_date
+            if (
+                line.date_maturity
+                and line.date_maturity.month == invoice_date_due.month
+                and line.date_maturity.year == invoice_date_due.year
+                and other_invoice_date
+                and other_invoice_date.month == self.invoice_date.month
+                and other_invoice_date.year == self.invoice_date.year
+            ):
+                return True
+        return False
+
     def _post(self, soft=True):
         inv_riba_no_bank = self.filtered(
             lambda x: x.is_riba_payment
@@ -238,24 +297,31 @@ class AccountMove(models.Model):
                 raise UserError(
                     _("Set a Service for Collection Fees in Company Config.")
                 )
-            # ---- Apply Collection Fees on invoice only on first due date of the month
-            # ---- Get Date of first due date
+            # Apply Collection Fees on invoice only on first due date of the month
+            # Get all due dates with collection fees already applied.
+            # Include draft moves (excluding the current one) so that other
+            # invoices posted in the same batch are also considered: during
+            # a multi-record post they are still draft when this one is
+            # evaluated, and would otherwise be missed by the deduplication.
             move_line = self.env["account.move.line"].search(
                 [
                     ("partner_id", "=", invoice.partner_id.id),
                     ("move_id.invoice_payment_term_id.riba", "=", True),
-                    ("date_maturity", ">=", fields.Date.context_today(invoice)),
+                    ("move_id.state", "in", ("posted", "draft")),
+                    ("move_id", "!=", invoice.id),
                 ]
             )
-            if not any(
-                line.due_cost_line for line in move_line.mapped("move_id.line_ids")
-            ):
-                move_line = self.env["account.move.line"]
-            # ---- Filtered recordset with date_maturity
+            # Keep only lines from invoices that already have collection fees
+            move_line = move_line.filtered(
+                lambda line: any(
+                    inv_line.due_cost_line for inv_line in line.move_id.invoice_line_ids
+                )
+            )
+            # Filtered recordset with date_maturity
             move_line = move_line.filtered(lambda line: line.date_maturity is not False)
-            # ---- Sorted
+            # Sorted
             move_line = move_line.sorted(key=lambda r: r.date_maturity)
-            # ---- Get date
+            # Get date
             previous_date_due = move_line.mapped("date_maturity")
             pterm_list = invoice.invoice_payment_term_id._compute_terms(
                 date_ref=invoice.invoice_date,
@@ -267,13 +333,52 @@ class AccountMove(models.Model):
                 untaxed_amount_currency=0,
                 sign=1,
             )
-            for pay_date in pterm_list:
-                if not invoice.month_check(pay_date["date"], previous_date_due):
-                    # ---- Get Line values for service product
+
+            policy = invoice.partner_id.riba_policy_expenses
+            # Policies that add a single fee per invoice only process the
+            # first maturity:
+            # - 'one_per_invoice': always one fee per invoice
+            # - 'one_a_maturity_invoice_month': one fee per invoice month,
+            #   skipped entirely if that month is already charged
+            pay_dates = pterm_list
+            if policy == "one_per_invoice":
+                pay_dates = pterm_list[:1]
+            elif policy == "one_a_maturity_invoice_month":
+                if invoice.invoice_month_check(move_line):
+                    pay_dates = []
+                else:
+                    pay_dates = pterm_list[:1]
+
+            for pay_date in pay_dates:
+                # Check if expenses should be applied based on policy
+                should_skip_expense = False
+                if policy == "maturity_per_invoice_month":
+                    should_skip_expense = invoice.maturity_per_invoice_month_check(
+                        pay_date["date"], move_line
+                    )
+                elif policy in ("one_per_invoice", "one_a_maturity_invoice_month"):
+                    should_skip_expense = False
+                else:
+                    should_skip_expense = invoice.month_check(
+                        pay_date["date"], previous_date_due
+                    )
+
+                if not should_skip_expense:
+                    # Get Line values for service product
                     service_prod = invoice.company_id.due_cost_service_id
                     account = service_prod.product_tmpl_id.get_product_accounts(
                         invoice.fiscal_position_id
                     )["income"]
+                    # 'one_per_invoice' fee is not tied to a maturity, so
+                    # it carries no date in its description
+                    if policy == "one_per_invoice":
+                        line_name = service_prod.name
+                    else:
+                        line_name = _("{line_name} for {month}-{year}").format(
+                            line_name=service_prod.name,
+                            month=pay_date["date"].month,
+                            year=pay_date["date"].year,
+                        )
                     line_vals = {
                         "partner_id": invoice.partner_id.id,
                         "product_id": service_prod.id,
@@ -282,20 +387,16 @@ class AccountMove(models.Model):
                             invoice.invoice_payment_term_id.riba_payment_cost
                         ),
                         "due_cost_line": True,
-                        "name": _("{line_name} for {month}-{year}").format(
-                            line_name=service_prod.name,
-                            month=pay_date["date"].month,
-                            year=pay_date["date"].year,
-                        ),
+                        "name": line_name,
                         "account_id": account.id,
                         "sequence": 9999,
                     }
-                    # ---- Update Line Value with tax if is set on product
+                    # Update Line Value with tax if is set on product
                     if invoice.company_id.due_cost_service_id.taxes_id:
                         tax = invoice.fiscal_position_id.map_tax(service_prod.taxes_id)
                         line_vals.update({"tax_ids": [(4, tax.id)]})
                     invoice.write({"invoice_line_ids": [(0, 0, line_vals)]})
-                    # ---- recompute invoice taxes
+                    # Recompute invoice taxes
                     invoice._sync_dynamic_lines(
                         container={"records": invoice, "self": invoice}
                     )

--- a/l10n_it_riba_oca/models/partner.py
+++ b/l10n_it_riba_oca/models/partner.py
@@ -38,8 +38,24 @@ class ResPartner(models.Model):
     )
     riba_policy_expenses = fields.Selection(
         [
-            ("one_a_month", "More invoices, one expense per Month"),
-            ("unlimited", "One expense per maturity"),
+            ("unlimited", "One expense per maturity (no deduplication)"),
+            (
+                "one_per_invoice",
+                "One expense per invoice (fixed, regardless of maturities)",
+            ),
+            (
+                "one_a_month",
+                "One expense per maturity month (deduplicated across invoices)",
+            ),
+            (
+                "one_a_maturity_invoice_month",
+                "One expense per invoice month (deduplicated by invoice date)",
+            ),
+            (
+                "maturity_per_invoice_month",
+                "One expense per maturity month "
+                "(deduplicated within the invoice month)",
+            ),
         ],
         default="one_a_month",
         string="Ri.Ba. Policy expenses",

--- a/l10n_it_riba_oca/readme/CONFIGURE.md
+++ b/l10n_it_riba_oca/readme/CONFIGURE.md
@@ -35,3 +35,27 @@ Nel caso si vogliano gestire anche le spese per ogni scadenza con
 ricevuta bancaria, si deve configurare un prodotto di tipo servizio e
 collegarlo in *Configurazione → Impostazioni → Contabilità → Imposte →
 Spese di incasso RiBa*.
+
+**Spese di incasso per cliente**
+
+Sulla scheda del cliente (*Contatti*), nella sezione **RiBa**, sono
+disponibili due campi che governano l'addebito delle spese di incasso al
+momento della conferma della fattura:
+
+- **Escludi spese Ri.Ba.** (`riba_exclude_expenses`): se attivo, al
+  cliente non viene mai addebitata alcuna spesa di incasso, qualunque sia
+  la politica impostata.
+- **Politica spese Ri.Ba.** (`riba_policy_expenses`): determina quante
+  righe spesa vengono aggiunte alla fattura. Le opzioni disponibili sono:
+
+| Politica (etichetta / chiave) | Quante spese per fattura | Comportamento tra fatture diverse |
+|---|---|---|
+| One expense per maturity — `unlimited` | una per ogni scadenza | nessuna deduplicazione: tutte le scadenze di tutte le fatture vengono sempre addebitate |
+| One expense per invoice — `one_per_invoice` | una sola, a prescindere dal numero di scadenze | nessuna deduplicazione: ogni fattura riceve la propria spesa |
+| One expense per maturity month — `one_a_month` (default) | una per ciascun mese in cui cade una scadenza | salta la spesa se quel mese è già coperto da una scadenza di un'altra fattura del cliente |
+| One expense per invoice month — `one_a_maturity_invoice_month` | una sola, a prescindere dal numero di scadenze | salta la spesa se nello stesso mese della data fattura esiste già un'altra fattura del cliente con spesa |
+| One expense per maturity month, dedup within invoice month — `maturity_per_invoice_month` | una per ogni mese di scadenza | salta la spesa se nello stesso mese della data fattura esiste già un'altra fattura con una scadenza nello **stesso mese** |
+
+La deduplicazione considera solo le fatture del cliente **già
+confermate** che riportano una riga spesa: l'ordine di conferma delle
+fatture quindi è rilevante.

--- a/l10n_it_riba_oca/static/description/index.html
+++ b/l10n_it_riba_oca/static/description/index.html
@@ -442,6 +442,105 @@ esempio “Crediti insoluti”.</p>
 ricevuta bancaria, si deve configurare un prodotto di tipo servizio e
 collegarlo in <em>Configurazione → Impostazioni → Contabilità → Imposte →
 Spese di incasso RiBa</em>.</p>
+<p><strong>Spese di incasso per cliente</strong></p>
+<p>Sulla scheda del cliente (<em>Contatti</em>), nella sezione <strong>RiBa</strong>, sono
+disponibili due campi che governano l’addebito delle spese di incasso al
+momento della conferma della fattura:</p>
+<ul class="simple">
+<li><strong>Escludi spese Ri.Ba.</strong> (<tt class="docutils literal">riba_exclude_expenses</tt>): se attivo, al
+cliente non viene mai addebitata alcuna spesa di incasso, qualunque
+sia la politica impostata.</li>
+<li><strong>Politica spese Ri.Ba.</strong> (<tt class="docutils literal">riba_policy_expenses</tt>): determina
+quante righe spesa vengono aggiunte alla fattura. Le opzioni
+disponibili sono:</li>
+</ul>
+<table border="1" class="docutils">
+<colgroup>
+<col width="33%" />
+<col width="33%" />
+<col width="33%" />
+</colgroup>
+<thead valign="bottom">
+<tr><th class="head">Politica (etichetta
+/ chiave)</th>
+<th class="head">Quante spese per
+fattura</th>
+<th class="head">Comportamento tra
+fatture diverse</th>
+</tr>
+</thead>
+<tbody valign="top">
+<tr><td>One expense per
+maturity —
+<tt class="docutils literal">unlimited</tt></td>
+<td>una per ogni
+scadenza</td>
+<td>nessuna
+deduplicazione:
+tutte le scadenze di
+tutte le fatture
+vengono sempre
+addebitate</td>
+</tr>
+<tr><td>One expense per
+invoice —
+<tt class="docutils literal">one_per_invoice</tt></td>
+<td>una sola, a
+prescindere dal
+numero di scadenze</td>
+<td>nessuna
+deduplicazione: ogni
+fattura riceve la
+propria spesa</td>
+</tr>
+<tr><td>One expense per
+maturity month —
+<tt class="docutils literal">one_a_month</tt>
+(default)</td>
+<td>una per ciascun mese
+in cui cade una
+scadenza</td>
+<td>salta la spesa se
+quel mese è già
+coperto da una
+scadenza di un’altra
+fattura del cliente</td>
+</tr>
+<tr><td>One expense per
+invoice month —
+<tt class="docutils literal">one_a_matu
+rity_invoice_month</tt></td>
+<td>una sola, a
+prescindere dal
+numero di scadenze</td>
+<td>salta la spesa se
+nello stesso mese
+della data fattura
+esiste già un’altra
+fattura del cliente
+con spesa</td>
+</tr>
+<tr><td>One expense per
+maturity month,
+dedup within invoice
+month —
+<tt class="docutils literal">maturity
+_per_invoice_month</tt></td>
+<td>una per ogni mese di
+scadenza</td>
+<td>salta la spesa se
+nello stesso mese
+della data fattura
+esiste già un’altra
+fattura con una
+scadenza nello
+<strong>stesso mese</strong></td>
+</tr>
+</tbody>
+</table>
+<p>La deduplicazione considera solo le fatture del cliente <strong>già
+confermate</strong> che riportano una riga spesa: l’ordine di conferma delle
+fatture quindi è rilevante.</p>
 </div>
 <div class="section" id="usage">
 <h2><a class="toc-backref" href="#toc-entry-3">Usage</a></h2>
@@ -470,8 +569,9 @@ impostata con la data di scadenza della RiBa, ma è possibile modificarla
 in due momenti:</p>
 <ul class="simple">
 <li>durante la creazione del pagamento, cliccando su “Segna righe come
-pagate” o su “Segna coma pagata” o usando l’azione “Registrazione Riba
-a data di scadenza” e indicando una data nel campo <tt class="docutils literal">Data pagamento</tt>,</li>
+pagate” o su “Segna coma pagata” o usando l’azione “Registrazione
+Riba a data di scadenza” e indicando una data nel campo
+<tt class="docutils literal">Data pagamento</tt>,</li>
 <li>successivamente a pagamento effettivamente avvenuto selezionando la
 registrazione dalla vista ed elenco ed eseguendo l’azione “Imposta
 data di pagamento RiBa”.</li>

--- a/l10n_it_riba_oca/tests/test_riba.py
+++ b/l10n_it_riba_oca/tests/test_riba.py
@@ -90,6 +90,204 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         # Collection fees line has been unlink
         self.assertEqual(len(self.invoice.invoice_line_ids), 1)
 
+    def _riba_term(self, name, line):
+        # Single-maturity RiBa payment term with collection fees.
+        return self.env["account.payment.term"].create(
+            {
+                "name": name,
+                "riba": True,
+                "riba_payment_cost": 5.00,
+                "line_ids": [(0, 0, line)],
+            }
+        )
+
+    def _make_riba_invoice(self, invoice_date, payment_term):
+        # Customer invoice ready to be posted, with a controlled invoice date
+        # and payment term.
+        self.partner.property_account_receivable_id = self.account_rec1_id.id
+        invoice = self.env["account.move"].create(
+            {
+                "invoice_date": invoice_date,
+                "move_type": "out_invoice",
+                "journal_id": self.sale_journal.id,
+                "partner_id": self.partner.id,
+                "invoice_payment_term_id": payment_term.id,
+                "riba_partner_bank_id": self.partner.bank_ids[0].id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product1.name,
+                            "product_id": self.product1.id,
+                            "quantity": 1.0,
+                            "price_unit": 100.00,
+                            "account_id": self.sale_account.id,
+                            "tax_ids": [[6, 0, self.tax_22.ids]],
+                        },
+                    )
+                ],
+            }
+        )
+        return invoice
+
+    def _fee_count(self, invoice):
+        return len(invoice.invoice_line_ids.filtered("due_cost_line"))
+
+    # The next tests tell one_a_month and one_a_maturity_invoice_month apart.
+    # With the default fixtures (same invoice date, same maturities) they
+    # behave identically, which hides their difference.
+
+    def test_one_a_month_dedup_by_maturity_month(self):
+        # one_a_month deduplicates by maturity *month*: two invoices in the
+        # same month with maturities in the same month (different days) -> the
+        # second invoice gets no fee.
+        self.partner.riba_policy_expenses = "one_a_month"
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        term = self._riba_term("RiBa 30", {"value": "balance", "months": 0, "days": 30})
+        inv1 = self._make_riba_invoice(datetime.date(2024, 1, 5), term)  # mat 02-04
+        inv2 = self._make_riba_invoice(datetime.date(2024, 1, 25), term)  # mat 02-24
+        inv1.action_post()
+        inv2.action_post()
+        self.assertEqual(self._fee_count(inv1), 1)
+        self.assertEqual(self._fee_count(inv2), 0)
+
+    def _make_feb_and_feb_mar_invoices(self):
+        # A: invoice 01/01 with a single February maturity.
+        # B: invoice 01/01 with February + March maturities.
+        term_a = self._riba_term("RiBa Feb", {"value": "balance", "months": 1})
+        term_b = self.env["account.payment.term"].create(
+            {
+                "name": "RiBa Feb+Mar",
+                "riba": True,
+                "riba_payment_cost": 5.00,
+                "line_ids": [
+                    (0, 0, {"value": "percent", "value_amount": 50.0, "months": 1}),
+                    (0, 0, {"value": "balance", "months": 2}),
+                ],
+            }
+        )
+        inv_a = self._make_riba_invoice(datetime.date(2024, 1, 1), term_a)
+        inv_b = self._make_riba_invoice(datetime.date(2024, 1, 1), term_b)
+        return inv_a, inv_b
+
+    def test_one_a_month_second_invoice_charges_only_new_month(self):
+        # one_a_month, invoices posted one by one: February is already charged
+        # by A, so B is charged only for the new month (March) -> 1.
+        self.partner.riba_policy_expenses = "one_a_month"
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        inv_a, inv_b = self._make_feb_and_feb_mar_invoices()
+        inv_a.action_post()
+        inv_b.action_post()
+        self.assertEqual(self._fee_count(inv_a), 1)
+        self.assertEqual(self._fee_count(inv_b), 1)
+
+    def test_one_a_month_batch_posting_charges_only_new_month(self):
+        # Same as above but A and B are posted in a single batch (as when
+        # several invoices are selected and confirmed together): B must still
+        # be charged only for March. Other invoices posted in the same batch
+        # are still draft, so the deduplication has to consider them too.
+        self.partner.riba_policy_expenses = "one_a_month"
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        inv_a, inv_b = self._make_feb_and_feb_mar_invoices()
+        (inv_a + inv_b).action_post()
+        self.assertEqual(self._fee_count(inv_a), 1)
+        self.assertEqual(self._fee_count(inv_b), 1)
+
+    def test_one_a_maturity_invoice_month_one_fee_per_invoice_month(self):
+        # one_a_maturity_invoice_month: a single fee per invoice month, on the
+        # first invoice of that month, regardless of how many maturities it
+        # has. The 30/60 term has two maturities but only ONE fee is charged,
+        # and a second invoice issued in the same month gets nothing.
+        self.partner.riba_policy_expenses = "one_a_maturity_invoice_month"
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        inv1 = self._make_riba_invoice(datetime.date(2024, 1, 5), self.payment_term1)
+        inv2 = self._make_riba_invoice(datetime.date(2024, 1, 25), self.payment_term1)
+        inv1.action_post()
+        inv2.action_post()
+        self.assertEqual(self._fee_count(inv1), 1)
+        self.assertEqual(self._fee_count(inv2), 0)
+
+    def test_one_a_maturity_invoice_month_charges_across_invoice_months(self):
+        # one_a_maturity_invoice_month: invoices issued in different months
+        # each get their own (single) fee.
+        self.partner.riba_policy_expenses = "one_a_maturity_invoice_month"
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        inv1 = self._make_riba_invoice(datetime.date(2024, 1, 15), self.payment_term1)
+        inv2 = self._make_riba_invoice(datetime.date(2024, 2, 15), self.payment_term1)
+        inv1.action_post()
+        inv2.action_post()
+        self.assertEqual(self._fee_count(inv1), 1)
+        self.assertEqual(self._fee_count(inv2), 1)
+
+    def test_maturity_per_invoice_month_dedup_same_maturity_month(self):
+        # maturity_per_invoice_month: within the same invoice month, a maturity
+        # MONTH already charged by another invoice is not charged again, even
+        # if the exact day differs (Feb 4 and Feb 24 are both "February").
+        self.partner.riba_policy_expenses = "maturity_per_invoice_month"
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        term = self._riba_term("RiBa 30", {"value": "balance", "months": 0, "days": 30})
+        inv1 = self._make_riba_invoice(datetime.date(2024, 1, 5), term)  # mat Feb 04
+        inv2 = self._make_riba_invoice(datetime.date(2024, 1, 25), term)  # mat Feb 24
+        inv1.action_post()
+        inv2.action_post()
+        self.assertEqual(self._fee_count(inv1), 1)
+        self.assertEqual(self._fee_count(inv2), 0)
+
+    def test_maturity_per_invoice_month_one_fee_per_maturity_month(self):
+        # maturity_per_invoice_month: an invoice with maturities in two
+        # different months gets a fee for each maturity month (unlike
+        # one_a_maturity_invoice_month, which charges a single fee per invoice
+        # month). A second invoice of the same month, whose maturity months are
+        # already covered, gets nothing.
+        self.partner.riba_policy_expenses = "maturity_per_invoice_month"
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        # payment_term1 is 30/60 -> maturities fall in two different months
+        inv1 = self._make_riba_invoice(datetime.date(2024, 1, 5), self.payment_term1)
+        inv1.action_post()
+        self.assertEqual(self._fee_count(inv1), 2)
+        inv2 = self._make_riba_invoice(datetime.date(2024, 1, 25), self.payment_term1)
+        inv2.action_post()
+        self.assertEqual(self._fee_count(inv2), 0)
+
+    def test_maturity_per_invoice_month_charges_across_invoice_months(self):
+        # maturity_per_invoice_month: the dedup is scoped to the invoice month,
+        # so the same maturity month on invoices issued in different months is
+        # charged on each (unlike one_a_month, which would dedup globally).
+        self.partner.riba_policy_expenses = "maturity_per_invoice_month"
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        term_jan = self._riba_term(
+            "RiBa +3m", {"value": "balance", "months": 3, "days": 0}
+        )
+        term_feb = self._riba_term(
+            "RiBa +2m", {"value": "balance", "months": 2, "days": 0}
+        )
+        inv1 = self._make_riba_invoice(datetime.date(2024, 1, 15), term_jan)  # Apr
+        inv2 = self._make_riba_invoice(datetime.date(2024, 2, 15), term_feb)  # Apr
+        inv1.action_post()
+        inv2.action_post()
+        self.assertEqual(self._fee_count(inv1), 1)
+        self.assertEqual(self._fee_count(inv2), 1)
+
+    def test_due_cost_one_per_invoice(self):
+        # one_per_invoice: exactly one fee per invoice, regardless of the
+        # number of maturities (the 30/60 term has two), and no deduplication
+        # across invoices.
+        self.partner.riba_policy_expenses = "one_per_invoice"
+        self.invoice.company_id.due_cost_service_id = self.service_due_cost.id
+        self.invoice.action_post()
+        # 1 product line + 1 single fee line (not 2, despite 2 maturities)
+        self.assertEqual(len(self.invoice.invoice_line_ids), 2)
+        self.assertEqual(
+            len(self.invoice.invoice_line_ids.filtered("due_cost_line")), 1
+        )
+        # a second invoice for the same partner in the same month still gets
+        # its own fee (no deduplication)
+        self.invoice2.action_post()
+        self.assertEqual(
+            len(self.invoice2.invoice_line_ids.filtered("due_cost_line")), 1
+        )
+
     def riba_sbf_common(self, configuration_id):
         invoice = self._create_sbf_invoice()
         invoice._onchange_riba_partner_bank_id()


### PR DESCRIPTION
La PR #4655 introduce un campo per impostare una politica spese Ri.Ba. per partner:
| Politica (etichetta / chiave) | Quante spese per fattura | Comportamento tra fatture diverse |
|---|---|---|
| One expense per maturity — `unlimited` | una per ogni scadenza | nessuna deduplicazione: tutte le scadenze di tutte le fatture vengono sempre addebitate |
| One expense per maturity month — `one_a_month` (default) | una per ciascun mese in cui cade una scadenza | salta la spesa se quel mese è già coperto da una scadenza di un'altra fattura del cliente |

Questa PR estende questa selezione con queste politiche:

| Politica (etichetta / chiave) | Quante spese per fattura | Comportamento tra fatture diverse |
|---|---|---|
| One expense per invoice — `one_per_invoice` | una sola, a prescindere dal numero di scadenze | nessuna deduplicazione: ogni fattura riceve la propria spesa |
| One expense per invoice month — `one_a_maturity_invoice_month` | una sola, a prescindere dal numero di scadenze | salta la spesa se nello stesso mese della data fattura esiste già un'altra fattura del cliente con spesa |
| One expense per maturity month, dedup within invoice month — `maturity_per_invoice_month` | una per ogni mese di scadenza | salta la spesa se nello stesso mese della data fattura esiste già un'altra fattura con una scadenza nello **stesso mese** |

Risolve la #5246 

Depends on #4655