### PR TITLE
[18.0][FIX] l10n_it_edi_extension: use format_alphanumeric for Causale XML node

### DIFF
--- a/l10n_it_edi_extension/data/invoice_it_template.xml
+++ b/l10n_it_edi_extension/data/invoice_it_template.xml
@@ -39,8 +39,8 @@
             />
         </xpath>
         <xpath expr="//DatiGeneraliDocumento/ImportoTotaleDocumento" position="after">
-            <t t-foreach="causale" t-as="c">
-                <Causale t-out="c" />
+            <t t-foreach="causale_lines" t-as="causale_line">
+                <Causale t-out="format_alphanumeric(causale_line, 200)" />
             </t>
             <Art73
                 t-if="record.l10n_edi_it_art73 or company.l10n_edi_it_art73"

--- a/l10n_it_edi_extension/models/account_move.py
+++ b/l10n_it_edi_extension/models/account_move.py
@@ -2,9 +2,12 @@
 # Copyright 2025 Simone Rubino
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import re
+import unicodedata
+
 from odoo import api, fields, models, osv
 from odoo.exceptions import UserError
-from odoo.tools import float_compare, html2plaintext
+from odoo.tools import float_compare, html2plaintext, is_html_empty
 
 from odoo.addons.base.models.ir_qweb_fields import Markup
 from odoo.addons.l10n_it_edi.models.account_move import get_date, get_float, get_text
@@ -266,11 +269,36 @@ class AccountMoveInherit(models.Model):
             )
         return res
 
+    @api.model
+    def _sanitize_causale(self, text):
+        # Normalize text into NFC
+        text = unicodedata.normalize("NFC", text)
+
+        # Mapping of "fancy" or typographic characters to ASCII-friendly equivalents
+        replacements = {
+            "\u2018": "'",  # left single quotation mark → straight apostrophe
+            "\u2019": "'",  # right single quotation mark → straight apostrophe
+            "\u201c": '"',  # left double quotation mark → straight quote
+            "\u201d": '"',  # right double quotation mark → straight quote
+            "\u2013": "-",  # en dash → hyphen
+            "\u2014": "-",  # em dash → hyphen
+            "\u2026": "...",  # ellipsis → three dots
+            "\u20ac": "EUR",  # euro sign → EUR text
+        }
+
+        for bad, good in replacements.items():
+            text = text.replace(bad, good)
+
+        # Remove any character outside Basic Latin + Latin-1 Supplement range
+        text = re.sub(r"[^\u0000-\u00FF]", "?", text)
+
+        return text
+
     def _l10n_it_edi_get_values(self, pdf_values=None):
         res = super()._l10n_it_edi_get_values(pdf_values)
 
         causale_list = []
-        if self.narration:
+        if not is_html_empty(self.narration):
             try:
                 narration_text = html2plaintext(self.narration)
             except Exception:
@@ -278,8 +306,11 @@ class AccountMoveInherit(models.Model):
 
             # max length of Causale is 200
             for causale in narration_text.split("\n"):
-                if not causale:
+                # Skip if causale is empty or only spaces
+                if not causale.strip():
                     continue
+
+                causale = self._sanitize_causale(causale)
                 causale_list_200 = [
                     causale[i : i + 200] for i in range(0, len(causale), 200)
                 ]

--- a/l10n_it_edi_extension/models/account_move.py
+++ b/l10n_it_edi_extension/models/account_move.py
@@ -2,9 +2,6 @@
 # Copyright 2025 Simone Rubino
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import re
-import unicodedata
-
 from odoo import api, fields, models, osv
 from odoo.exceptions import UserError
 from odoo.tools import float_compare, html2plaintext, is_html_empty
@@ -269,35 +266,10 @@ class AccountMoveInherit(models.Model):
             )
         return res
 
-    @api.model
-    def _sanitize_causale(self, text):
-        # Normalize text into NFC
-        text = unicodedata.normalize("NFC", text)
-
-        # Mapping of "fancy" or typographic characters to ASCII-friendly equivalents
-        replacements = {
-            "\u2018": "'",  # left single quotation mark → straight apostrophe
-            "\u2019": "'",  # right single quotation mark → straight apostrophe
-            "\u201c": '"',  # left double quotation mark → straight quote
-            "\u201d": '"',  # right double quotation mark → straight quote
-            "\u2013": "-",  # en dash → hyphen
-            "\u2014": "-",  # em dash → hyphen
-            "\u2026": "...",  # ellipsis → three dots
-            "\u20ac": "EUR",  # euro sign → EUR text
-        }
-
-        for bad, good in replacements.items():
-            text = text.replace(bad, good)
-
-        # Remove any character outside Basic Latin + Latin-1 Supplement range
-        text = re.sub(r"[^\u0000-\u00FF]", "?", text)
-
-        return text
-
     def _l10n_it_edi_get_values(self, pdf_values=None):
         res = super()._l10n_it_edi_get_values(pdf_values)
 
-        causale_list = []
+        causale_lines = []
         if not is_html_empty(self.narration):
             try:
                 narration_text = html2plaintext(self.narration)
@@ -305,19 +277,13 @@ class AccountMoveInherit(models.Model):
                 narration_text = ""
 
             # max length of Causale is 200
-            for causale in narration_text.split("\n"):
-                # Skip if causale is empty or only spaces
-                if not causale.strip():
-                    continue
+            for line in narration_text.splitlines():
+                if line.strip():
+                    causale_lines.extend(
+                        line[i : i + 200] for i in range(0, len(line), 200)
+                    )
 
-                causale = self._sanitize_causale(causale)
-                causale_list_200 = [
-                    causale[i : i + 200] for i in range(0, len(causale), 200)
-                ]
-                for causale200 in causale_list_200:
-                    causale_list.append(causale200)
-
-        res["causale"] = causale_list
+        res["causale_lines"] = causale_lines
 
         return res
 

--- a/l10n_it_edi_extension/readme/CONTRIBUTORS.md
+++ b/l10n_it_edi_extension/readme/CONTRIBUTORS.md
@@ -5,3 +5,5 @@
 - Nextev Srl \<<odoo@nextev.it>\>
 - [Stesi Consulting srl](https://www.stesi.consulting/):
   - Michele Di Croce \<<dicroce.m@stesi.consulting>\>
+- [Agile Business Group](https://www.agilebg.com/):
+  - Alex Comba \<<alex.comba@agilebg.com>\>

--- a/l10n_it_edi_extension/tests/export_xmls/test_invoice_causale_non_latin.xml
+++ b/l10n_it_edi_extension/tests/export_xmls/test_invoice_causale_non_latin.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- pylint:disable=xml-syntax-error -->
+<p:FatturaElettronica
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+    xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd"
+    versione="FPR12"
+>
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>V202200001</ProgressivoInvio>
+            <FormatoTrasmissione>FPR12</FormatoTrasmissione>
+            <CodiceDestinatario>0000000</CodiceDestinatario>
+            <ContattiTrasmittente>
+                <Telefono>0266766700</Telefono>
+                <Email>test@test.it</Email>
+            </ContattiTrasmittente>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>01234560157</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>01234560157</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>company_2_data</Denominazione>
+                </Anagrafica>
+                <RegimeFiscale>RF01</RegimeFiscale>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>1234 Test Street</Indirizzo>
+                <CAP>12345</CAP>
+                <Comune>Prova</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <DatiAnagrafici>
+                <IdFiscaleIVA>
+                    <IdPaese>IT</IdPaese>
+                    <IdCodice>00465840031</IdCodice>
+                </IdFiscaleIVA>
+                <CodiceFiscale>93026890017</CodiceFiscale>
+                <Anagrafica>
+                    <Denominazione>Alessi</Denominazione>
+                </Anagrafica>
+            </DatiAnagrafici>
+            <Sede>
+                <Indirizzo>Via Privata Alessi 6</Indirizzo>
+                <CAP>28887</CAP>
+                <Comune>Milan</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+                <TipoDocumento>TD01</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2022-03-24</Data>
+                <Numero>INV/2022/00001</Numero>
+                <ImportoTotaleDocumento>976.49</ImportoTotaleDocumento>
+                <Causale>```</Causale>
+                <Causale
+                >L'impresa è un'attività economica organizzata ai fini della produzione</Causale>
+                <Causale>o dello scambio di beni o servizi.</Causale>
+                <Causale>Importo totale fattura è 976,49 EUR.</Causale>
+                <Causale>```</Causale>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+        <DatiBeniServizi>
+            <DettaglioLinee>
+                <NumeroLinea>1</NumeroLinea>
+                <Descrizione>line1</Descrizione>
+                <Quantita>1.00</Quantita>
+                <PrezzoUnitario>800.40000000</PrezzoUnitario>
+                <PrezzoTotale>800.40000000</PrezzoTotale>
+                <AliquotaIVA>22.00</AliquotaIVA>
+            </DettaglioLinee>
+            <DatiRiepilogo>
+                <AliquotaIVA>22.00</AliquotaIVA>
+                <ImponibileImporto>800.40</ImponibileImporto>
+                <Imposta>176.09</Imposta>
+                <EsigibilitaIVA>I</EsigibilitaIVA>
+            </DatiRiepilogo>
+        </DatiBeniServizi>
+        <DatiPagamento>
+            <CondizioniPagamento>TP02</CondizioniPagamento>
+            <DettaglioPagamento>
+                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
+                <ImportoPagamento>976.49</ImportoPagamento>
+                <CodicePagamento>INV/2022/00001</CodicePagamento>
+            </DettaglioPagamento>
+        </DatiPagamento>
+    </FatturaElettronicaBody>
+</p:FatturaElettronica>

--- a/l10n_it_edi_extension/tests/export_xmls/test_invoice_causale_non_latin.xml
+++ b/l10n_it_edi_extension/tests/export_xmls/test_invoice_causale_non_latin.xml
@@ -69,11 +69,19 @@
                 <ImportoTotaleDocumento>976.49</ImportoTotaleDocumento>
                 <Causale>```</Causale>
                 <Causale
-                >L'impresa è un'attività economica organizzata ai fini della produzione</Causale>
+                >L?impresa è un?attività economica organizzata ai fini della produzione</Causale>
                 <Causale>o dello scambio di beni o servizi.</Causale>
-                <Causale>Importo totale fattura è 976,49 EUR.</Causale>
+                <Causale>Importo totale fattura è 976,49 ?.</Causale>
                 <Causale>```</Causale>
             </DatiGeneraliDocumento>
+            <DatiTrasporto>
+                <IndirizzoResa>
+                    <Indirizzo>Via Privata Alessi 6</Indirizzo>
+                    <CAP>28887</CAP>
+                    <Comune>Milan</Comune>
+                    <Nazione>IT</Nazione>
+                </IndirizzoResa>
+            </DatiTrasporto>
         </DatiGenerali>
         <DatiBeniServizi>
             <DettaglioLinee>

--- a/l10n_it_edi_extension/tests/test_export.py
+++ b/l10n_it_edi_extension/tests/test_export.py
@@ -22,6 +22,40 @@ class TestExport(Common):
         invoice.action_post()
         self._assert_export_invoice(invoice, "narration.xml")
 
+    def test_invoice_causale_non_latin(self):
+        narration = """
+            <p> </p>
+            <p>```</p>
+            <p>L’impresa è un’attività economica organizzata ai fini della produzione
+             o dello scambio di beni o servizi.</p>
+            <p>Importo totale fattura è 976,49 €.</p>
+            <p>```</p>
+        """
+        invoice = (
+            self.env["account.move"]
+            .with_company(self.company)
+            .create(
+                {
+                    "move_type": "out_invoice",
+                    "invoice_date": "2022-03-24",
+                    "invoice_date_due": "2022-03-24",
+                    "partner_id": self.italian_partner_a.id,
+                    "narration": narration,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": "line1",
+                                "price_unit": 800.40,
+                                "tax_ids": [Command.set(self.default_tax.ids)],
+                            }
+                        ),
+                    ],
+                }
+            )
+        )
+        invoice.action_post()
+        self._assert_export_invoice(invoice, "test_invoice_causale_non_latin.xml")
+
     def test_partner_shipping(self):
         """The partner shipping included in the invoice
         is exported to the XML in IndirizzoResa node."""


### PR DESCRIPTION
La funzione [format_alphanumeric](https://github.com/odoo/odoo/blob/5be73aaf0a4ce92398b131bbf7962145af210492/addons/l10n_it_edi/models/account_move.py#L1651) si adatta perfettamente anche al nodo `Causale`. Questo nodo condivide infatti la stessa logica di `RiferimentoNormativo`([vedi template XML](https://github.com/odoo/odoo/blob/5be73aaf0a4ce92398b131bbf7962145af210492/addons/l10n_it_edi/data/invoice_it_template.xml#L199)) basata sul pattern XSD `[\p{IsBasicLatin}\p{IsLatin-1Supplement}]`.

Sostituisce https://github.com/OCA/l10n-italy/pull/4924 e risolve https://github.com/OCA/l10n-italy/issues/5176