### PR TITLE
[IMP] l10n_it_riba_queued: Canale dedicato

### DIFF
--- a/l10n_it_riba_queued/README.rst
+++ b/l10n_it_riba_queued/README.rst
@@ -51,6 +51,22 @@ prevent other lines' payment.
 .. contents::
    :local:
 
+Configuration
+=============
+
+**Italiano**
+
+Configurare il canale ``root.RiBa`` come indicato dal modulo
+``queue_job``. Se il canale RiBa ha capacità superiore a 1,
+l'elaborazione di più record contemporaneamente potrebbe causare errori
+di concorrenza durante la scrittura.
+
+**English**
+
+Configure the ``root.RiBa`` channel as suggested by the ``queue_job``
+module. If the RiBa channel has more than 1 as capacity, processing
+multiple records at once may incur in concurrent writes errors.
+
 Usage
 =====
 

--- a/l10n_it_riba_queued/__manifest__.py
+++ b/l10n_it_riba_queued/__manifest__.py
@@ -14,6 +14,8 @@
         "queue_job",
     ],
     "data": [
+        "data/queue_job_channel_data.xml",
+        "data/queue_job_function_data.xml",
         "wizards/wizard_riba_multiple_payment_views.xml",
     ],
 }

--- a/l10n_it_riba_queued/data/queue_job_channel_data.xml
+++ b/l10n_it_riba_queued/data/queue_job_channel_data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    ~ Copyright 2026 Simone Rubino - PyTech
+    ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="channel_riba" model="queue.job.channel">
+        <field name="name">RiBa</field>
+        <field name="parent_id" ref="queue_job.channel_root" />
+    </record>
+</odoo>

--- a/l10n_it_riba_queued/data/queue_job_function_data.xml
+++ b/l10n_it_riba_queued/data/queue_job_function_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    ~ Copyright 2026 Simone Rubino - PyTech
+    ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="job_function_riba_settle" model="queue.job.function">
+        <field
+            name="model_id"
+            ref="l10n_it_ricevute_bancarie.model_riba_distinta_line"
+        />
+        <field name="method">riba_line_settlement</field>
+        <field name="channel_id" ref="channel_riba" />
+    </record>
+</odoo>

--- a/l10n_it_riba_queued/readme/CONFIGURE.md
+++ b/l10n_it_riba_queued/readme/CONFIGURE.md
@@ -1,0 +1,9 @@
+**Italiano**
+
+Configurare il canale `root.RiBa` come indicato dal modulo `queue_job`.
+Se il canale RiBa ha capacità superiore a 1, l'elaborazione di più record contemporaneamente potrebbe causare errori di concorrenza durante la scrittura.
+
+**English**
+
+Configure the `root.RiBa` channel as suggested by the `queue_job` module.
+If the RiBa channel has more than 1 as capacity, processing multiple records at once may incur in concurrent writes errors.

--- a/l10n_it_riba_queued/static/description/index.html
+++ b/l10n_it_riba_queued/static/description/index.html
@@ -386,18 +386,31 @@ prevent other lines’ payment.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
+<p><strong>Italiano</strong></p>
+<p>Configurare il canale <tt class="docutils literal">root.RiBa</tt> come indicato dal modulo
+<tt class="docutils literal">queue_job</tt>. Se il canale RiBa ha capacità superiore a 1,
+l’elaborazione di più record contemporaneamente potrebbe causare errori
+di concorrenza durante la scrittura.</p>
+<p><strong>English</strong></p>
+<p>Configure the <tt class="docutils literal">root.RiBa</tt> channel as suggested by the <tt class="docutils literal">queue_job</tt>
+module. If the RiBa channel has more than 1 as capacity, processing
+multiple records at once may incur in concurrent writes errors.</p>
+</div>
 <div class="section" id="usage">
-<h2><a class="toc-backref" href="#toc-entry-1">Usage</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-2">Usage</a></h2>
 <p><strong>Italiano</strong></p>
 <p>Nella procedura di pagamento di righe multiple, premere “Pagamento
 asincrono”.</p>
@@ -405,7 +418,7 @@ asincrono”.</p>
 <p>In the multiple lines payment wizard, click “Pay Async”.</p>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/l10n-italy/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -413,15 +426,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-3">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-4">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-5">Authors</a></h3>
 <ul class="simple">
 <li>PyTech</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-5">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-6">Contributors</a></h3>
 <ul class="simple">
 <li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
@@ -430,7 +443,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />


### PR DESCRIPTION
Crea un canale dedicato per il processamento asincrono dei pagamenti RiBa in modo da evitare errori di concorrenza.

Gli errori di concorrenza ci possono essere perché il pagamento contemporaneo di più RiBa potrebbe implicare la scrittura di uno stesso campo calcolato storato e l'aggiornamento da parte di processi concorrenti solleverebbe l'errore:
> ERROR: could not serialize access due to concurrent update

Oppure perché entrambi i movimenti cercano di staccare un progressivo dalla stessa sequenza:
> ERROR: could not obtain lock on row in relation "ir_sequence_date_range"