### PR TITLE
[IMP] l10n_it_delivery_note: creando una fattura da più ddt le righe non vengono generate basandosi sulle righe dei ddt

### DIFF
--- a/l10n_it_delivery_note/models/account_invoice.py
+++ b/l10n_it_delivery_note/models/account_invoice.py
@@ -6,9 +6,9 @@
 # @author: Matteo Bilotta <mbilotta@linkeurope.it>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models
 
-from .stock_delivery_note import DATE_FORMAT, DOMAIN_INVOICE_STATUSES
+from .stock_delivery_note import DATE_FORMAT
 
 
 class AccountInvoice(models.Model):
@@ -20,6 +20,9 @@ class AccountInvoice(models.Model):
         "invoice_id",
         "delivery_note_id",
         string="Delivery Notes",
+        compute="_compute_delivery_note_ids",
+        store=True,
+        readonly=False,
         copy=False,
     )
 
@@ -28,6 +31,13 @@ class AccountInvoice(models.Model):
     def _compute_delivery_note_count(self):
         for invoice in self:
             invoice.delivery_note_count = len(invoice.delivery_note_ids)
+
+    @api.depends(
+        "line_ids.delivery_note_id",
+    )
+    def _compute_delivery_note_ids(self):
+        for move in self:
+            move.delivery_note_ids = move.line_ids.delivery_note_id
 
     def goto_delivery_notes(self, **kwargs):
         delivery_notes = self.mapped("delivery_note_ids")
@@ -124,28 +134,10 @@ class AccountInvoice(models.Model):
                 )
             else:
                 sequence = 1
-                done_invoice_lines = self.env["account.move.line"]
                 for dn in invoice.mapped("delivery_note_ids").sorted(key="name"):
                     dn_invoice_lines = invoice.invoice_line_ids.filtered(
-                        lambda x: x not in done_invoice_lines
-                        and dn
-                        in x.mapped(
-                            "sale_line_ids.delivery_note_line_ids.delivery_note_id"
-                        )
-                        # fixme test invoice from 2 sale lines
+                        lambda x: dn == x.delivery_note_id
                     )
-                    done_invoice_lines |= dn_invoice_lines
-                    for note_line in dn.line_ids.filtered(
-                        lambda li: li.invoice_status == DOMAIN_INVOICE_STATUSES[2]
-                    ):
-                        for invoice_line in dn_invoice_lines:
-                            if (
-                                note_line
-                                in invoice_line.sale_line_ids.delivery_note_line_ids
-                            ):
-                                invoice_line.delivery_note_id = (
-                                    note_line.delivery_note_id.id
-                                )
                     if dn_invoice_lines:
                         new_lines.append(
                             (
@@ -190,6 +182,24 @@ class AccountInvoiceLine(models.Model):
     _inherit = "account.move.line"
 
     delivery_note_id = fields.Many2one(
-        "stock.delivery.note", string="Delivery Note", readonly=True, copy=False
+        comodel_name="stock.delivery.note",
+        string="Delivery Note",
+        compute="_compute_delivery_note_id",
+        readonly=False,
+        store=True,
+        copy=False,
+    )
+    delivery_note_line_id = fields.Many2one(
+        comodel_name="stock.delivery.note.line",
+        string="Delivery Note Line",
+        readonly=True,
+        copy=False,
     )
     note_dn = fields.Boolean(string="Note DN")
+
+    @api.depends(
+        "delivery_note_line_id",
+    )
+    def _compute_delivery_note_id(self):
+        for line in self:
+            line.delivery_note_id = line.delivery_note_line_id.delivery_note_id

--- a/l10n_it_delivery_note/models/sale_order.py
+++ b/l10n_it_delivery_note/models/sale_order.py
@@ -104,6 +104,30 @@ class SaleOrder(models.Model):
         invoices = self.env["account.move"].browse(invoice_ids)
         invoices.update_delivery_note_lines()
 
+    def _get_invoiceable_lines(self, final=False):
+        order_lines = super()._get_invoiceable_lines(final=final)
+        invoicing_delivery_notes = self.env.context.get(
+            "invoicing_delivery_notes",
+            self.env["stock.delivery.note"].browse(),
+        )
+        new_order_lines = self.env["sale.order.line"].browse()
+        for order_line in order_lines:
+            invoiceable_dn_lines = order_line.delivery_note_line_ids.filtered(
+                lambda dn_line: dn_line.is_invoiceable
+            )
+            if invoicing_delivery_notes:
+                invoiceable_dn_lines = invoiceable_dn_lines.filtered(
+                    lambda dn_line: dn_line.delivery_note_id in invoicing_delivery_notes
+                )
+            if len(invoiceable_dn_lines) > 1:
+                # Add a new order line for each linked delivery note line.
+                # Every new corresponding invoice line
+                # will invoice the delivered quantity
+                for _index in range(len(invoiceable_dn_lines) - 1):
+                    new_order_lines += order_line
+            new_order_lines += order_line
+        return new_order_lines
+
     def _create_invoices(self, grouped=False, final=False, date=None):
         invoice_ids = super()._create_invoices(grouped=grouped, final=final, date=date)
 
@@ -169,3 +193,36 @@ class SaleOrderLine(models.Model):
         return self.filtered(lambda li: li.has_picking).filtered(
             lambda li: li.is_pickings_related(picking_ids)
         )
+
+    def _prepare_invoice_line(self, **optional_values):
+        values = super()._prepare_invoice_line(**optional_values)
+        invoiced_dn_lines = self.env.context.get(
+            "delivery_note_invoiced_lines",
+            self.env["stock.delivery.note.line"].browse(),
+        )
+        invoiceable_dn_lines = (
+            self.delivery_note_line_ids.filtered(lambda dn_line: dn_line.is_invoiceable)
+            - invoiced_dn_lines
+        )
+        invoicing_delivery_notes = self.env.context.get(
+            "invoicing_delivery_notes",
+            self.env["stock.delivery.note"].browse(),
+        )
+        if invoicing_delivery_notes:
+            invoiceable_dn_lines = invoiceable_dn_lines.filtered(
+                lambda dn_line: dn_line.delivery_note_id in invoicing_delivery_notes
+            )
+
+        if invoiceable_dn_lines:
+            invoiced_dn_line = fields.first(invoiceable_dn_lines)
+            values.update(
+                {
+                    "delivery_note_line_id": invoiced_dn_line.id,
+                    "quantity": invoiced_dn_line.product_qty,
+                }
+            )
+            self.env.context = dict(
+                self.env.context,
+                delivery_note_invoiced_lines=invoiced_dn_lines | invoiced_dn_line,
+            )
+        return values

--- a/l10n_it_delivery_note/models/stock_delivery_note.py
+++ b/l10n_it_delivery_note/models/stock_delivery_note.py
@@ -750,9 +750,11 @@ class StockDeliveryNote(models.Model):
                 if order_lines.filtered(lambda li: li.need_to_be_invoiced):
                     cache[downpayment] = downpayment.fix_qty_to_invoice()
 
-            invoice_ids = sale_ids.filtered(
-                lambda o: o.invoice_status == DOMAIN_INVOICE_STATUSES[1]
-            )._create_invoices(final=True)
+            invoice_ids = (
+                sale_ids.with_context(invoicing_delivery_notes=self)
+                .filtered(lambda o: o.invoice_status == DOMAIN_INVOICE_STATUSES[1])
+                ._create_invoices(final=True)
+            )
 
             for line, vals in cache.items():
                 line.write(vals)

--- a/l10n_it_delivery_note/tests/test_stock_delivery_note_invoicing.py
+++ b/l10n_it_delivery_note/tests/test_stock_delivery_note_invoicing.py
@@ -1355,19 +1355,40 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
         invoice = sales_order.invoice_ids
         invoice.action_post()
         self.assertEqual(invoice.state, "posted")
-        self.assertEqual(
-            invoice.invoice_line_ids.filtered(
-                lambda inv_line: inv_line.product_id.id
-                == self.right_corner_desk_line[2]["product_id"]
-            ).quantity,
-            2,
-        )
-        self.assertEqual(
-            invoice.invoice_line_ids.filtered(
-                lambda inv_line: inv_line.product_id.id
-                == self.desk_combination_line[2]["product_id"]
-            ).quantity,
-            1,
+        self.assertRecordValues(
+            invoice.invoice_line_ids.sorted("sequence"),
+            [
+                {
+                    "note_dn": True,
+                    "delivery_note_id": dn.id,
+                    "product_id": False,
+                    "quantity": 0,
+                },
+                {
+                    "note_dn": False,
+                    "delivery_note_id": dn.id,
+                    "product_id": self.right_corner_desk_line[2]["product_id"],
+                    "quantity": 1,
+                },
+                {
+                    "note_dn": True,
+                    "delivery_note_id": back_dn.id,
+                    "product_id": False,
+                    "quantity": 0,
+                },
+                {
+                    "note_dn": False,
+                    "delivery_note_id": back_dn.id,
+                    "product_id": self.right_corner_desk_line[2]["product_id"],
+                    "quantity": 1,
+                },
+                {
+                    "note_dn": False,
+                    "delivery_note_id": back_dn.id,
+                    "product_id": self.desk_combination_line[2]["product_id"],
+                    "quantity": 1,
+                },
+            ],
         )
         self.assertEqual(dn.invoice_status, "invoiced")
         self.assertEqual(back_dn.invoice_status, "invoiced")
@@ -1473,3 +1494,76 @@ class StockDeliveryNoteInvoicingTest(StockDeliveryNoteCommon):
         self.assertIn(dn_2.date.strftime(DATE_FORMAT), label_so_2.name)
         self.assertEqual(product_line_2.product_id, so_2.order_line.product_id)
         self.assertEqual(product_line_2.quantity, 2)
+
+    def test_multiple_dn_invoice_one(self):
+        """Create multiple Delivery Notes for the same Sale Order,
+        and invoice only one Delivery Note.
+        Only the lines of the invoiced Delivery Note
+        are present in the invoice.
+        """
+        # Order 2 products, but deliver only 1
+        sales_order = self.create_sales_order(
+            [
+                self.right_corner_desk_line,  # 2
+            ],
+        )
+        sales_order.action_confirm()
+        picking = sales_order.picking_ids
+        picking.move_lines.quantity_done = 1
+
+        # Confirm the picking as-is: create backorder
+        res_dict = picking.button_validate()
+        wizard = Form(
+            self.env[(res_dict.get("res_model"))].with_context(res_dict["context"])
+        ).save()
+        wizard.process()
+
+        # Create Delivery Note
+        res_dict = picking.action_delivery_note_create()
+        wizard = Form(
+            self.env[(res_dict.get("res_model"))].with_context(res_dict["context"])
+        ).save()
+        wizard.confirm()
+        dn = picking.delivery_note_id
+        dn.action_confirm()
+        dn.action_done()
+
+        # Create Delivery Note for backorder
+        picking_backorder = self.env["stock.picking"].search(
+            [("backorder_id", "=", picking.id)]
+        )
+        picking_backorder.move_lines.quantity_done = 1
+        picking_backorder.button_validate()
+        back_res_dict = picking_backorder.action_delivery_note_create()
+        back_wizard = Form(
+            self.env[(back_res_dict.get("res_model"))].with_context(
+                back_res_dict["context"]
+            )
+        ).save()
+        back_wizard.confirm()
+        back_dn = picking_backorder.delivery_note_id
+        back_dn.action_confirm()
+        back_dn.action_done()
+
+        dn.action_invoice()
+        invoice = sales_order.invoice_ids
+        invoice.action_post()
+        self.assertRecordValues(
+            invoice.invoice_line_ids.sorted("sequence"),
+            [
+                {
+                    "note_dn": True,
+                    "delivery_note_id": dn.id,
+                    "product_id": False,
+                    "quantity": 0,
+                },
+                {
+                    "note_dn": False,
+                    "delivery_note_id": dn.id,
+                    "product_id": self.right_corner_desk_line[2]["product_id"],
+                    "quantity": 1,
+                },
+            ],
+        )
+        self.assertEqual(dn.invoice_status, "invoiced")
+        self.assertEqual(back_dn.invoice_status, "to invoice")

--- a/l10n_it_fatturapa_out_dn/tests/data/IT06363391001_outDDT.xml
+++ b/l10n_it_fatturapa_out_dn/tests/data/IT06363391001_outDDT.xml
@@ -73,6 +73,7 @@
                 <NumeroDDT>DDT/00001</NumeroDDT>
                 <DataDDT>2019-08-07</DataDDT>
                 <RiferimentoNumeroLinea>1</RiferimentoNumeroLinea>
+                <RiferimentoNumeroLinea>2</RiferimentoNumeroLinea>
             </DatiDDT>
         </DatiGenerali>
         <DatiBeniServizi>


### PR DESCRIPTION
Implementa https://github.com/OCA/l10n-italy/issues/3979.

La modifica al test verifica il nuovo comportamento.