### PR TITLE
[14.0] [FIX] l10n_it_fatturapa_in: convert received date to context timezone

### DIFF
--- a/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
+++ b/l10n_it_fatturapa_in/wizard/wizard_import_fatturapa.py
@@ -1121,7 +1121,13 @@ class WizardImportFatturapa(models.TransientModel):
         received_date = attachment.e_invoice_received_date
         if not received_date:
             received_date = attachment.create_date
-        received_date = received_date.date()
+        # received_date is a naive UTC datetime; convert it to the context
+        # timezone before extracting the date, otherwise invoices received in
+        # the early hours (still the previous day in UTC) get a reception date
+        # (and accounting registration date) one day earlier than the local one.
+        received_date = fields.Datetime.context_timestamp(
+            attachment, received_date
+        ).date()
         return received_date
 
     def _prepare_invoice_values(self, fatt, fatturapa_attachment, FatturaBody, partner):


### PR DESCRIPTION
The e-invoice received date was extracted with `received_date.date()` directly on `e_invoice_received_date` (a Datetime field, stored naive in UTC). Taking `.date()` in UTC returns the wrong day for invoices received in the early hours of the local morning, which in UTC still fall on the previous day.

Example: an invoice received at 01:18 CEST (UTC+2) is stored as 23:18 UTC of the previous day, so `.date()` yielded the day before. This wrong date then propagated to the accounting registration date (`date`) when the company uses `in_invoice_registration_date == "rec_date"`.

Convert the value with `fields.Datetime.context_timestamp` before calling `.date()`, so the reception (and registration) date matches the local timezone.

Assisted-by: Claude Opus 4.8