### PR TITLE
[18.0][FIX] l10n_it_account: minimal_layout inherit

### DIFF
--- a/l10n_it_account/reports/account_reports_view.xml
+++ b/l10n_it_account/reports/account_reports_view.xml
@@ -104,7 +104,7 @@
 
     <template id="minimal_layout" inherit_id="web.minimal_layout" priority="100">
         <xpath expr="//head/script" position="replace">
-            <script>
+            <script t-if="subst">
                 function subst() {
                     var vars = {};
                     var x = document.location.search.substring(1).split('&amp;');


### PR DESCRIPTION
Senza questa PR si genera un errore se si hanno altri moduli che ereditano correttamente la vista, es. https://github.com/OCA/reporting-engine/blob/52e03a544f25b789ed34a0e842603ce0b80f36aa/report_qweb_element_page_visibility/views/layouts.xml#L3 