### PR TITLE
[FIX] Fatturazione di un DdT con kit

### DIFF
--- a/l10n_it_delivery_note/models/sale_order.py
+++ b/l10n_it_delivery_note/models/sale_order.py
@@ -116,6 +116,7 @@ class SaleOrder(models.Model):
         for order_line in order_lines:
             invoiceable_dn_lines = order_line.delivery_note_line_ids.filtered(
                 lambda dn_line: dn_line.is_invoiceable
+                and order_line.product_id == dn_line.product_id
             )
             if invoicing_delivery_notes:
                 invoiceable_dn_lines = invoiceable_dn_lines.filtered(
@@ -203,7 +204,10 @@ class SaleOrderLine(models.Model):
             self.env["stock.delivery.note.line"].browse(),
         )
         invoiceable_dn_lines = (
-            self.delivery_note_line_ids.filtered(lambda dn_line: dn_line.is_invoiceable)
+            self.delivery_note_line_ids.filtered(
+                lambda dn_line: dn_line.is_invoiceable
+                and self.product_id == dn_line.product_id
+            )
             - invoiced_dn_lines
         )
         invoicing_delivery_notes = self.env.context.get(

--- a/l10n_it_delivery_note/models/sale_order.py
+++ b/l10n_it_delivery_note/models/sale_order.py
@@ -108,20 +108,9 @@ class SaleOrder(models.Model):
 
     def _get_invoiceable_lines(self, final=False):
         order_lines = super()._get_invoiceable_lines(final=final)
-        invoicing_delivery_notes = self.env.context.get(
-            "invoicing_delivery_notes",
-            self.env["stock.delivery.note"].browse(),
-        )
         new_order_lines = self.env["sale.order.line"].browse()
         for order_line in order_lines:
-            invoiceable_dn_lines = order_line.delivery_note_line_ids.filtered(
-                lambda dn_line: dn_line.is_invoiceable
-                and order_line.product_id == dn_line.product_id
-            )
-            if invoicing_delivery_notes:
-                invoiceable_dn_lines = invoiceable_dn_lines.filtered(
-                    lambda dn_line: dn_line.delivery_note_id in invoicing_delivery_notes
-                )
+            invoiceable_dn_lines = order_line._get_invoiceable_dn_lines()
             if len(invoiceable_dn_lines) > 1:
                 # Add a new order line for each linked delivery note line.
                 # Every new corresponding invoice line
@@ -197,18 +186,10 @@ class SaleOrderLine(models.Model):
             lambda li: li.is_pickings_related(picking_ids)
         )
 
-    def _prepare_invoice_line(self, **optional_values):
-        values = super()._prepare_invoice_line(**optional_values)
-        invoiced_dn_lines = self.env.context.get(
-            "delivery_note_invoiced_lines",
-            self.env["stock.delivery.note.line"].browse(),
-        )
-        invoiceable_dn_lines = (
-            self.delivery_note_line_ids.filtered(
-                lambda dn_line: dn_line.is_invoiceable
-                and self.product_id == dn_line.product_id
-            )
-            - invoiced_dn_lines
+    def _get_invoiceable_dn_lines(self):
+        invoiceable_dn_lines = self.delivery_note_line_ids.filtered(
+            lambda dn_line: dn_line.is_invoiceable
+            and self.product_id == dn_line.product_id
         )
         invoicing_delivery_notes = self.env.context.get(
             "invoicing_delivery_notes",
@@ -218,6 +199,15 @@ class SaleOrderLine(models.Model):
             invoiceable_dn_lines = invoiceable_dn_lines.filtered(
                 lambda dn_line: dn_line.delivery_note_id in invoicing_delivery_notes
             )
+        return invoiceable_dn_lines
+
+    def _prepare_invoice_line(self, **optional_values):
+        values = super()._prepare_invoice_line(**optional_values)
+        invoiced_dn_lines = self.env.context.get(
+            "delivery_note_invoiced_lines",
+            self.env["stock.delivery.note.line"].browse(),
+        )
+        invoiceable_dn_lines = self._get_invoiceable_dn_lines() - invoiced_dn_lines
 
         if invoiceable_dn_lines:
             invoiced_dn_line = fields.first(invoiceable_dn_lines)


### PR DESCRIPTION
Il problema succede solo in `14.0` dopo https://github.com/OCA/l10n-italy/pull/5254.

**Passi**:
1. Creare un Kit con 2 Componenti
2. Vendere il Kit e spedirlo: nota che i componenti vengono spediti invece del kit
3. Creare un DdT e fatturare l'ordine

**Prima di questa modifica**:
Il Kit veniva fatturato 2 volte

**Dopo questa modifica**:
Il Kit veniva fatturato una sola volta

Non posso aggiungere un test perché il modulo non dipende da `mrp`.