### PR TITLE
[18.0][FIX] l10n_it_location_nuts: add missing Valle d'Aosta NUTS mapping

### DIFF
--- a/l10n_it_location_nuts/wizard/nuts_import.py
+++ b/l10n_it_location_nuts/wizard/nuts_import.py
@@ -10,6 +10,7 @@ class NutsImport(models.TransientModel):
         "ITG14": "base.state_it_ag",  # Agrigento
         "ITC18": "base.state_it_al",  # Alessandria
         "ITI32": "base.state_it_an",  # Ancona
+        "ITC20": "base.state_it_ao",  # Aosta
         "ITI18": "base.state_it_ar",  # Arezzo
         "ITI34": "base.state_it_ap",  # Ascoli Piceno
         "ITC17": "base.state_it_at",  # Asti


### PR DESCRIPTION
Risolve https://github.com/OCA/l10n-italy/issues/5278 per `18.0`.
