### PR TITLE
[18.0][FIX] l10n_it_edi_doi_extension: wrong sign on sale refunds in _compute_invoiced and other fixes

### DIFF
--- a/l10n_it_edi_doi_extension/models/account_move.py
+++ b/l10n_it_edi_doi_extension/models/account_move.py
@@ -1,6 +1,6 @@
 # Copyright 2025 Nextev Srl
 
-from odoo import _, api, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -72,36 +72,37 @@ class AccountMove(models.Model):
             )
         return  # W8110
 
+    @api.depends("l10n_it_edi_doi_total_amount")
     def _compute_l10n_it_edi_doi_warning(self):
-        """Override to show custom warning when DOI amounts don't cover
-        invoice total.
+        """Append a coverage warning when the bridge rows do not cover the
+        invoice DOI amount. Core warnings (threshold, validity) are kept.
         """
         super()._compute_l10n_it_edi_doi_warning()
-        for move in self:
-            # Clear the warning first
-            move.l10n_it_edi_doi_warning = ""
-
-            # Only show warning if amounts don't match
+        for move in self.filtered("l10n_it_edi_doi_ids"):
+            # Sale documents carry a signed amount (core), purchase ones do not
+            doi_amount = abs(move.l10n_it_edi_doi_amount)
             if (
-                move.l10n_it_edi_doi_use
-                and move.l10n_it_edi_doi_amount > 0
-                and move.l10n_it_edi_doi_total_amount < move.l10n_it_edi_doi_amount
+                move.currency_id.compare_amounts(
+                    move.l10n_it_edi_doi_total_amount, doi_amount
+                )
+                >= 0
             ):
-                covered = (
-                    f"{move.l10n_it_edi_doi_total_amount:.2f} "
-                    f"{move.currency_id.symbol}"
-                )
-                total = (
-                    f"{move.l10n_it_edi_doi_amount:.2f} " f"{move.currency_id.symbol}"
-                )
-                move.l10n_it_edi_doi_warning = _(
-                    "Warning: The total amount covered by declarations "
-                    "(%(covered)s) is less than the invoice DOI amount "
-                    "(%(total)s). Please adjust the amounts or add more "
-                    "declarations.",
-                    covered=covered,
-                    total=total,
-                )
+                continue
+            covered = (
+                f"{move.l10n_it_edi_doi_total_amount:.2f} {move.currency_id.symbol}"
+            )
+            total = f"{doi_amount:.2f} {move.currency_id.symbol}"
+            coverage = _(
+                "Warning: The total amount covered by declarations "
+                "(%(covered)s) is less than the invoice DOI amount "
+                "(%(total)s). Please adjust the amounts or add more "
+                "declarations.",
+                covered=covered,
+                total=total,
+            )
+            move.l10n_it_edi_doi_warning = "\n\n".join(
+                filter(None, [move.l10n_it_edi_doi_warning, coverage])
+            )
         return  # W8110
 
     def _compute_l10n_it_edi_doi_amount(self):
@@ -113,18 +114,13 @@ class AccountMove(models.Model):
             if not tax or not move.l10n_it_edi_doi_id:
                 move.l10n_it_edi_doi_amount = 0
                 continue
+            # The DOI tax can share the line with other taxes: read the taxable base
             declaration_lines = move.invoice_line_ids.filtered(
                 lambda line, tax=tax: tax in line.tax_ids
             )
-            move.l10n_it_edi_doi_amount = sum(declaration_lines.mapped("price_total"))
-
-        # Fallback for migrated invoices: old v16 invoices don't have the v18
-        # DOI tax on their lines, so the standard compute gives 0.
-        # If the invoice has a DOI but no DOI-taxed lines, use amount_untaxed
-        # (which was the full DOI amount in v16).
-        for move in self:
-            if move.l10n_it_edi_doi_id and not move.l10n_it_edi_doi_amount:
-                move.l10n_it_edi_doi_amount = abs(move.amount_untaxed)
+            move.l10n_it_edi_doi_amount = sum(
+                declaration_lines.mapped("price_subtotal")
+            )
         return  # W8110
 
     def _compute_l10n_it_edi_doi_id(self):
@@ -179,30 +175,35 @@ class AccountMove(models.Model):
             raise UserError("\n".join(errors))
         return super()._post(soft)
 
-    def _reverse_moves(self, default_values_list=None, cancel=False):
-        """Override to copy DOI data from original invoice to refund."""
-        reverse_moves = super()._reverse_moves(
-            default_values_list=default_values_list, cancel=cancel
-        )
+    def copy_data(self, default=None):
+        """Carry the bridge lines onto credit notes only.
 
-        # Copy DOI links from original invoices to their refunds
-        for reverse_move in reverse_moves:
-            if not reverse_move.reversed_entry_id:
-                continue
-
-            original_move = reverse_move.reversed_entry_id
-            # Copy DOI bridge records
-            for doi_link in original_move.l10n_it_edi_doi_ids:
-                self.env["account.move.doi"].create(
+        A credit note must reverse the same declarations with the same amounts.
+        A duplicate follows core instead: the split between declarations depends
+        on their remaining amount at invoicing time, so it is not copied.
+        Core _reverse_moves builds the credit note with copy(), so the lines are
+        created while the move is still draft.
+        The lines are copied whatever the current state of the declaration: a
+        credit note reverses a consumption that already happened, so it must
+        point to the same declaration even if it was terminated or revoked since.
+        Core copy_data keeps l10n_it_edi_doi_id in that case as well (state and
+        dates are not blocking when the amount is not positive).
+        """
+        data_list = super().copy_data(default)
+        if not (default and default.get("reversed_entry_id")):
+            return data_list
+        for move, data in zip(self, data_list, strict=True):
+            data["l10n_it_edi_doi_ids"] = [
+                Command.create(
                     {
-                        "move_id": reverse_move.id,
-                        "declaration_id": doi_link.declaration_id.id,
-                        "amount": doi_link.amount,
-                        "sequence": doi_link.sequence,
+                        "declaration_id": link.declaration_id.id,
+                        "amount": link.amount,
+                        "sequence": link.sequence,
                     }
                 )
-
-        return reverse_moves
+                for link in move.l10n_it_edi_doi_ids
+            ]
+        return data_list
 
     def action_open_declaration_of_intent(self):
         """Open declaration(s) of intent.

--- a/l10n_it_edi_doi_extension/models/account_move_doi.py
+++ b/l10n_it_edi_doi_extension/models/account_move_doi.py
@@ -1,7 +1,7 @@
 # Copyright 2025 Nextev Srl
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class AccountMoveDoi(models.Model):
@@ -31,8 +31,7 @@ class AccountMoveDoi(models.Model):
     )
     amount = fields.Monetary(
         currency_field="currency_id",
-        help="Amount of the invoice covered by this declaration of intent. "
-        "If zero, the full remaining amount will be used.",
+        help="Amount of the invoice covered by this declaration of intent.",
     )
     currency_id = fields.Many2one(
         related="move_id.currency_id",
@@ -106,10 +105,18 @@ class AccountMoveDoi(models.Model):
     @api.constrains("amount")
     def _check_amount(self):
         for record in self:
-            if record.amount < 0:
+            if record.amount <= 0:
                 raise ValidationError(
-                    _("The amount covered by a declaration cannot be negative.")
+                    _("The amount covered by a declaration must be positive.")
                 )
+
+    def _check_move_is_draft(self):
+        # Rows with amount 0 come from the v16 migration (raw SQL, no constraint):
+        # they stay editable so the amount can be fixed or the row removed.
+        if any(record.move_id.state != "draft" and record.amount for record in self):
+            raise UserError(
+                _("Declarations of Intent can only be changed on draft invoices.")
+            )
 
     def _compute_display_name(self):
         for record in self:
@@ -136,16 +143,22 @@ class AccountMoveDoi(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         records = super().create(vals_list)
+        # Credit notes get their rows through copy_data while still draft, so a
+        # row created on a non draft move can only be a manual change.
+        records._check_move_is_draft()
         records._sync_l10n_it_edi_doi_id()
         return records
 
     def write(self, vals):
+        if vals.keys() & {"declaration_id", "amount", "move_id"}:
+            self._check_move_is_draft()
         res = super().write(vals)
         if "declaration_id" in vals:
             self._sync_l10n_it_edi_doi_id()
         return res
 
     def unlink(self):
+        self._check_move_is_draft()
         moves = self.mapped("move_id")
         res = super().unlink()
         self._sync_l10n_it_edi_doi_id(moves)

--- a/l10n_it_edi_doi_extension/models/declaration_of_intent.py
+++ b/l10n_it_edi_doi_extension/models/declaration_of_intent.py
@@ -73,16 +73,19 @@ class L10nItDeclarationOfIntent(models.Model):
         amounts from the bridge model. For invoices without bridge records (single
         declaration via l10n_it_edi_doi_id), use the standard l10n_it_edi_doi_amount.
 
-        Refunds (in_refund, out_refund) reduce the invoiced amount.
+        Only posted documents count, as in core. Bridge amounts are unsigned on
+        both sides, so refunds are negated. l10n_it_edi_doi_amount is signed by
+        core on sale documents and unsigned on purchase documents, so only
+        in_refund is negated there.
         """
         for declaration in self:
             total_invoiced = 0
 
-            # Get all posted invoices and draft with name linked through the bridge
-            # model
+            # Get all posted invoices linked through the bridge model.
+            # Rows with amount 0 (v16 migration leftovers) carry no split
+            # information: their invoice falls back to l10n_it_edi_doi_amount.
             posted_doi_links = declaration.move_doi_ids.filtered(
-                lambda doi: doi.move_id.state == "posted"
-                or (doi.move_id.state == "draft" and doi.move_id.name)
+                lambda doi: doi.move_id.state == "posted" and doi.amount
             )
             bridge_moves = posted_doi_links.mapped("move_id")
 
@@ -102,7 +105,7 @@ class L10nItDeclarationOfIntent(models.Model):
             single_declaration_invoices = posted_invoices - bridge_moves
             for invoice in single_declaration_invoices:
                 amount = invoice.l10n_it_edi_doi_amount
-                if invoice.move_type in ("in_refund", "out_refund"):
+                if invoice.move_type == "in_refund":
                     amount = -amount
                 total_invoiced += amount
 

--- a/l10n_it_edi_doi_extension/models/purchase_order.py
+++ b/l10n_it_edi_doi_extension/models/purchase_order.py
@@ -112,7 +112,7 @@ class PurchaseOrder(models.Model):
             order.l10n_it_edi_doi_warning = ""
             declaration = order.l10n_it_edi_doi_id
 
-            show_warning = declaration and order.state != "cancelled"
+            show_warning = declaration and order.state != "cancel"
             if not show_warning:
                 continue
 
@@ -239,7 +239,7 @@ class PurchaseOrder(models.Model):
         for order in self:
             declaration = order.l10n_it_edi_doi_id
             if not declaration:
-                return
+                continue
             partner = order.partner_id.commercial_partner_id
             errors = declaration._get_validity_warnings(
                 order.company_id,

--- a/l10n_it_edi_doi_extension/security/ir.model.access.csv
+++ b/l10n_it_edi_doi_extension/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_account_move_doi_readonly,account.move.doi.readonly,model_account_move_doi,account.group_account_readonly,1,0,0,0
 access_account_move_doi_user,account.move.doi.user,model_account_move_doi,account.group_account_invoice,1,1,1,1
 access_account_move_doi_manager,account.move.doi.manager,model_account_move_doi,account.group_account_manager,1,1,1,1

--- a/l10n_it_edi_doi_extension/tests/__init__.py
+++ b/l10n_it_edi_doi_extension/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_doi_issued_from_company
+from . import test_plafond_fixes

--- a/l10n_it_edi_doi_extension/tests/test_doi_issued_from_company.py
+++ b/l10n_it_edi_doi_extension/tests/test_doi_issued_from_company.py
@@ -234,7 +234,7 @@ class TestDoiIssuedFromCompany(TransactionCase):
         invoice.l10n_it_edi_doi_id = False
 
         self.env["account.move.doi"].create(
-            {"move_id": invoice.id, "declaration_id": self.doi_in.id, "amount": 0}
+            {"move_id": invoice.id, "declaration_id": self.doi_in.id, "amount": 900.0}
         )
         self.assertEqual(invoice.l10n_it_edi_doi_id, self.doi_in)
 
@@ -245,7 +245,7 @@ class TestDoiIssuedFromCompany(TransactionCase):
         invoice.l10n_it_edi_doi_id = False
 
         bridge = self.env["account.move.doi"].create(
-            {"move_id": invoice.id, "declaration_id": self.doi_in.id, "amount": 0}
+            {"move_id": invoice.id, "declaration_id": self.doi_in.id, "amount": 900.0}
         )
         self.assertEqual(invoice.l10n_it_edi_doi_id, self.doi_in)
 
@@ -258,7 +258,7 @@ class TestDoiIssuedFromCompany(TransactionCase):
         invoice.l10n_it_edi_doi_id = False
 
         bridge = self.env["account.move.doi"].create(
-            {"move_id": invoice.id, "declaration_id": self.doi_in.id, "amount": 0}
+            {"move_id": invoice.id, "declaration_id": self.doi_in.id, "amount": 900.0}
         )
         self.assertEqual(invoice.l10n_it_edi_doi_id, self.doi_in)
 

--- a/l10n_it_edi_doi_extension/tests/test_plafond_fixes.py
+++ b/l10n_it_edi_doi_extension/tests/test_plafond_fixes.py
@@ -1,0 +1,318 @@
+# Copyright 2026 STeSI Consulting
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from dateutil.relativedelta import relativedelta
+
+from odoo import Command, fields
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestPlafondFixes(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+        cls.company.write(
+            {
+                "country_id": cls.env.ref("base.it").id,
+                "account_fiscal_country_id": cls.env.ref("base.it").id,
+            }
+        )
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "DOI Partner",
+                "country_id": cls.env.ref("base.it").id,
+            }
+        )
+        cls.product = cls.env["product.product"].create({"name": "DOI Product"})
+        tax_group = cls.env["account.tax.group"].create({"name": "DOI group"})
+
+        def tax(name, amount, use):
+            return cls.env["account.tax"].create(
+                {
+                    "name": name,
+                    "amount": amount,
+                    "type_tax_use": use,
+                    "tax_group_id": tax_group.id,
+                    "l10n_it_exempt_reason": "N3.5" if not amount else False,
+                    "l10n_it_law_reference": "Art. 8" if not amount else False,
+                }
+            )
+
+        cls.sale_doi_tax = tax("0% DOI sale", 0, "sale")
+        cls.sale_vat_tax = tax("22% sale", 22, "sale")
+        cls.bill_doi_tax = tax("0% DOI purchase", 0, "purchase")
+        cls.bill_extra_tax = tax("4% purchase", 4, "purchase")
+        cls.company.write(
+            {
+                "l10n_it_edi_doi_tax_id": cls.sale_doi_tax.id,
+                "l10n_it_edi_doi_bill_tax_id": cls.bill_doi_tax.id,
+            }
+        )
+        cls.doi_out = cls._create_declaration("out", "1", threshold=5000)
+        cls.doi_out_2 = cls._create_declaration("out", "2", threshold=5000)
+        cls.doi_in = cls._create_declaration("in", "3", threshold=5000)
+
+    @classmethod
+    def _create_declaration(cls, doi_type, protocol, threshold, partner=None):
+        today = fields.Date.today()
+        return cls.env["l10n_it_edi_doi.declaration_of_intent"].create(
+            {
+                "partner_id": (partner or cls.partner).id,
+                "company_id": cls.company.id,
+                "state": "active",
+                "type": doi_type,
+                "currency_id": cls.company.currency_id.id,
+                "issue_date": today,
+                "start_date": today,
+                "end_date": today + relativedelta(months=2),
+                "threshold": threshold,
+                "protocol_number_part1": protocol,
+                "protocol_number_part2": protocol,
+            }
+        )
+
+    def _create_invoice(self, taxes, move_type="out_invoice", price=900.0):
+        return self.env["account.move"].create(
+            {
+                "move_type": move_type,
+                "partner_id": self.partner.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": 1,
+                            "price_unit": price,
+                            "tax_ids": [Command.set(taxes.ids)],
+                        }
+                    )
+                ],
+            }
+        )
+
+    def _reverse(self, invoice):
+        wizard = (
+            self.env["account.move.reversal"]
+            .with_context(
+                active_model="account.move",
+                active_ids=invoice.ids,
+            )
+            .create({"journal_id": invoice.journal_id.id, "reason": "test"})
+        )
+        return self.env["account.move"].browse(wizard.reverse_moves()["res_id"])
+
+    def _add_link(self, invoice, declaration, amount):
+        return self.env["account.move.doi"].create(
+            {
+                "move_id": invoice.id,
+                "declaration_id": declaration.id,
+                "amount": amount,
+            }
+        )
+
+    # 01: sale credit note lowers the plafond
+    def test_01_sale_credit_note_lowers_invoiced(self):
+        invoice = self._create_invoice(self.sale_doi_tax)
+        self.assertEqual(invoice.l10n_it_edi_doi_id, self.doi_out)
+        invoice.action_post()
+        self.assertEqual(self.doi_out.invoiced, 900.0)
+        refund = self._reverse(invoice)
+        self.assertEqual(refund.l10n_it_edi_doi_id, self.doi_out)
+        self.assertEqual(refund.l10n_it_edi_doi_amount, -900.0)
+        refund.action_post()
+        self.assertEqual(self.doi_out.invoiced, 0.0)
+
+    # 02: a fully taxed invoice does not consume the plafond
+    def test_02_vat_invoice_does_not_consume_plafond(self):
+        invoice = self._create_invoice(self.sale_vat_tax)
+        self.assertEqual(invoice.l10n_it_edi_doi_id, self.doi_out)
+        self.assertEqual(invoice.l10n_it_edi_doi_amount, 0.0)
+        invoice.action_post()
+        self.assertEqual(self.doi_out.invoiced, 0.0)
+
+    # 03: extra taxes on the DOI line do not inflate the amount
+    def test_03_purchase_amount_uses_taxable_base(self):
+        bill = self._create_invoice(
+            self.bill_doi_tax | self.bill_extra_tax, "in_invoice"
+        )
+        self.assertEqual(bill.l10n_it_edi_doi_id, self.doi_in)
+        self.assertEqual(bill.l10n_it_edi_doi_amount, 900.0)
+        bill.action_post()
+        self.assertEqual(self.doi_in.invoiced, 900.0)
+        refund = self._reverse(bill)
+        refund.action_post()
+        self.assertEqual(self.doi_in.invoiced, 0.0)
+
+    # 04 + 06: core threshold warning is back, no coverage banner without bridge rows
+    def test_04_06_threshold_warning_without_coverage_banner(self):
+        invoice = self._create_invoice(self.sale_doi_tax, price=6000.0)
+        self.assertIn("exceeded", invoice.l10n_it_edi_doi_warning)
+        self.assertNotIn("covered by declarations", invoice.l10n_it_edi_doi_warning)
+        small = self._create_invoice(self.sale_doi_tax)
+        self.assertFalse(small.l10n_it_edi_doi_warning)
+        self._add_link(small, self.doi_out, 100.0)
+        small.invalidate_recordset(["l10n_it_edi_doi_warning"])
+        self.assertIn("covered by declarations", small.l10n_it_edi_doi_warning)
+
+    # 05: draft invoices never count, bridge rows or not
+    def test_05_draft_not_counted(self):
+        invoice = self._create_invoice(self.sale_doi_tax)
+        invoice.name = "INV/TEST/0001"
+        self._add_link(invoice, self.doi_out, 900.0)
+        self.assertEqual(self.doi_out.invoiced, 0.0)
+        invoice.action_post()
+        self.assertEqual(self.doi_out.invoiced, 900.0)
+
+    # 07: bridge rows are locked once the invoice is posted
+    def test_07_posted_invoice_rows_locked(self):
+        invoice = self._create_invoice(self.sale_doi_tax)
+        link = self._add_link(invoice, self.doi_out, 900.0)
+        invoice.action_post()
+        with self.assertRaises(UserError):
+            link.unlink()
+        with self.assertRaises(UserError):
+            link.write({"amount": 1.0})
+        with self.assertRaises(UserError):
+            self._add_link(invoice, self.doi_out_2, 1.0)
+        link.write({"sequence": 5})
+        self.assertEqual(invoice.l10n_it_edi_doi_id, self.doi_out)
+
+    # 08: read-only accountants can read the bridge rows
+    def test_08_readonly_user_reads_bridge_rows(self):
+        invoice = self._create_invoice(self.sale_doi_tax)
+        self._add_link(invoice, self.doi_out, 900.0)
+        auditor = self.env["res.users"].create(
+            {
+                "name": "Auditor",
+                "login": "doi_auditor",
+                "groups_id": [
+                    Command.set(
+                        [
+                            self.env.ref("base.group_user").id,
+                            self.env.ref("account.group_account_readonly").id,
+                        ]
+                    )
+                ],
+            }
+        )
+        data = invoice.with_user(auditor).web_read(
+            {
+                "l10n_it_edi_doi_ids": {"fields": {"amount": {}}},
+            }
+        )
+        self.assertEqual(data[0]["l10n_it_edi_doi_ids"][0]["amount"], 900.0)
+
+    # 09: a duplicate follows core (no bridge lines), a credit note mirrors them
+    def test_09_copy_and_reversal(self):
+        invoice = self._create_invoice(self.sale_doi_tax)
+        self._add_link(invoice, self.doi_out, 500.0)
+        self._add_link(invoice, self.doi_out_2, 400.0)
+        copy = invoice.copy()
+        self.assertFalse(copy.l10n_it_edi_doi_ids)
+        self.assertEqual(copy.l10n_it_edi_doi_id, self.doi_out)
+        invoice.action_post()
+        refund = self._reverse(invoice)
+        self.assertRecordValues(
+            refund.l10n_it_edi_doi_ids,
+            [
+                {"declaration_id": self.doi_out.id, "amount": 500.0},
+                {"declaration_id": self.doi_out_2.id, "amount": 400.0},
+            ],
+        )
+
+    # 10: a zero amount is rejected
+    def test_10_zero_amount_rejected(self):
+        invoice = self._create_invoice(self.sale_doi_tax)
+        with self.assertRaises(ValidationError):
+            self._add_link(invoice, self.doi_out, 0.0)
+
+    # 11: every order in a multi-record check gets validated
+    def test_11_purchase_constraint_checks_all_orders(self):
+        # purchase.order.create runs one record at a time, so the constraint
+        # is exercised directly on a two-record set: the first order has no
+        # declaration, the second one holds a declaration that turned invalid.
+        other = self.env["res.partner"].create({"name": "No DOI Partner"})
+        line = {
+            "product_id": self.product.id,
+            "product_qty": 1,
+            "price_unit": 100.0,
+            "taxes_id": [Command.set(self.bill_doi_tax.ids)],
+        }
+        orders = self.env["purchase.order"].create(
+            [
+                {"partner_id": other.id, "order_line": [Command.create(line)]},
+                {"partner_id": self.partner.id, "order_line": [Command.create(line)]},
+            ]
+        )
+        self.assertFalse(orders[0].l10n_it_edi_doi_id)
+        self.assertEqual(orders[1].l10n_it_edi_doi_id, self.doi_in)
+        self.doi_in.partner_id = other
+        with self.assertRaises(ValidationError):
+            orders._check_l10n_it_edi_doi_id()
+
+    # 12: cancelled orders show no warning
+    def test_12_cancelled_order_no_warning(self):
+        order = self.env["purchase.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": 1,
+                            "price_unit": 9000.0,
+                            "taxes_id": [Command.set(self.bill_doi_tax.ids)],
+                        }
+                    )
+                ],
+            }
+        )
+        self.assertEqual(order.l10n_it_edi_doi_id, self.doi_in)
+        self.assertIn("exceeded", order.l10n_it_edi_doi_warning)
+        order.button_cancel()
+        self.assertFalse(order.l10n_it_edi_doi_warning)
+
+    # migrated rows with amount 0 do not hide the invoice and stay editable
+    def test_13_migrated_zero_amount_row(self):
+        invoice = self._create_invoice(self.sale_doi_tax)
+        invoice.action_post()
+        self.assertEqual(self.doi_out.invoiced, 900.0)
+        self.env.cr.execute(
+            """
+            INSERT INTO account_move_doi
+                (move_id, declaration_id, amount, sequence, currency_id, company_id)
+            VALUES (%s, %s, 0, 10, %s, %s)
+            """,
+            (
+                invoice.id,
+                self.doi_out.id,
+                invoice.currency_id.id,
+                invoice.company_id.id,
+            ),
+        )
+        self.env.invalidate_all()
+        self.doi_out._compute_invoiced()
+        self.assertEqual(self.doi_out.invoiced, 900.0)
+        row = invoice.l10n_it_edi_doi_ids
+        row.amount = 900.0
+        self.assertEqual(self.doi_out.invoiced, 900.0)
+        with self.assertRaises(UserError):
+            row.unlink()
+
+    # credit notes keep the rows even when the declaration was terminated since
+    def test_14_credit_note_on_terminated_declaration(self):
+        invoice = self._create_invoice(self.sale_doi_tax)
+        self._add_link(invoice, self.doi_out, 500.0)
+        self._add_link(invoice, self.doi_out_2, 400.0)
+        invoice.action_post()
+        self.assertEqual(self.doi_out.invoiced, 500.0)
+        self.doi_out.action_terminate()
+        refund = self._reverse(invoice)
+        self.assertEqual(refund.l10n_it_edi_doi_id, self.doi_out)
+        self.assertEqual(len(refund.l10n_it_edi_doi_ids), 2)
+        refund.action_post()
+        self.assertEqual(self.doi_out.invoiced, 0.0)
+        self.assertEqual(self.doi_out_2.invoiced, 0.0)

--- a/l10n_it_edi_doi_extension/views/account_move_views.xml
+++ b/l10n_it_edi_doi_extension/views/account_move_views.xml
@@ -54,7 +54,7 @@
                             <field name="l10n_it_edi_doi_total_amount" />
                         </group>
                     </group>
-                    <field name="l10n_it_edi_doi_ids">
+                    <field name="l10n_it_edi_doi_ids" readonly="state != 'draft'">
                         <list editable="bottom">
                             <field name="sequence" widget="handle" />
                             <field


### PR DESCRIPTION
### Description 
A customer credit note under a declaration of intent was raising the plafond instead of lowering it. Core already applies -direction_sign to l10n_it_edi_doi_amount, so an out_refund comes in negative and _compute_invoiced negated it a second time. Bill amounts are computed by this module without sign, so the negation stays for in_refund only.

### Fixes
- Apply the absolute value so it is not double negative the value on refund
- Append the declaration of intent warning instead of overriding it
- The _reverse_moves override is replaced by copy_data adding the bridge lines when reversed_entry_id is in default: core _reverse_moves goes through copy(), so the lines are created while the move is still draft, while the override recreated them after super(), on an already posted move when cancel=True. Duplicates keep following core (no bridge lines): the split between declarations depends on their remaining amount at invoicing time.
- raise error if amount <= 0 , before the helps sait that if amount=0 the full amount is used but never implemented in the code 
- If it is a DOI migrated from 16.0 now it used the amount_untaxed as fallback written by post_init_hook
- Use price_subtotal instead of price_total so if there are more than one taxes, only the subtotal of doi tax is used . For example one line two different taxes , one with tax_amount > 0 , the tax_amount was added to the DOI amount. It is wrong
- Make the bridge DOI lines readonly if posted because deleting them on posted invoice was clearing l10n_it_edi_doi_id , if it was already sent the data in XML becames different than the data on invoice
- Add permission on group_account_readonly group
