### PR TITLE
[18.0][FIX] l10n_it_asset_management: monthly depreciation pro rata

### DIFF
--- a/l10n_it_asset_management/models/asset_depreciation.py
+++ b/l10n_it_asset_management/models/asset_depreciation.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
 from odoo.tools import float_compare, float_is_zero
+from odoo.tools.date_utils import relativedelta
 
 
 class AssetDepreciation(models.Model):
@@ -507,7 +508,15 @@ class AssetDepreciation(models.Model):
                 )
             )
 
-        if self.pro_rata_temporis or self._context.get("force_prorata"):
+        pro_rata = self.pro_rata_temporis or self._context.get("force_prorata")
+        if pro_rata and period == "month":
+            # Monthly depreciation already divides the year by 12.
+            # Pro rata has to work on that month: applying it to the
+            # whole fiscal year cuts the amount a second time.
+            multiplier *= self.get_pro_rata_month_multiplier(
+                dep_date, period_count=period_count
+            )
+        elif pro_rata:
             fiscal_year_obj = self.env["account.fiscal.year"]
             fy_start = fiscal_year_obj.get_fiscal_year_by_date(
                 date_start, company=self.company_id
@@ -646,6 +655,35 @@ class AssetDepreciation(models.Model):
         raise NotImplementedError(
             self.env._("Cannot get pro rata temporis multiplier for unspecified mode")
         )
+
+    def get_pro_rata_month_multiplier(self, dep_date, period_count=None):
+        """
+        Computes and returns the pro rata multiplier of a monthly
+        depreciation.
+
+        The depreciated period ends on ``dep_date`` and begins
+        ``period_count`` months earlier, on the first day of that month.
+        An asset registered before the period gets the whole period.
+        An asset registered inside it gets the days from ``date_start``
+        to ``dep_date``.
+
+        :param dep_date: depreciation date as a fields.Date value
+        :param period_count: number of depreciated months, 1 when missing
+        :return: owned fraction of the depreciated period
+        """
+        self.ensure_one()
+        if not (self.pro_rata_temporis or self._context.get("force_prorata")):
+            return 1
+
+        dep_date = fields.Date.to_date(dep_date)
+        date_start = fields.Date.to_date(self.date_start)
+        period_start = dep_date + relativedelta(day=1, months=1 - (period_count or 1))
+        if date_start <= period_start:
+            return 1
+
+        period_days = (dep_date - period_start).days + 1
+        owned_days = (dep_date - date_start).days + 1
+        return owned_days / period_days
 
     def make_name(self):
         self.ensure_one()

--- a/l10n_it_asset_management/readme/CONTRIBUTORS.md
+++ b/l10n_it_asset_management/readme/CONTRIBUTORS.md
@@ -7,6 +7,8 @@
 - [Aion Tech](https://aiontech.company/):
   - Simone Rubino \<<simone.rubino@aion-tech.it>\>
 - Nextev Srl \<<odoo@nextev.it>\>
+- [STeSI Consulting](https://stesi.consulting):
+  - Michele Di Croce \<<dicroce.m@stesi.consulting>\>
 
 Base icon made by [surang](https://www.flaticon.com/authors/surang) from
 [www.flaticon.com](https://www.flaticon.com/).

--- a/l10n_it_asset_management/tests/test_assets_management.py
+++ b/l10n_it_asset_management/tests/test_assets_management.py
@@ -652,6 +652,57 @@ class TestAssets(Common):
             ],
         )
 
+    def test_monthly_depreciation_pro_rata(self):
+        """
+        Monthly depreciation with pro rata reduces the month
+        the asset was registered in, and no other month.
+        """
+        # Arrange
+        purchase_date = date(2019, 7, 16)
+        asset = self._create_asset(purchase_date)
+        first_depreciation_date = date(2019, 7, 31)
+        second_depreciation_date = date(2019, 8, 31)
+        third_depreciation_date = date(2019, 10, 31)
+        self._generate_fiscal_years(purchase_date, third_depreciation_date)
+        civ_depreciation_type = self.env.ref(
+            "l10n_it_asset_management.ad_type_civilistico"
+        )
+        civ_depreciation = asset.depreciation_ids.filtered(
+            lambda x: x.type_id == civ_depreciation_type
+        )
+        civ_depreciation.percentage = 12.0
+        civ_depreciation.pro_rata_temporis = True
+        # pre-condition
+        self.assertEqual(civ_depreciation.date_start, purchase_date)
+        self.assertEqual(civ_depreciation.amount_depreciable, 1000)
+
+        # Act
+        self._depreciate_asset(asset, first_depreciation_date, period="month")
+        self._depreciate_asset(asset, second_depreciation_date, period="month")
+        self._depreciate_asset(
+            asset, third_depreciation_date, period="month", period_count=2
+        )
+
+        # Assert: July gets 16 days out of 31, the later months get
+        # their whole quota
+        self.assertRecordValues(
+            civ_depreciation.line_ids,
+            [
+                {
+                    "date": first_depreciation_date,
+                    "amount": 2.58,
+                },
+                {
+                    "date": second_depreciation_date,
+                    "amount": 5,
+                },
+                {
+                    "date": third_depreciation_date,
+                    "amount": 10,
+                },
+            ],
+        )
+
     def test_missing_fiscal_year_warning(self):
         """
         If some years are not configured as fiscal years,


### PR DESCRIPTION
Monthly depreciation on a pro rata asset comes out about twelve times too low. A customer got 10,96 for July where the quota is 250 (asset of 15.000 at 20%, registered 16/07).

The multiplier gets divided by 12 for the month, then multiplied by the days elapsed since the start of the fiscal year. The month is already a twelfth of the year, so the day fraction cuts it twice. Only December survives, its fraction being 1.

The monthly branch now looks at the month instead of the year: 16 days out of 31 in July, full quota from August. Yearly depreciations keep the old path, and so does the previsional report, which passes no period.

New test: 2,58 / 5 / 10 with the fix, 0,22 / 0,64 / 2,96 without.

