### PR TITLE
[IMP] Mostrare solo il codice nomenclatura nella stampa della fattura

### DIFF
--- a/l10n_it_intrastat/reports/report_invoice.xml
+++ b/l10n_it_intrastat/reports/report_invoice.xml
@@ -13,8 +13,11 @@
         </table>
         <td name="account_invoice_line_name" position="inside">
             <t t-if="show_intrastat_code">
-                <t t-set="product" t-value="line.product_id" />
-                <span class="d-block text-muted" t-field="product.intrastat_code_id" />
+                <t t-set="intrastat_code" t-value="line.product_id.intrastat_code_id" />
+                <div t-if="intrastat_code" class="d-block text-muted">
+                    <strong>Intrastat Code: </strong>
+                    <span t-field="intrastat_code.name">n/a</span>
+                </div>
             </t>
         </td>
     </template>


### PR DESCRIPTION
Implementa https://github.com/OCA/l10n-italy/issues/5274.
Prima era <img width="361" height="117" alt="image" src="https://github.com/user-attachments/assets/6d482baa-c523-4d58-aec0-12f1a0b47dd3" />, dopo questa PR sarà <img width="473" height="132" alt="image" src="https://github.com/user-attachments/assets/c0cfe623-313f-41cb-b360-ba8a81b5173a" />.
