### PR TITLE
[18.0] [FIX] l10n_it_riba_oca: post the credit entry, allow to cancel slips

### DIFF
--- a/l10n_it_riba_oca/models/riba.py
+++ b/l10n_it_riba_oca/models/riba.py
@@ -174,16 +174,26 @@ class RibaList(models.Model):
             for line in slip.line_ids:
                 line.confirm()
 
+    def _unlink_move(self, move):
+        """Delete `move`, setting it back to draft first if it is posted.
+
+        Posted entries cannot be deleted while they are reconciled:
+        `button_draft` takes care of removing the reconciliation.
+        """
+        if move.state == "posted":
+            move.button_draft()
+        move.unlink()
+
     def riba_cancel(self):
         for slip in self:
             for line in slip.line_ids:
                 line.state = "cancel"
                 if line.acceptance_move_id:
-                    line.acceptance_move_id.unlink()
+                    slip._unlink_move(line.acceptance_move_id)
                 if line.past_due_move_id:
-                    line.past_due_move_id.unlink()
+                    slip._unlink_move(line.past_due_move_id)
             if slip.credit_move_id:
-                slip.credit_move_id.unlink()
+                slip._unlink_move(slip.credit_move_id)
             slip.state = "cancel"
 
     def settle_all_line(self):

--- a/l10n_it_riba_oca/tests/test_riba.py
+++ b/l10n_it_riba_oca/tests/test_riba.py
@@ -181,7 +181,7 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
         )
         res = credit_wizard.create_move()
         credit_move_id = self.env["account.move"].browse(res["res_id"])
-        credit_move_id.action_post()
+        self.assertEqual(credit_move_id.state, "posted")
         self.assertEqual(riba_list.state, "credited")
 
         # Test that credit_move_id is properly set on riba lines
@@ -422,7 +422,7 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
 
         res = credit_wizard.create_move()
         credit_move_id = self.env["account.move"].browse(res["res_id"])
-        credit_move_id.action_post()
+        self.assertEqual(credit_move_id.state, "posted")
         self.assertEqual(riba_list.state, "credited")
 
         # pay wizard with skip
@@ -914,7 +914,8 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
             )
         )
         res = credit_wizard.create_move()
-        self.env["account.move"].browse([res["res_id"]]).action_post()
+        credit_move = self.env["account.move"].browse([res["res_id"]])
+        self.assertEqual(credit_move.state, "posted")
         self.assertEqual(slip.state, "credited")
         # Act
         payment_wizard_action = slip.settle_all_line()

--- a/l10n_it_riba_oca/tests/test_riba.py
+++ b/l10n_it_riba_oca/tests/test_riba.py
@@ -226,6 +226,26 @@ class TestInvoiceDueCost(riba_common.TestRibaCommon):
                 break
         self.assertTrue(bank_past_due_line)
 
+    def test_riba_sbf_cancel_credited(self):
+        """A credited slip can be cancelled, deleting its entries."""
+        # Arrange
+        invoice, riba_list = self.riba_sbf_common()
+        acceptance_moves = riba_list.line_ids.acceptance_move_id
+        credit_move = riba_list.credit_move_id
+        # pre-condition: the entries are posted and the invoice is reconciled
+        self.assertEqual(set(acceptance_moves.mapped("state")), {"posted"})
+        self.assertEqual(credit_move.state, "posted")
+        self.assertEqual(invoice.payment_state, "paid")
+
+        # Act
+        riba_list.riba_cancel()
+
+        # Assert
+        self.assertEqual(riba_list.state, "cancel")
+        self.assertFalse(acceptance_moves.exists())
+        self.assertFalse(credit_move.exists())
+        self.assertEqual(invoice.payment_state, "not_paid")
+
     def test_riba_incasso_all_paid(self):
         """
         RiBa of type 'After Collection' all paid flow

--- a/l10n_it_riba_oca/wizard/wizard_credit.py
+++ b/l10n_it_riba_oca/wizard/wizard_credit.py
@@ -250,8 +250,11 @@ class RibaCredit(models.TransientModel):
                 ]
             )
 
-        # Create the accounting move
+        # Create and post the accounting move: the line on the RiBa account
+        # has to be reconciled when the bank collects the RiBa, or when the
+        # RiBa is past due, and draft entries cannot be reconciled.
         move = move_model.create(move_vals)
+        move.action_post()
 
         # Update RiBa slip to credited state
         vals = {


### PR DESCRIPTION
The credit entry was created in draft, so its line on the RiBa account could not be reconciled until the user posted it by hand, while both the settlement and the past due reconcile it. The wizard posts it now.

Cancelling an accepted slip failed, because its acceptance entries are posted and reconciled with the invoices:

    You cannot do this modification on a reconciled journal entry.

The entries of the slip are now set back to draft, which also removes their reconciliation, before being deleted.

